### PR TITLE
Inline Katagami job docs for synth hot path

### DIFF
--- a/katagami-curation/specs/curation_job.ioa.toml
+++ b/katagami-curation/specs/curation_job.ioa.toml
@@ -88,6 +88,11 @@ name = "completion_contract"
 type = "string"
 initial = "legacy-json-v1"
 
+[[state]]
+name = "inline_job_docs"
+type = "bool"
+initial = "false"
+
 # --- Session spawning fields ---
 
 [[state]]
@@ -131,7 +136,7 @@ initial = ""
 name = "Configure"
 kind = "input"
 from = ["Queued"]
-params = ["job_type", "design_language_id", "direction_id", "workspace_id", "input", "model", "provider", "soul_id", "max_turns", "tools_enabled", "query_id", "completion_contract"]
+params = ["job_type", "design_language_id", "direction_id", "workspace_id", "input", "model", "provider", "soul_id", "max_turns", "tools_enabled", "query_id", "completion_contract", "inline_job_docs"]
 hint = "Set or update job parameters before execution."
 
 [[action]]
@@ -139,7 +144,7 @@ name = "ConfigureAndSubmit"
 kind = "internal"
 from = ["Queued"]
 to = "Ready"
-params = ["job_type", "design_language_id", "direction_id", "workspace_id", "input", "model", "provider", "soul_id", "max_turns", "tools_enabled", "query_id", "completion_contract"]
+params = ["job_type", "design_language_id", "direction_id", "workspace_id", "input", "model", "provider", "soul_id", "max_turns", "tools_enabled", "query_id", "completion_contract", "inline_job_docs"]
 hint = "Configure a trigger-created job and start session spawning in one transition."
 effect = [{ type = "trigger", name = "build_session_message" }]
 

--- a/katagami-curation/specs/model.csdl.xml
+++ b/katagami-curation/specs/model.csdl.xml
@@ -27,6 +27,7 @@
         <Property Name="ProgressLog" Type="Edm.String" Nullable="false" DefaultValue="[]" />
         <Property Name="ErrorMessage" Type="Edm.String" Nullable="false" DefaultValue="" />
         <Property Name="CompletionContract" Type="Edm.String" Nullable="false" DefaultValue="legacy-json-v1" />
+        <Property Name="InlineJobDocs" Type="Edm.Boolean" Nullable="false" DefaultValue="false" />
         <!-- Session spawning fields -->
         <Property Name="SoulId" Type="Edm.String" Nullable="false" DefaultValue="app-agent-bootstrap" />
         <Property Name="Model" Type="Edm.String" Nullable="false" DefaultValue="" />

--- a/katagami-curation/wasm/finalize_spawned_session/src/lib.rs
+++ b/katagami-curation/wasm/finalize_spawned_session/src/lib.rs
@@ -1041,7 +1041,8 @@ fn spawn_synth_followup(
             "job_type": "synthesize",
             "workspace_id": workspace_id,
             "input": synth_input.to_string(),
-            "query_id": query_id
+            "query_id": query_id,
+            "inline_job_docs": true
         });
         let configure_resp = ctx.http_call(
             "POST",
@@ -1144,7 +1145,8 @@ fn spawn_quality_review_followup(
         "job_type": "quality_review",
         "workspace_id": workspace_id,
         "input": review_input.to_string(),
-        "query_id": query_id
+        "query_id": query_id,
+        "inline_job_docs": true
     });
     let configure_resp = ctx.http_call(
         "POST",


### PR DESCRIPTION
## Summary
- Add inline_job_docs to CurationJob so selected jobs can inline the exact required skill/knowledge docs at session creation.
- Set synthesize and quality_review follow-up jobs to inline their job docs, avoiding repeated LLM/tool turns that chunk-read SKILL.md.
- Update CSDL for the new CurationJob field.

## Validation
- cargo check --manifest-path katagami-curation/wasm/finalize_spawned_session/Cargo.toml
- cargo build --target wasm32-wasip1 --release (finalize_spawned_session)
- uvx pytest katagami-curation/tests/test_no_hardcoded_prompts_in_wasm.py katagami-curation/tests/test_source_search_hot_path.py -q
