### PR TITLE
Add curation finalizer tolerances and liveness

### DIFF
--- a/.proofs/023-curation-finalizer-liveness.md
+++ b/.proofs/023-curation-finalizer-liveness.md
@@ -1,0 +1,53 @@
+# 023 Curation Finalizer Tolerances And Liveness
+
+Date: 2026-05-07
+
+## Change
+
+- `finalize_spawned_session` accepts image-like thumbnail payloads mislabeled as `text/plain`.
+- `finalize_spawned_session` regenerates deterministic `DESIGN.md` when lint metadata is missing, invalid, or dirty.
+- Curation query/job/direction specs now give active states timeouts so stale work fails through entity actions instead of remaining indefinitely nonterminal.
+
+## Red
+
+```text
+cargo test
+error[E0432]: unresolved import `super::design_md_projection_refresh_reason`
+
+python3 katagami-curation/tests/test_curation_liveness_contract.py
+FAILED (failures=3)
+```
+
+The tests first captured the missing finalizer helper and the indefinite active curation states.
+
+## Green
+
+```text
+cargo fmt --check
+cargo test
+running 5 tests ... ok
+
+python3 katagami-curation/tests/test_curation_liveness_contract.py
+Ran 3 tests in 0.003s
+OK
+```
+
+## Build
+
+```text
+cargo build --target wasm32-unknown-unknown --release
+finalize_spawned_session.wasm sha256 a6f4afd9d086823a2a20061016ecab2c347444bd159e614404f648d610c144c6
+```
+
+## Production Hot-Load
+
+```json
+{"module_name":"finalize_spawned_session","sha256_hash":"a6f4afd9d086823a2a20061016ecab2c347444bd159e614404f648d610c144c6","size_bytes":405003}
+```
+
+Spec hot-load returned `HTTP 200`, loaded `CurationDirection`, `CurationJob`, and `CurationQuery`, and all verification levels passed for all three.
+
+## Live Cleanup
+
+- Moved stale curation jobs with failed/missing spawned sessions through `Katagami.Curation.Fail`.
+- Verified production has `0` nonterminal `CurationJob` entities after cleanup.

--- a/katagami-curation/specs/curation_direction.ioa.toml
+++ b/katagami-curation/specs/curation_direction.ioa.toml
@@ -7,7 +7,7 @@
 name = "CurationDirection"
 states = ["Discovered", "Synthesizing", "Completed", "Failed"]
 initial = "Discovered"
-allow_indefinite_states = ["Discovered", "Synthesizing"]
+allow_indefinite_states = ["Discovered", "Completed", "Failed"]
 
 [[state]]
 name = "query_id"
@@ -119,6 +119,12 @@ from = ["Discovered", "Synthesizing"]
 to = "Failed"
 params = ["error_message"]
 hint = "The direction could not be synthesized."
+
+[[state_timeout]]
+state = "Synthesizing"
+after_seconds = 7200
+on_timeout = "Fail"
+params = { error_message = "CurationDirection remained Synthesizing for 2h without synthesis completion." }
 
 [[invariant]]
 name = "CompletedIsFinal"

--- a/katagami-curation/specs/curation_job.ioa.toml
+++ b/katagami-curation/specs/curation_job.ioa.toml
@@ -9,7 +9,7 @@
 name = "CurationJob"
 states = ["Queued", "Ready", "Running", "Finalizing", "Completed", "Failed"]
 initial = "Queued"
-allow_indefinite_states = ["Queued", "Ready", "Running", "Finalizing", "Failed"]
+allow_indefinite_states = ["Completed", "Failed"]
 
 # --- State Variables ---
 
@@ -546,7 +546,7 @@ hint = "Finalize job completion after session recording and trigger-native follo
 [[action]]
 name = "Fail"
 kind = "input"
-from = ["Ready", "Running", "Finalizing"]
+from = ["Queued", "Ready", "Running", "Finalizing"]
 to = "Failed"
 params = ["error_message"]
 hint = "Mark job as failed with error details."
@@ -562,6 +562,30 @@ module = "finalize_spawned_session"
 
 [action.triggers.config]
 temper_api_url = "{secret:temper_api_url}"
+
+[[state_timeout]]
+state = "Queued"
+after_seconds = 900
+on_timeout = "Fail"
+params = { error_message = "CurationJob remained Queued for 15m without submission." }
+
+[[state_timeout]]
+state = "Ready"
+after_seconds = 900
+on_timeout = "Fail"
+params = { error_message = "CurationJob remained Ready for 15m without a spawned Session." }
+
+[[state_timeout]]
+state = "Running"
+after_seconds = 7200
+on_timeout = "Fail"
+params = { error_message = "CurationJob remained Running for 2h without self-reporting completion." }
+
+[[state_timeout]]
+state = "Finalizing"
+after_seconds = 900
+on_timeout = "Fail"
+params = { error_message = "CurationJob remained Finalizing for 15m without completing finalization." }
 
 [[action.triggers]]
 name = "job_failure_fails_direction"

--- a/katagami-curation/specs/curation_query.ioa.toml
+++ b/katagami-curation/specs/curation_query.ioa.toml
@@ -14,7 +14,7 @@
 name = "CurationQuery"
 states = ["Submitted", "Researching", "Synthesizing", "Organizing", "Completed", "Failed"]
 initial = "Submitted"
-allow_indefinite_states = ["Submitted", "Researching", "Synthesizing", "Organizing"]
+allow_indefinite_states = ["Submitted", "Completed", "Failed"]
 
 # --- State Variables ---
 
@@ -139,6 +139,24 @@ from = ["Submitted", "Researching", "Synthesizing", "Organizing"]
 to = "Failed"
 params = ["error_message"]
 hint = "Pipeline failed at any stage."
+
+[[state_timeout]]
+state = "Researching"
+after_seconds = 7200
+on_timeout = "Fail"
+params = { error_message = "CurationQuery remained Researching for 2h without source-search completion." }
+
+[[state_timeout]]
+state = "Synthesizing"
+after_seconds = 14400
+on_timeout = "Fail"
+params = { error_message = "CurationQuery remained Synthesizing for 4h without synthesis completion." }
+
+[[state_timeout]]
+state = "Organizing"
+after_seconds = 14400
+on_timeout = "Fail"
+params = { error_message = "CurationQuery remained Organizing for 4h without organization completion." }
 
 # --- Invariants ---
 

--- a/katagami-curation/tests/test_curation_liveness_contract.py
+++ b/katagami-curation/tests/test_curation_liveness_contract.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+import tomllib
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_spec(name: str) -> dict:
+    return tomllib.loads((ROOT / "specs" / name).read_text())
+
+
+def state_timeout_map(spec: dict) -> dict[str, dict]:
+    return {item["state"]: item for item in spec.get("state_timeout", [])}
+
+
+def indefinite_states(spec: dict) -> set[str]:
+    return set(spec["automaton"].get("allow_indefinite_states", []))
+
+
+def action_by_name(spec: dict, name: str) -> dict:
+    return next(action for action in spec.get("action", []) if action["name"] == name)
+
+
+class CurationLivenessContractTest(unittest.TestCase):
+    def test_curation_query_active_states_time_out_to_failed(self):
+        spec = load_spec("curation_query.ioa.toml")
+        timeouts = state_timeout_map(spec)
+
+        for state in ["Researching", "Synthesizing", "Organizing"]:
+            self.assertNotIn(state, indefinite_states(spec))
+            self.assertEqual(timeouts[state]["on_timeout"], "Fail")
+            self.assertIn("error_message", timeouts[state]["params"])
+
+    def test_curation_job_active_states_time_out_to_failed(self):
+        spec = load_spec("curation_job.ioa.toml")
+        timeouts = state_timeout_map(spec)
+
+        self.assertIn("Queued", action_by_name(spec, "Fail")["from"])
+        for state in ["Queued", "Ready", "Running", "Finalizing"]:
+            self.assertNotIn(state, indefinite_states(spec))
+            self.assertEqual(timeouts[state]["on_timeout"], "Fail")
+            self.assertIn("error_message", timeouts[state]["params"])
+
+    def test_curation_direction_synthesizing_times_out_to_failed(self):
+        spec = load_spec("curation_direction.ioa.toml")
+        timeouts = state_timeout_map(spec)
+
+        self.assertNotIn("Synthesizing", indefinite_states(spec))
+        self.assertEqual(timeouts["Synthesizing"]["on_timeout"], "Fail")
+        self.assertIn("error_message", timeouts["Synthesizing"]["params"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/katagami-curation/wasm/finalize_spawned_session/src/lib.rs
+++ b/katagami-curation/wasm/finalize_spawned_session/src/lib.rs
@@ -794,10 +794,11 @@ fn verify_design_md(
 ) -> Result<(), String> {
     let mut fields = entity_fields(language);
     let mut design_md_file_id = string_field_any(&fields, "design_md_file_id", "");
-    if design_md_file_id.is_empty() {
+    let refresh_reason = design_md_projection_refresh_reason(&fields, &design_md_file_id);
+    if let Some(refresh_reason) = refresh_reason {
         if workspace_id.is_empty() {
             return Err(format!(
-                "DesignLanguage '{language_id}' has no design_md_file_id and the CurationJob has no workspace_id for deterministic DESIGN.md generation"
+                "DesignLanguage '{language_id}' needs deterministic DESIGN.md generation ({refresh_reason}) but the CurationJob has no workspace_id"
             ));
         }
         let generated = render_design_md_projection(language_id, &fields);
@@ -818,6 +819,7 @@ fn verify_design_md(
                 "warnings": 0
             },
             "generated_by": "katagami-finalizer",
+            "refresh_reason": refresh_reason,
             "checks": [
                 "deterministic projection rendered from verified Katagami fields"
             ]
@@ -945,8 +947,10 @@ fn thumbnail_mime_type_is_acceptable(mime_type: &str, body: &str) -> bool {
     matches!(
         normalized.as_str(),
         "image/jpeg" | "image/jpg" | "image/png" | "image/webp" | "image/gif"
-    ) || matches!(normalized.as_str(), "" | "application/octet-stream")
-        && thumbnail_payload_looks_image_like(body)
+    ) || (matches!(
+        normalized.as_str(),
+        "" | "application/octet-stream" | "text/plain"
+    ) && thumbnail_payload_looks_image_like(body))
 }
 
 fn thumbnail_payload_looks_image_like(body: &str) -> bool {
@@ -1417,6 +1421,10 @@ fn read_file_value(
     headers: &[(String, String)],
     file_id: &str,
 ) -> Result<String, String> {
+    if file_id.trim().is_empty() {
+        return Err("Cannot read Files('')/$value: missing file id".to_string());
+    }
+
     let resp = ctx.http_call(
         "GET",
         &format!("{api_url}/tdata/Files('{file_id}')/$value"),
@@ -1431,6 +1439,43 @@ fn read_file_value(
         ));
     }
     Ok(resp.body)
+}
+
+fn design_md_projection_refresh_reason(
+    fields: &serde_json::Value,
+    design_md_file_id: &str,
+) -> Option<&'static str> {
+    if design_md_file_id.trim().is_empty() {
+        return Some("missing_design_md_file_id");
+    }
+
+    let raw = string_field_any(fields, "design_md_lint_result", "");
+    if raw.trim().is_empty() {
+        return Some("missing_design_md_lint_result");
+    }
+
+    let parsed: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(parsed) => parsed,
+        Err(_) => return Some("invalid_design_md_lint_json"),
+    };
+    let errors = parsed
+        .get("summary")
+        .and_then(|summary| summary.get("errors"))
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0);
+    let warnings = parsed
+        .get("summary")
+        .and_then(|summary| summary.get("warnings"))
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0);
+
+    if errors != 0 {
+        Some("design_md_lint_errors")
+    } else if warnings != 0 {
+        Some("design_md_lint_warnings")
+    } else {
+        None
+    }
 }
 
 fn verify_design_md_lint_result(
@@ -2404,7 +2449,8 @@ fn publish_job_progression(
 #[cfg(test)]
 mod tests {
     use super::{
-        json_object_field, render_design_md_projection, thumbnail_mime_type_is_acceptable,
+        design_md_projection_refresh_reason, json_object_field, render_design_md_projection,
+        thumbnail_mime_type_is_acceptable,
     };
     use serde_json::json;
 
@@ -2472,5 +2518,39 @@ mod tests {
             "application/octet-stream",
             "<html><body>not a thumbnail</body></html>"
         ));
+    }
+
+    #[test]
+    fn thumbnail_mime_accepts_text_plain_when_payload_is_base64_jpeg() {
+        assert!(thumbnail_mime_type_is_acceptable(
+            "text/plain",
+            "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBD"
+        ));
+    }
+
+    #[test]
+    fn design_md_projection_refreshes_missing_or_dirty_lint_metadata() {
+        assert_eq!(
+            design_md_projection_refresh_reason(&json!({}), ""),
+            Some("missing_design_md_file_id")
+        );
+        assert_eq!(
+            design_md_projection_refresh_reason(&json!({}), "fl-design-md"),
+            Some("missing_design_md_lint_result")
+        );
+        assert_eq!(
+            design_md_projection_refresh_reason(
+                &json!({"design_md_lint_result": "{\"summary\":{\"errors\":0,\"warnings\":2}}"}),
+                "fl-design-md"
+            ),
+            Some("design_md_lint_warnings")
+        );
+        assert_eq!(
+            design_md_projection_refresh_reason(
+                &json!({"design_md_lint_result": "{\"summary\":{\"errors\":0,\"warnings\":0}}"}),
+                "fl-design-md"
+            ),
+            None
+        );
     }
 }


### PR DESCRIPTION
## Summary\n- accept image-like text/plain thumbnails in curation finalizer\n- regenerate deterministic DESIGN.md when lint metadata is missing or dirty\n- add active-state timeouts for curation query/job/direction entities\n\n## Verification\n- cargo fmt --check (finalize_spawned_session)\n- cargo test (finalize_spawned_session)\n- python3 katagami-curation/tests/test_curation_liveness_contract.py\n- cargo build --target wasm32-unknown-unknown --release (finalize_spawned_session)\n- hot-loaded WASM and specs to Railway\n- verified production has zero nonterminal CurationJobs after cleanup