### PR TITLE
Speed up Katagami curation hot paths

### DIFF
--- a/docs/adrs/0008-fast-curation-hot-paths.md
+++ b/docs/adrs/0008-fast-curation-hot-paths.md
@@ -1,0 +1,65 @@
+# ADR 0008: Fast Curation Hot Paths
+
+Date: 2026-04-28
+
+## Status
+
+Accepted for the Layer 1 production unblock.
+
+## Context
+
+Katagami curation was spending too much time on generic file and entity
+machinery while doing ordinary agent work. Source-search jobs scanned broad
+workspace/library state, fetched and archived more than they needed, and
+multiplied static knowledge reads before creating directions. Synthesis jobs
+created a new language by dispatching many small setter actions in sequence,
+which amplified remote storage latency and made Turso append stalls visible to
+users.
+
+The deeper architecture still moves session turns and hot agent state toward
+first-class Temper entities. This ADR documents the immediate production
+boundary so Katagami can run usable cycles while that larger cleanup proceeds.
+
+## Decision
+
+Katagami source-search is a compact metadata hot path.
+
+- Targeted source-search jobs do not read `/katagami/index.md` or
+  `/katagami/log.md` unless explicitly asked for a library-wide audit.
+- Source-search must not list all `DesignSources`; duplicate checks must use a
+  narrow filter such as the current query, exact URL, slug, or title.
+- Targeted source-search runs a bounded number of searches, fetches at most the
+  top three pages, and stores compact metadata, summaries, excerpts, topics,
+  and references on `DesignSource` entities.
+- Full fetched-page archives are deferred PawFS artifacts, not synchronous
+  research-path writes.
+
+Katagami synthesis writes the core language spec as one coherent transition.
+
+- New synthesis jobs create the `DesignLanguage` and then call
+  `DesignLanguage.SetSpec` once with name, slug, philosophy, tokens, rules,
+  layout principles, guidance, and tags.
+- `SetSpec` marks the required spec sections present and invalidates derived
+  artifacts such as embodiment quality, DESIGN.md verification, and publish
+  readiness.
+- Narrow setter actions remain valid for small edits and repair jobs.
+
+Agent tool instructions must match runtime reality.
+
+- Monty `execute` calls are treated as self-contained because production
+  sessions may reset the Python heap between provider turns.
+- Agents should batch dependent operations in one focused call, and carry
+  durable IDs/results explicitly through Temper entities or files.
+
+## Consequences
+
+The curation cycle does fewer unnecessary reads, fewer page fetches, and fewer
+hot writes before the first publishable language exists. PawFS remains the
+governed artifact plane for embodiments, DESIGN.md exports, snapshots, and
+operator-requested source archives, but it is not used for every intermediate
+research mutation.
+
+This does not replace the planned Layer 2 work. Session entries, tool calls,
+tool results, trace metadata, and durable memory should still become direct
+Temper-native operational state. This ADR keeps the current Katagami workflow
+fast enough to use while that larger model is completed.

--- a/katagami-commons/specs/design_language.ioa.toml
+++ b/katagami-commons/specs/design_language.ioa.toml
@@ -140,6 +140,24 @@ params = ["name", "slug"]
 hint = "Set the design language name and URL-safe slug."
 
 [[action]]
+name = "SetSpec"
+kind = "input"
+from = ["Draft", "UnderReview"]
+effect = [
+  { type = "set_bool", var = "has_philosophy", value = "true" },
+  { type = "set_bool", var = "has_tokens", value = "true" },
+  { type = "set_bool", var = "has_rules", value = "true" },
+  { type = "set_bool", var = "has_layout", value = "true" },
+  { type = "set_bool", var = "has_guidance", value = "true" },
+  { type = "set_bool", var = "has_design_md", value = "false" },
+  { type = "set_bool", var = "has_valid_design_md", value = "false" },
+  { type = "set_bool", var = "design_md_verified", value = "false" },
+  { type = "set_bool", var = "quality_review_passed", value = "false" }
+]
+params = ["name", "slug", "philosophy", "tokens", "rules", "layout_principles", "guidance", "tags"]
+hint = "Set the complete core spec for a newly synthesized or substantially revised language in one coherent hot-path transition."
+
+[[action]]
 name = "WritePhilosophy"
 kind = "input"
 from = ["Draft", "UnderReview"]

--- a/katagami-curation/agents/curator/skills/research-direction/SKILL.md
+++ b/katagami-curation/agents/curator/skills/research-direction/SKILL.md
@@ -8,17 +8,23 @@ Job type: `source_search`
 
 ## Process
 
-1. **Orient**: Read `/katagami/index.md` and `/katagami/log.md` if they exist. List existing DesignSources to avoid duplicates.
-2. **Parse scope**: Read the job input for search scope — design movements, aesthetic directions, specific styles to research.
-3. **Search broadly**: Use `temper.web_search(query)` with varied, focused queries for design system documentation, foundational articles, style guides, and reference implementations.
-4. **Shortlist**: Select 5-8 high-signal, directly relevant sources per movement.
-5. **Fetch and distill**: For each shortlisted source, fetch only so you can
+1. **Parse scope first**: Read the job input for search scope — design movements, aesthetic directions, specific styles to research. Do not start by reading workspace files.
+2. **Bound orientation**: Do not read `/katagami/index.md` or `/katagami/log.md` during `source_search` unless the input explicitly asks for a library-wide audit. Do not call `temper.list('DesignSources', '')`. If you need duplicate protection, list only a narrow query-scoped subset, such as the current `query_id`, exact URL, or a precise title/source slug filter.
+3. **Search narrowly**: Use `temper.web_search(query)` with varied, focused queries for design system documentation, foundational articles, style guides, and reference implementations. For targeted requests, run 2-4 searches total.
+4. **Shortlist compactly**: Select 3-5 high-signal, directly relevant sources per targeted query. Use 5-8 only for broad survey jobs.
+5. **Fetch and distill**: For targeted requests, fetch at most the top 3
+   shortlisted sources. For the remaining sources, use `temper.web_search`
+   title/URL/snippet metadata and set `metadata.fetch_status = "skipped"`.
+   For fetched sources, fetch only so you can
    evaluate it and extract compact source metadata. Do **not** write the full
    fetched page to PawFS in `source_search`; source archival is a separate,
    deferred artifact step.
    ```python
    fetched = temper.web_fetch(url)
-   text = fetched.get("text", "") or fetched.get("content", "")
+   if isinstance(fetched, str):
+       text = fetched
+   else:
+       text = fetched.get("text", "") or fetched.get("content", "")
    summary = "2-4 sentence source-specific summary"
    excerpt = text[:1200]
    metadata = {
@@ -27,6 +33,7 @@ Job type: `source_search`
        "summary": summary,
        "excerpt": excerpt,
        "content_length": len(text),
+       "fetch_status": "fetched",
        "archive_status": "deferred"
    }
    ```
@@ -51,7 +58,7 @@ Job type: `source_search`
    Use `metadata.archive_status = "deferred"` when the full page text was not
    archived. `file_id` is optional for hot-path research and should remain
    empty unless an existing file artifact already exists.
-7. **Create CurationDirection entities for fan-out**: For each discovered movement, create one direction and queue it. Do not create `CurationJob` entities yourself; `QueueSynthesis` triggers the synthesize job.
+7. **Create CurationDirection entities for fan-out**: For each discovered movement, create one direction and queue it. For targeted requests, create 1-2 directions; create more only for explicit broad-survey jobs. Do not create `CurationJob` entities yourself; `QueueSynthesis` triggers the synthesize job.
    ```python
    direction_ids = []
    for movement in discovered_movements:
@@ -111,12 +118,21 @@ Do NOT create synthesize jobs yourself. CurationDirection.QueueSynthesis handles
 
 - No `import` statements. A safe `json` helper is preloaded in the Monty REPL;
   use `json.dumps(...)` and `json.loads(...)` without importing.
+- Treat each `execute` call as self-contained. Do not rely on Python variables
+  created by a previous call; persist durable data into entities or include it
+  in the current script.
 - Available tools: `temper.web_search(query)`, `temper.web_fetch(url)`, `temper.write(path, content)`, `temper.read(path)`, `temper.list(...)`, `temper.get(...)`, `temper.create(...)`, `temper.action(...)`
 - Do not use `temper.write(...)` during `source_search` except for an explicit
   operator-requested artifact. Research source text belongs in compact
   DesignSource metadata during this job; full PawFS archival is deferred.
+- Do not call `temper.list('DesignSources', '')` during `source_search`; use a
+  narrow filter tied to `query_id`, exact `source_url`, or a precise slug/title.
+- For targeted source-search jobs, do not fetch every shortlisted page. Fetch at
+  most 3 pages and use web-search snippets for the rest.
 - **ALL array and object parameters MUST use the preloaded `json.dumps(...)`.** NEVER use `str()` or Python repr — these produce single-quoted strings that break JSON parsing in the UI.
-- `temper.web_fetch(url)` returns a structured object. Read with `fetched.get("text", "")`
+- `temper.web_fetch(url)` may return a text string or a structured object. For
+  string results, use the value directly; for object results, read with
+  `fetched.get("text", "")`.
 
 ## Output
 

--- a/katagami-curation/agents/curator/skills/synthesize-language/SKILL.md
+++ b/katagami-curation/agents/curator/skills/synthesize-language/SKILL.md
@@ -22,7 +22,7 @@ When the job type is `regenerate_embodiment` and the input contains `existing_la
    - If no sources exist, research the design direction: `temper.web_search(language_name + ' design system UI patterns')` and `temper.web_fetch(url)` on the best results
    - Study the real-world references: what makes this design movement distinctive? What are the defining structural choices, typography conventions, color palettes, spatial relationships?
    - Rewrite each failing section with concrete, research-backed content — not vague adjectives, but specific CSS techniques and design decisions grounded in real references
-   - Call the appropriate Set action (WritePhilosophy, SetTokens, SetRules, SetLayout, SetGuidance)
+   - Call `SetSpec` when rewriting multiple spec sections, or the narrow Set action for one isolated section
    - Re-validate until all sections pass
 6. Go to the **EMBODIMENT PHASE** — generate HTML from the now-complete spec
 7. Use the entity's `visual_character`, `signature_patterns`, and all tokens to generate the HTML
@@ -49,14 +49,13 @@ Read the knowledge files in your workspace:
 
 ### Tool Call 1 — SPEC PHASE
 
-Create the DesignLanguage entity and write ALL spec sections. This is where you make the structural decisions.
+Create the DesignLanguage entity and write ALL spec sections. This is where you make the structural decisions. For new synthesis jobs, use `SetSpec` once after constructing every section; do not split the core spec across `SetName`, `WritePhilosophy`, `SetTokens`, `SetRules`, `SetLayout`, `SetGuidance`, and `SetTags`.
 
 ```python
 slug = 'my-language-slug'
 name = 'My Language Name'
 lang = temper.create('DesignLanguages', {'Id': slug})
 eid = lang['entity_id']
-temper.action('DesignLanguages', eid, 'SetName', {'name': name, 'slug': slug})
 ```
 
 **Philosophy** — must include `visual_character`: 3-5 CONCRETE visual traits unique to this language. Not design platitudes like "clean and minimal" but structural choices like "thick 4px solid black borders on every container", "uppercase monospace section labels", "asymmetric grid with oversized left gutter", "diagonal clip-path corners on cards".
@@ -68,7 +67,6 @@ philosophy = {
     "anti_values": [...],
     "visual_character": ["3-5 CONCRETE visual traits — these become the structural blueprint for the embodiment"]
 }
-temper.action('DesignLanguages', eid, 'WritePhilosophy', {'philosophy': json.dumps(philosophy)})
 ```
 
 **Tokens** — must include surfaces, borders, and motion:
@@ -84,7 +82,6 @@ tokens = {
     "borders": {"default_width": "...", "accent_width": "...", "style": "solid|dashed|double|groove|none", "character": "describe the border personality"},
     "motion": {"duration": "...", "easing": "...", "philosophy": "snappy|elastic|deliberate|none"}
 }
-temper.action('DesignLanguages', eid, 'SetTokens', {'tokens': json.dumps(tokens)})
 ```
 
 Tokens must also be DESIGN.md-projectable:
@@ -102,17 +99,13 @@ rules = {
     "density": "...",
     "signature_patterns": ["3-5 unique CSS techniques, e.g. 'every card has a 4px left-border color accent', 'section headers use decorative double-underline', 'all containers use clip-path for angled corners'"]
 }
-temper.action('DesignLanguages', eid, 'SetRules', {'rules': json.dumps(rules)})
 ```
 
 **Layout and Guidance:**
 
 ```python
 layout = {"grid": "...", "breakpoints": "...", "whitespace": "..."}
-temper.action('DesignLanguages', eid, 'SetLayout', {'layout_principles': json.dumps(layout)})
-
 guidance = {"do": [...], "dont": [...]}
-temper.action('DesignLanguages', eid, 'SetGuidance', {'guidance': json.dumps(guidance)})
 ```
 
 Guidance should be phrased so it can become DESIGN.md Do's and Don'ts without losing meaning.
@@ -120,8 +113,16 @@ Guidance should be phrased so it can become DESIGN.md Do's and Don'ts without lo
 **Tags** — set 5-10 specific, searchable tags describing the language's visual/structural properties. These help with gallery search and filtering. Use concrete descriptors, not abstract art history terms.
 
 ```python
-temper.action('DesignLanguages', eid, 'SetTags', {
-    'tags': json.dumps(['serif-editorial', 'high-contrast', 'dark-mode', 'column-grid', 'long-form-reading'])
+tags = ['serif-editorial', 'high-contrast', 'dark-mode', 'column-grid', 'long-form-reading']
+temper.action('DesignLanguages', eid, 'SetSpec', {
+    'name': name,
+    'slug': slug,
+    'philosophy': json.dumps(philosophy, ensure_ascii=False),
+    'tokens': json.dumps(tokens, ensure_ascii=False),
+    'rules': json.dumps(rules, ensure_ascii=False),
+    'layout_principles': json.dumps(layout, ensure_ascii=False),
+    'guidance': json.dumps(guidance, ensure_ascii=False),
+    'tags': json.dumps(tags, ensure_ascii=False)
 })
 ```
 

--- a/katagami-curation/tests/test_design_md_contract.py
+++ b/katagami-curation/tests/test_design_md_contract.py
@@ -81,6 +81,7 @@ class DesignMdContractTests(unittest.TestCase):
     def test_source_spec_changes_invalidate_design_md(self):
         for action_name in [
             "SetName",
+            "SetSpec",
             "WritePhilosophy",
             "SetTokens",
             "SetRules",
@@ -103,6 +104,31 @@ class DesignMdContractTests(unittest.TestCase):
                 self.assertTrue(
                     self._sets_bool(action_name, "quality_review_passed", "false")
                 )
+
+    def test_set_spec_is_complete_hot_path_transition(self):
+        set_spec = self.actions["SetSpec"]
+        self.assertEqual(set_spec["from"], ["Draft", "UnderReview"])
+        self.assertEqual(
+            set_spec["params"],
+            [
+                "name",
+                "slug",
+                "philosophy",
+                "tokens",
+                "rules",
+                "layout_principles",
+                "guidance",
+                "tags",
+            ],
+        )
+        for var in [
+            "has_philosophy",
+            "has_tokens",
+            "has_rules",
+            "has_layout",
+            "has_guidance",
+        ]:
+            self.assertTrue(self._sets_bool("SetSpec", var, "true"))
 
     def test_review_skill_owns_design_md_gate(self):
         review_skill = (

--- a/katagami-curation/tests/test_source_search_hot_path.py
+++ b/katagami-curation/tests/test_source_search_hot_path.py
@@ -13,8 +13,26 @@ class SourceSearchHotPathTests(unittest.TestCase):
         self.assertIn("deferred", skill)
         self.assertIn("'file_id': ''", skill)
         self.assertIn("Do not use `temper.write(...)` during `source_search`", skill)
+        self.assertIn("Do not call `temper.list('DesignSources', '')`", skill)
+        self.assertIn("For targeted requests, create 1-2 directions", skill)
+        self.assertIn("Treat each `execute` call as self-contained", skill)
+        self.assertIn("fetch at most the top 3", skill)
+        self.assertIn("isinstance(fetched, str)", skill)
         self.assertNotIn("temper.write('/katagami/sources/'", skill)
         self.assertNotIn('temper.write("/katagami/sources/', skill)
+
+    def test_synthesis_uses_single_spec_transition_for_new_languages(self):
+        root = Path(__file__).resolve().parents[1]
+        skill = (
+            root / "agents" / "curator" / "skills" / "synthesize-language" / "SKILL.md"
+        ).read_text()
+
+        self.assertIn("use `SetSpec` once", skill)
+        self.assertIn("'SetSpec'", skill)
+        self.assertIn("'philosophy': json.dumps(philosophy", skill)
+        self.assertIn("'tags': json.dumps(tags", skill)
+        self.assertNotIn("'WritePhilosophy'", skill)
+        self.assertNotIn("'SetTokens'", skill)
 
     def test_storage_model_documents_pawfs_artifact_boundary(self):
         root = Path(__file__).resolve().parents[2]

--- a/katagami-curation/wasm/build_session_message/src/lib.rs
+++ b/katagami-curation/wasm/build_session_message/src/lib.rs
@@ -129,33 +129,14 @@ pub extern "C" fn run(_ctx_ptr: i32, _ctx_len: i32) -> i32 {
             .as_ref()
             .map(|doc| doc.path.as_str())
             .unwrap_or(template.instruction_path.as_str());
-        let knowledge_docs = [
-            "/system/knowledge/design-principles.md",
-            "/system/knowledge/quality-standards.md",
-            "/system/knowledge/feedback-log.md",
-        ]
-        .iter()
-        .filter_map(|path| load_doc_file(&ctx, &api_url, &headers, path, inline_job_docs))
-        .collect::<Vec<_>>();
+        let knowledge_specs = knowledge_read_specs_for_skill(skill);
+        let knowledge_docs = knowledge_specs
+            .iter()
+            .filter_map(|(path, _)| load_doc_file(&ctx, &api_url, &headers, path, inline_job_docs))
+            .collect::<Vec<_>>();
         let instruction_read_command =
             temper_read_command(effective_instruction_path, instruction_doc.as_ref());
-        let knowledge_read_commands = render_read_commands(
-            &[
-                (
-                    "/system/knowledge/design-principles.md",
-                    "embodiment standards",
-                ),
-                (
-                    "/system/knowledge/quality-standards.md",
-                    "quality thresholds",
-                ),
-                (
-                    "/system/knowledge/feedback-log.md",
-                    "human feedback to incorporate",
-                ),
-            ],
-            &knowledge_docs,
-        );
+        let knowledge_read_commands = render_read_commands(knowledge_specs, &knowledge_docs);
         let loaded_reference_block = render_loaded_reference_block(
             instruction_doc.as_ref(),
             &knowledge_docs,
@@ -737,6 +718,31 @@ fn temper_read_command(path: &str, loaded: Option<&LoadedDoc>) -> String {
     }
 }
 
+fn knowledge_read_specs_for_skill(skill: &str) -> &'static [(&'static str, &'static str)] {
+    const FULL_CURATION_KNOWLEDGE: &[(&str, &str)] = &[
+        (
+            "/system/knowledge/design-principles.md",
+            "embodiment standards",
+        ),
+        (
+            "/system/knowledge/quality-standards.md",
+            "quality thresholds",
+        ),
+        (
+            "/system/knowledge/feedback-log.md",
+            "human feedback to incorporate",
+        ),
+    ];
+
+    match skill {
+        // Source search needs the research-direction skill contract and web
+        // search/fetch tools. Embodiment and quality docs are for synthesis and
+        // review; loading them here adds turns and context without helping.
+        "research-direction" => &[],
+        _ => FULL_CURATION_KNOWLEDGE,
+    }
+}
+
 fn render_read_commands(paths: &[(&str, &str)], loaded_docs: &[LoadedDoc]) -> String {
     paths
         .iter()
@@ -891,8 +897,9 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        config_bool, field_bool, instruction_path_candidates, normalize_bootstrapped_soul_id,
-        parse_template, render_loaded_reference_block, temper_read_command, LoadedDoc,
+        config_bool, field_bool, instruction_path_candidates, knowledge_read_specs_for_skill,
+        normalize_bootstrapped_soul_id, parse_template, render_loaded_reference_block,
+        temper_read_command, LoadedDoc,
     };
 
     #[test]
@@ -969,6 +976,14 @@ mod tests {
                     .to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn source_search_uses_only_skill_doc_by_default() {
+        assert!(knowledge_read_specs_for_skill("research-direction").is_empty());
+        assert!(knowledge_read_specs_for_skill("synthesize-language")
+            .iter()
+            .any(|(path, _)| *path == "/system/knowledge/design-principles.md"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n- bound source-search reads/fetches and keep fetched pages out of the synchronous PawFS path\n- add DesignLanguage.SetSpec for one coherent synthesis spec transition\n- document the Layer 1 curation hot-path boundary in ADR 0008\n\n## Tests\n- python3 -m unittest discover -s katagami-curation/tests\n- cargo test --manifest-path katagami-curation/wasm/build_session_message/Cargo.toml --lib\n- cargo build --manifest-path katagami-curation/wasm/build_session_message/Cargo.toml --target wasm32-wasip1 --release