### PR TITLE
Document Monty JSON helper contract

### DIFF
--- a/docs/adrs/0007-monty-json-helper-contract.md
+++ b/docs/adrs/0007-monty-json-helper-contract.md
@@ -1,0 +1,39 @@
+# ADR 0007: Monty JSON Helper Contract
+
+Date: 2026-04-28
+
+## Status
+
+Accepted for the reliability pass.
+
+## Context
+
+Katagami typed job actions store several fields as JSON strings, including
+source ids, topic lists, synthesis input, review output, and taxonomy metadata.
+The curator skills correctly require JSON serialization instead of Python
+`str(...)`, because Python repr uses single quotes and produces payloads that
+break UI parsing and finalizer validation.
+
+The Monty REPL is intentionally restricted and forbids imports in agent code.
+That made the old instruction contradictory: skills told agents not to import
+anything, but also told them to call `json.dumps(...)`. In production, a
+source-search smoke session confirmed that `json` was undefined.
+
+## Decision
+
+OpenPaw preloads a safe `json` helper in every Monty REPL session. Katagami
+skills use `json.dumps(...)` and `json.loads(...)` without importing.
+
+Katagami skills must continue to serialize every array or object action
+parameter with `json.dumps(...)`. They must not use `str(...)`, Python repr, or
+hand-built JSON-like strings for typed job payloads.
+
+## Consequences
+
+Agents get a stable JSON serialization contract that works inside the
+restricted REPL. Typed Katagami actions can remain strict without forcing each
+skill to carry its own fragile JSON helper.
+
+This does not change the storage architecture. Hot operational state remains
+Temper entities; PawFS remains for governed artifacts such as embodiments,
+DESIGN.md exports, snapshots, and explicit archives.

--- a/katagami-curation/agents/curator/AGENT.md
+++ b/katagami-curation/agents/curator/AGENT.md
@@ -28,7 +28,10 @@ Read knowledge files before starting work:
 - `temper.web_search(query)` — search the web
 - `temper.web_fetch(url)` — fetch a URL
 
-No `import` statements. The `sandbox.*` and `bash` tools are available for `synthesize`, `evolve_language`, and `regenerate_embodiment` jobs. Always serialize JSON with `json.dumps(...)`.
+No `import` statements. A safe `json` helper is preloaded in the Monty REPL;
+use `json.dumps(...)` and `json.loads(...)` without importing. The
+`sandbox.*` and `bash` tools are available for `synthesize`, `evolve_language`,
+and `regenerate_embodiment` jobs.
 
 ## Entity Sets
 

--- a/katagami-curation/agents/curator/skills/organize-taxonomy/SKILL.md
+++ b/katagami-curation/agents/curator/skills/organize-taxonomy/SKILL.md
@@ -132,9 +132,10 @@ Read the knowledge files in your workspace:
 
 ## Tooling Rules
 
-- No `import` statements
+- No `import` statements. A safe `json` helper is preloaded in the Monty REPL;
+  use `json.dumps(...)` and `json.loads(...)` without importing.
 - Available tools: `temper.list(...)`, `temper.get(...)`, `temper.create(...)`, `temper.action(...)`, `temper.write(path, content)`, `temper.read(path)`
-- **ALL array and object parameters MUST use `json.dumps(...)`.** NEVER use `str()` or Python repr — these produce single-quoted strings that break JSON parsing in the UI. Example: `json.dumps(['a', 'b'])` → `'["a", "b"]'` (correct), NOT `str(['a', 'b'])` → `"['a', 'b']"` (broken).
+- **ALL array and object parameters MUST use the preloaded `json.dumps(...)`.** NEVER use `str()` or Python repr — these produce single-quoted strings that break JSON parsing in the UI. Example: `json.dumps(['a', 'b'])` -> `'["a", "b"]'` (correct), NOT `str(['a', 'b'])` -> `"['a', 'b']"` (broken).
 
 ## Output
 

--- a/katagami-curation/agents/curator/skills/research-direction/SKILL.md
+++ b/katagami-curation/agents/curator/skills/research-direction/SKILL.md
@@ -109,12 +109,13 @@ Do NOT create synthesize jobs yourself. CurationDirection.QueueSynthesis handles
 
 ## Tooling Rules
 
-- No `import` statements
+- No `import` statements. A safe `json` helper is preloaded in the Monty REPL;
+  use `json.dumps(...)` and `json.loads(...)` without importing.
 - Available tools: `temper.web_search(query)`, `temper.web_fetch(url)`, `temper.write(path, content)`, `temper.read(path)`, `temper.list(...)`, `temper.get(...)`, `temper.create(...)`, `temper.action(...)`
 - Do not use `temper.write(...)` during `source_search` except for an explicit
   operator-requested artifact. Research source text belongs in compact
   DesignSource metadata during this job; full PawFS archival is deferred.
-- **ALL array and object parameters MUST use `json.dumps(...)`.** NEVER use `str()` or Python repr — these produce single-quoted strings that break JSON parsing in the UI.
+- **ALL array and object parameters MUST use the preloaded `json.dumps(...)`.** NEVER use `str()` or Python repr — these produce single-quoted strings that break JSON parsing in the UI.
 - `temper.web_fetch(url)` returns a structured object. Read with `fetched.get("text", "")`
 
 ## Output

--- a/katagami-curation/agents/curator/skills/review-quality/SKILL.md
+++ b/katagami-curation/agents/curator/skills/review-quality/SKILL.md
@@ -98,9 +98,10 @@ For each language specified in the job input (or ALL languages if none specified
 
 ## Tooling Rules
 
-- No `import` statements
+- No `import` statements. A safe `json` helper is preloaded in the Monty REPL;
+  use `json.dumps(...)` and `json.loads(...)` without importing.
 - Available tools: `temper.list(...)`, `temper.get(...)`, `temper.create(...)`, `temper.action(...)`, `temper.write(path, content)`, `temper.read(path)`, `sandbox.bash(cmd)`, `sandbox.write(path, content)`, `sandbox.read(path)`
-- **ALL array and object parameters MUST use `json.dumps(...)`.** NEVER use `str()` or Python repr — these produce single-quoted strings that break JSON parsing in the UI. Example: `json.dumps(['a', 'b'])` → `'["a", "b"]'` (correct), NOT `str(['a', 'b'])` → `"['a', 'b']"` (broken).
+- **ALL array and object parameters MUST use the preloaded `json.dumps(...)`.** NEVER use `str()` or Python repr — these produce single-quoted strings that break JSON parsing in the UI. Example: `json.dumps(['a', 'b'])` -> `'["a", "b"]'` (correct), NOT `str(['a', 'b'])` -> `"['a', 'b']"` (broken).
 
 ## Output
 

--- a/katagami-curation/agents/curator/skills/synthesize-language/SKILL.md
+++ b/katagami-curation/agents/curator/skills/synthesize-language/SKILL.md
@@ -343,10 +343,11 @@ else:
 
 ## Tooling Rules
 
-- No `import` statements
+- No `import` statements. A safe `json` helper is preloaded in the Monty REPL;
+  use `json.dumps(...)` and `json.loads(...)` without importing.
 - No `enumerate(..., start=...)` — use `for i in range(len(items)):` instead
 - Available tools: `temper.list(...)`, `temper.get(...)`, `temper.create(...)`, `temper.action(...)`, `temper.write(path, content)`, `temper.read(path)`, `sandbox.bash(cmd)`, `sandbox.write(path, content)`, `sandbox.read(path)`
-- **ALL array and object parameters MUST use `json.dumps(...)`.** NEVER use `str()` or Python repr — these produce single-quoted strings that break JSON parsing in the UI. Example: `json.dumps(['a', 'b'])` → `'["a", "b"]'` (correct), NOT `str(['a', 'b'])` → `"['a', 'b']"` (broken).
+- **ALL array and object parameters MUST use the preloaded `json.dumps(...)`.** NEVER use `str()` or Python repr — these produce single-quoted strings that break JSON parsing in the UI. Example: `json.dumps(['a', 'b'])` -> `'["a", "b"]'` (correct), NOT `str(['a', 'b'])` -> `"['a', 'b']"` (broken).
 - String literals containing quotes MUST use proper escaping. Prefer single-quoted strings for JSON content.
 
 ## Output

--- a/katagami-curation/tests/test_source_search_hot_path.py
+++ b/katagami-curation/tests/test_source_search_hot_path.py
@@ -36,6 +36,20 @@ class SourceSearchHotPathTests(unittest.TestCase):
         self.assertIn('"MaxChecks": "80"', builder)
         self.assertNotIn('"MaxChecks": "180"', builder)
 
+    def test_curator_skills_use_preloaded_json_helper_contract(self):
+        root = Path(__file__).resolve().parents[1]
+        curator_root = root / "agents" / "curator"
+        docs = [curator_root / "AGENT.md"]
+        docs.extend((curator_root / "skills").glob("*/SKILL.md"))
+
+        for doc in docs:
+            text = doc.read_text()
+            with self.subTest(doc=doc.relative_to(root)):
+                self.assertIn("json.dumps", text)
+                self.assertIn("without importing", text)
+                self.assertNotIn("import json", text)
+                self.assertNotIn("from json", text)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary\n- clarify that Katagami curator skills use the preloaded Monty json helper without imports\n- add ADR 0007 for the runtime/prompt JSON serialization contract\n- add a regression test so skills do not drift back to impossible import instructions\n\n## Tests\n- python3 -m unittest discover -s katagami-curation/tests