### PR TITLE
Avoid PawFS writes in source search hot path

### DIFF
--- a/katagami-commons/APP.md
+++ b/katagami-commons/APP.md
@@ -20,7 +20,10 @@ One canonical element within one DesignLanguage. Created from the ElementManifes
 
 ### DesignSource
 
-Raw research material (articles, style guides, design system docs) about design movements. Follows the koto-wiki WikiSource pattern.
+Research references (articles, style guides, design system docs) about design
+movements. Source-search jobs index compact metadata, topics, summaries, and
+short excerpts synchronously. Full source-page archival is deferred so research
+does not block on governed file writes.
 
 **States:** `Submitted` -> `Indexed` | `Failed`
 
@@ -38,7 +41,13 @@ Agent-maintained hierarchical classification of design movements and schools.
 
 ## Storage Model
 
-Entity metadata lives in Temper entities. Large content (embodiment HTML, source text, generated DESIGN.md files) lives in paw-fs File entities, referenced by `FileId` fields. This keeps entity payloads small.
+Entity metadata lives in Temper entities. Hot operational state should remain
+small and queryable. Large governed artifacts (embodiment HTML, generated
+DESIGN.md files, published snapshots, and operator-requested source archives)
+live in paw-fs File entities referenced by `FileId` fields. Source-search jobs
+must not synchronously write every fetched page to paw-fs; they store compact
+source summaries/excerpts in `DesignSource.Metadata` and leave `FileId` empty
+until a later archival step creates a governed artifact.
 
 ## Integration with katagami-curation
 

--- a/katagami-curation/APP.md
+++ b/katagami-curation/APP.md
@@ -15,7 +15,7 @@ declared as Temper reactions.
 **States:** `Queued` -> `Ready` -> `Running` -> `Finalizing` -> `Completed` | `Failed`
 
 **Job Types:**
-- `source_search` — Research design movements and store authoritative sources
+- `source_search` — Research design movements and index compact authoritative source metadata
 - `synthesize` — Create DesignLanguage specs with embodiments
 - `quality_review` — Validate DESIGN.md, fix embodiment fidelity against the spec, then publish
 - `organize_taxonomy` — Taxonomy maintenance and cross-referencing
@@ -43,6 +43,11 @@ DesignSource and CurationDirection entities, synthesizes DesignLanguage specs,
 repairs embodiments, and maintains taxonomy. The quality gate keeps generated
 languages out of `Published` until embodiment review and DESIGN.md validation
 both pass.
+
+`source_search` is a hot operational workflow. It should create DesignSource
+and CurationDirection entities synchronously, but it must not write every
+fetched source page into paw-fs while the job is waiting. Full source archival
+belongs in a later artifact step.
 
 ## Pipeline
 

--- a/katagami-curation/agents/curator/AGENT.md
+++ b/katagami-curation/agents/curator/AGENT.md
@@ -23,7 +23,7 @@ Read knowledge files before starting work:
 - `temper.get(entity_set, entity_id)` — get a single entity
 - `temper.create(entity_set, fields)` — create an entity
 - `temper.action(entity_set, entity_id, action, params)` — dispatch an action
-- `temper.write(path, content)` — write to workspace file
+- `temper.write(path, content)` — write governed artifacts to workspace files
 - `temper.read(path)` — read a workspace file
 - `temper.web_search(query)` — search the web
 - `temper.web_fetch(url)` — fetch a URL
@@ -35,7 +35,7 @@ No `import` statements. The `sandbox.*` and `bash` tools are available for `synt
 - **CurationJobs** — your control plane (job_type, input, output)
 - **CurationDirections** — one researched direction that queues one synthesize job
 - **DesignLanguages** — complete design languages with specs + embodiments
-- **DesignSources** — raw research material indexed from the web
+- **DesignSources** — compact research references indexed from the web
 - **Taxonomies** — design movement classification system
 - **ElementManifests** — canonical element set definition
 
@@ -49,7 +49,12 @@ Knowledge files (read via `temper.read()`):
 Workspace at `/katagami/`:
 - `/katagami/embodiments/{slug}.html` — embodiment files (self-contained HTML)
 - `/katagami/design-md/{slug}/DESIGN.md` — validated DESIGN.md exports
-- `/katagami/sources/{slug}.md` — research source files
+- `/katagami/sources/{slug}.md` — deferred source archives, not the source-search hot path
+
+Use PawFS for governed artifacts: embodiments, DESIGN.md exports, published
+snapshots, and explicitly requested source archives. During `source_search`,
+store source title, URL, type, topics, summary, and short excerpts on
+DesignSource entities; do not write full fetched pages to PawFS.
 
 ## Completion Protocol
 

--- a/katagami-curation/agents/curator/skills/research-direction/SKILL.md
+++ b/katagami-curation/agents/curator/skills/research-direction/SKILL.md
@@ -12,13 +12,26 @@ Job type: `source_search`
 2. **Parse scope**: Read the job input for search scope — design movements, aesthetic directions, specific styles to research.
 3. **Search broadly**: Use `temper.web_search(query)` with varied, focused queries for design system documentation, foundational articles, style guides, and reference implementations.
 4. **Shortlist**: Select 5-8 high-signal, directly relevant sources per movement.
-5. **Fetch and store**: For each source:
+5. **Fetch and distill**: For each shortlisted source, fetch only so you can
+   evaluate it and extract compact source metadata. Do **not** write the full
+   fetched page to PawFS in `source_search`; source archival is a separate,
+   deferred artifact step.
    ```python
    fetched = temper.web_fetch(url)
    text = fetched.get("text", "") or fetched.get("content", "")
-   result = temper.write('/katagami/sources/' + source_slug + '.md', text)
-   file_id = result["file_id"]
+   summary = "2-4 sentence source-specific summary"
+   excerpt = text[:1200]
+   metadata = {
+       "query_id": query_id,
+       "source_slug": source_slug,
+       "summary": summary,
+       "excerpt": excerpt,
+       "content_length": len(text),
+       "archive_status": "deferred"
+   }
    ```
+   Keep excerpts short enough for entity metadata. Prefer signal over volume:
+   concise summaries, concrete topics, and canonical references.
 6. **Create DesignSource entities**:
    ```python
    src = temper.create('DesignSources', {})
@@ -26,7 +39,7 @@ Job type: `source_search`
        'title': title,
        'source_type': source_type,
        'source_url': url,
-       'file_id': file_id,
+       'file_id': '',
        'metadata': json.dumps(metadata)
    })
    temper.action('DesignSources', src['entity_id'], 'Index', {
@@ -35,6 +48,9 @@ Job type: `source_search`
    })
    ```
    `source_type` must be one of: "article", "style_guide", "design_system_docs", "reference"
+   Use `metadata.archive_status = "deferred"` when the full page text was not
+   archived. `file_id` is optional for hot-path research and should remain
+   empty unless an existing file artifact already exists.
 7. **Create CurationDirection entities for fan-out**: For each discovered movement, create one direction and queue it. Do not create `CurationJob` entities yourself; `QueueSynthesis` triggers the synthesize job.
    ```python
    direction_ids = []
@@ -68,7 +84,10 @@ Job type: `source_search`
        temper.action('CurationDirections', direction_id, 'QueueSynthesis', {})
        direction_ids.append(direction_id)
    ```
-8. **Update workspace**: Update `/katagami/log.md` and `/katagami/index.md` with findings.
+8. **Do not update workspace files in the hot path**: Put findings in
+   DesignSource metadata, CurationDirection fields, and the CurationJob
+   completion output. Do not update `/katagami/log.md`, `/katagami/index.md`,
+   or `/katagami/sources/*.md` during `source_search`.
 9. **Complete the job**:
    ```python
    temper.action('CurationJobs', job_id, 'CompleteResearch', {
@@ -92,6 +111,9 @@ Do NOT create synthesize jobs yourself. CurationDirection.QueueSynthesis handles
 
 - No `import` statements
 - Available tools: `temper.web_search(query)`, `temper.web_fetch(url)`, `temper.write(path, content)`, `temper.read(path)`, `temper.list(...)`, `temper.get(...)`, `temper.create(...)`, `temper.action(...)`
+- Do not use `temper.write(...)` during `source_search` except for an explicit
+  operator-requested artifact. Research source text belongs in compact
+  DesignSource metadata during this job; full PawFS archival is deferred.
 - **ALL array and object parameters MUST use `json.dumps(...)`.** NEVER use `str()` or Python repr — these produce single-quoted strings that break JSON parsing in the UI.
 - `temper.web_fetch(url)` returns a structured object. Read with `fetched.get("text", "")`
 
@@ -104,3 +126,5 @@ Job output JSON must include:
 - `discovered_movements` — array of movement names found
 - `topic_allowlist` — topics ready for synthesis
 - `direction_ids` — array of CurationDirection entity IDs queued for synthesis
+- `archive_status` — `"deferred"` unless the operator explicitly requested
+  PawFS archival during this run

--- a/katagami-curation/tests/test_source_search_hot_path.py
+++ b/katagami-curation/tests/test_source_search_hot_path.py
@@ -1,0 +1,41 @@
+import unittest
+from pathlib import Path
+
+
+class SourceSearchHotPathTests(unittest.TestCase):
+    def test_source_search_does_not_archive_full_pages_synchronously(self):
+        root = Path(__file__).resolve().parents[1]
+        skill = (
+            root / "agents" / "curator" / "skills" / "research-direction" / "SKILL.md"
+        ).read_text()
+
+        self.assertIn("archive_status", skill)
+        self.assertIn("deferred", skill)
+        self.assertIn("'file_id': ''", skill)
+        self.assertIn("Do not use `temper.write(...)` during `source_search`", skill)
+        self.assertNotIn("temper.write('/katagami/sources/'", skill)
+        self.assertNotIn('temper.write("/katagami/sources/', skill)
+
+    def test_storage_model_documents_pawfs_artifact_boundary(self):
+        root = Path(__file__).resolve().parents[2]
+        commons_app = (root / "katagami-commons" / "APP.md").read_text()
+        curator_agent = (
+            root / "katagami-curation" / "agents" / "curator" / "AGENT.md"
+        ).read_text()
+
+        self.assertIn("Source-search jobs", commons_app)
+        self.assertIn("must not synchronously write", commons_app)
+        self.assertIn("do not write full fetched pages to PawFS", curator_agent)
+
+    def test_curation_session_link_uses_lower_write_volume_poll_budget(self):
+        root = Path(__file__).resolve().parents[1]
+        builder = (
+            root / "wasm" / "build_session_message" / "src" / "lib.rs"
+        ).read_text()
+
+        self.assertIn('"MaxChecks": "80"', builder)
+        self.assertNotIn('"MaxChecks": "180"', builder)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/katagami-curation/wasm/build_session_message/src/lib.rs
+++ b/katagami-curation/wasm/build_session_message/src/lib.rs
@@ -438,7 +438,7 @@ fn create_session_link(
         "ChildSessionId": child_session_id,
         "OnCompletedAction": "",
         "OnFailureAction": "Fail",
-        "MaxChecks": "180",
+        "MaxChecks": "80",
     });
     let configure_resp = ctx.http_call(
         "POST",


### PR DESCRIPTION
## Summary\n- update source-search skill to index compact DesignSource metadata/excerpts instead of writing full fetched pages to PawFS\n- document the PawFS artifact boundary for Katagami agents\n- lower Katagami SessionLink monitor MaxChecks to match the lower-write polling profile\n\n## Tests\n- python3 -m unittest katagami-curation/tests/test_no_hardcoded_prompts_in_wasm.py katagami-curation/tests/test_reaction_resolver_types.py katagami-curation/tests/test_design_md_contract.py katagami-curation/tests/test_source_search_hot_path.py\n- cargo test && cargo build --target wasm32-wasip1 --release (katagami-curation/wasm/build_session_message)