### PR TITLE
Fix Katagami job template skill paths

### DIFF
--- a/katagami-curation/seed-data/job_templates.toml
+++ b/katagami-curation/seed-data/job_templates.toml
@@ -11,7 +11,7 @@ name = "Configure"
 [instance.actions.params]
 job_type = "source_search"
 skill_id = "research-direction"
-instruction_path = "/agents/sl-bootstrap-agent-soul-curator/skills/research-direction/SKILL.md"
+instruction_path = "/agents/curator/skills/research-direction/SKILL.md"
 tools_profile = "temper_get,temper_list,temper_create,temper_action,temper_write,temper_read,temper_web_search,temper_web_fetch"
 requires_sandbox = false
 max_turns_default = "250"
@@ -32,7 +32,7 @@ name = "Configure"
 [instance.actions.params]
 job_type = "synthesize"
 skill_id = "synthesize-language"
-instruction_path = "/agents/sl-bootstrap-agent-soul-curator/skills/synthesize-language/SKILL.md"
+instruction_path = "/agents/curator/skills/synthesize-language/SKILL.md"
 tools_profile = "temper_get,temper_list,temper_create,temper_action,temper_write,temper_read,temper_web_search,temper_web_fetch,bash,read,write,edit"
 requires_sandbox = true
 max_turns_default = "250"
@@ -53,7 +53,7 @@ name = "Configure"
 [instance.actions.params]
 job_type = "quality_review"
 skill_id = "review-quality"
-instruction_path = "/agents/sl-bootstrap-agent-soul-curator/skills/review-quality/SKILL.md"
+instruction_path = "/agents/curator/skills/review-quality/SKILL.md"
 tools_profile = "temper_get,temper_list,temper_create,temper_action,temper_write,temper_read,bash,read,write,edit"
 requires_sandbox = true
 max_turns_default = "250"
@@ -74,7 +74,7 @@ name = "Configure"
 [instance.actions.params]
 job_type = "organize_taxonomy"
 skill_id = "organize-taxonomy"
-instruction_path = "/agents/sl-bootstrap-agent-soul-curator/skills/organize-taxonomy/SKILL.md"
+instruction_path = "/agents/curator/skills/organize-taxonomy/SKILL.md"
 tools_profile = "temper_get,temper_list,temper_create,temper_action,temper_write,temper_read"
 requires_sandbox = false
 max_turns_default = "250"
@@ -95,7 +95,7 @@ name = "Configure"
 [instance.actions.params]
 job_type = "regenerate_embodiment"
 skill_id = "synthesize-language"
-instruction_path = "/agents/sl-bootstrap-agent-soul-curator/skills/synthesize-language/SKILL.md"
+instruction_path = "/agents/curator/skills/synthesize-language/SKILL.md"
 tools_profile = "temper_get,temper_list,temper_create,temper_action,temper_write,temper_read,temper_web_search,temper_web_fetch,bash,read,write,edit"
 requires_sandbox = true
 max_turns_default = "250"
@@ -116,7 +116,7 @@ name = "Configure"
 [instance.actions.params]
 job_type = "evolve_language"
 skill_id = "synthesize-language"
-instruction_path = "/agents/sl-bootstrap-agent-soul-curator/skills/synthesize-language/SKILL.md"
+instruction_path = "/agents/curator/skills/synthesize-language/SKILL.md"
 tools_profile = "temper_get,temper_list,temper_create,temper_action,temper_write,temper_read,temper_web_search,temper_web_fetch,bash,read,write,edit"
 requires_sandbox = true
 max_turns_default = "250"


### PR DESCRIPTION
## Summary\n- point Katagami job template instruction paths at the canonical curator skills\n- prevent production seed/reconcile from reintroducing sl-bootstrap-agent-soul-curator skill paths\n\n## Validation\n- python3 -m unittest katagami-curation/tests/test_no_hardcoded_prompts_in_wasm.py katagami-curation/tests/test_reaction_resolver_types.py katagami-curation/tests/test_design_md_contract.py