### PR TITLE
Fix Katagami reaction resolver compatibility

### DIFF
--- a/katagami-curation/reactions/reactions.toml
+++ b/katagami-curation/reactions/reactions.toml
@@ -22,7 +22,7 @@ entity_type = "CurationQuery"
 action = "ResearchComplete"
 
 [reaction.resolve_target]
-type = "Field"
+type = "field"
 field = "query_id"
 
 # When a synthesize CurationJob completes, the organize follow-up has
@@ -40,7 +40,7 @@ entity_type = "CurationQuery"
 action = "SynthesisComplete"
 
 [reaction.resolve_target]
-type = "Field"
+type = "field"
 field = "query_id"
 
 # When an organize_taxonomy CurationJob completes, the full pipeline is done.
@@ -57,7 +57,7 @@ entity_type = "CurationQuery"
 action = "OrganizationComplete"
 
 [reaction.resolve_target]
-type = "Field"
+type = "field"
 field = "query_id"
 
 # When a CurationJob fails, propagate the failure to the CurationQuery.
@@ -73,5 +73,5 @@ entity_type = "CurationQuery"
 action = "Fail"
 
 [reaction.resolve_target]
-type = "Field"
+type = "field"
 field = "query_id"

--- a/katagami-curation/specs/reactions.toml
+++ b/katagami-curation/specs/reactions.toml
@@ -22,7 +22,7 @@ entity_type = "CurationQuery"
 action = "ResearchComplete"
 
 [reaction.resolve_target]
-type = "Field"
+type = "field"
 field = "query_id"
 
 # When a synthesize CurationJob completes, the organize follow-up has
@@ -40,7 +40,7 @@ entity_type = "CurationQuery"
 action = "SynthesisComplete"
 
 [reaction.resolve_target]
-type = "Field"
+type = "field"
 field = "query_id"
 
 # When an organize_taxonomy CurationJob completes, the full pipeline is done.
@@ -57,7 +57,7 @@ entity_type = "CurationQuery"
 action = "OrganizationComplete"
 
 [reaction.resolve_target]
-type = "Field"
+type = "field"
 field = "query_id"
 
 # When a CurationJob fails, propagate the failure to the CurationQuery.
@@ -73,5 +73,5 @@ entity_type = "CurationQuery"
 action = "Fail"
 
 [reaction.resolve_target]
-type = "Field"
+type = "field"
 field = "query_id"

--- a/katagami-curation/tests/test_reaction_resolver_types.py
+++ b/katagami-curation/tests/test_reaction_resolver_types.py
@@ -1,0 +1,38 @@
+import tomllib
+import unittest
+from pathlib import Path
+
+
+ALLOWED_RESOLVER_TYPES = {
+    "field",
+    "same_id",
+    "static",
+    "create_if_missing",
+    "create",
+}
+
+
+def iter_reaction_files():
+    root = Path(__file__).resolve().parents[1]
+    yield root / "reactions" / "reactions.toml"
+    yield root / "specs" / "reactions.toml"
+
+
+class ReactionResolverTypeTests(unittest.TestCase):
+    def test_reaction_resolver_types_match_temper_parser_contract(self):
+        for path in iter_reaction_files():
+            parsed = tomllib.loads(path.read_text())
+            for reaction in parsed["reaction"]:
+                resolver_type = reaction["resolve_target"]["type"]
+                self.assertIn(
+                    resolver_type,
+                    ALLOWED_RESOLVER_TYPES,
+                    (
+                        f"{path}: reaction '{reaction['name']}' uses unsupported "
+                        f"resolver type {resolver_type!r}"
+                    ),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize katagami-curation reaction resolver types to the lowercase forms accepted by temper main
- add a small regression test so future edits keep the bundle compatible

## Verification
- python3 katagami-curation/tests/test_reaction_resolver_types.py
