### PR TITLE
[codex] Harden curation thumbnail rendering

### DIFF
--- a/katagami-curation/agents/curator/skills/review-quality/SKILL.md
+++ b/katagami-curation/agents/curator/skills/review-quality/SKILL.md
@@ -62,6 +62,24 @@ For each language specified in the job input (or ALL languages if none specified
    - **curator_notes**: If present, these are specific fix instructions from the human curator. Follow them first.
 7. **Regenerate the embodiment as self-contained HTML.** Follow the sandbox visual feedback loop from the `synthesize-language` skill:
    - Write HTML to sandbox
+   - Prepare and prove the browser runtime before any screenshot:
+
+```python
+browser_setup_log = sandbox.bash("""set -eu
+python3 -m pip install --quiet playwright pillow
+python3 -m playwright install chromium >/dev/null
+python3 - <<'PY'
+from playwright.sync_api import sync_playwright
+p = sync_playwright().start()
+b = p.chromium.launch()
+b.close()
+p.stop()
+print('playwright ready')
+PY
+""")
+assert '[exit code: 0]' in browser_setup_log and 'playwright ready' in browser_setup_log, browser_setup_log
+```
+
    - Screenshot with Playwright at 3 viewports (desktop 1440x960, tablet 768px, mobile 375px)
    - Visually evaluate each viewport
    - Iterate until quality passes at all three sizes
@@ -78,52 +96,51 @@ For each language specified in the job input (or ALL languages if none specified
    - Stored PawFS file MIME metadata: `image/jpeg`
    - Safety: disable animations/transitions before capture so the gallery image is deterministic
 
-   ```python
-   sandbox.bash('pip install pillow 2>&1 | tail -1')
-   sandbox.bash("""python3 -c "
-   from playwright.sync_api import sync_playwright
-   from PIL import Image
+```python
+thumb_log = sandbox.bash("""python3 - <<'PY'
+from playwright.sync_api import sync_playwright
+from PIL import Image
 
-   safety_css = '''
-   *, *::before, *::after {
-     animation-duration: 0s !important;
-     animation-delay: 0s !important;
-     animation-iteration-count: 1 !important;
-     transition-duration: 0s !important;
-     transition-delay: 0s !important;
-   }
-   html, body {
-     max-height: 1800px !important;
-     overflow: hidden !important;
-   }
-   '''
+safety_css = '''
+*, *::before, *::after {
+  animation-duration: 0s !important;
+  animation-delay: 0s !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0s !important;
+  transition-delay: 0s !important;
+}
+html, body {
+  max-height: 1800px !important;
+  overflow: hidden !important;
+}
+'''
 
-   p = sync_playwright().start()
-   b = p.chromium.launch()
-   pg = b.new_page(viewport={'width': 1440, 'height': 960})
-   pg.goto('file:///tmp/embodiment.html')
-   pg.add_style_tag(content=safety_css)
-   pg.wait_for_timeout(1000)
-   pg.screenshot(path='/tmp/thumbnail_source.jpg', type='jpeg', quality=84, full_page=False)
-   pg.close()
-   b.close()
-   p.stop()
+p = sync_playwright().start()
+b = p.chromium.launch()
+pg = b.new_page(viewport={'width': 1440, 'height': 960})
+pg.goto('file:///tmp/embodiment.html')
+pg.add_style_tag(content=safety_css)
+pg.wait_for_timeout(1000)
+pg.screenshot(path='/tmp/thumbnail_source.jpg', type='jpeg', quality=84, full_page=False)
+pg.close()
+b.close()
+p.stop()
 
-   img = Image.open('/tmp/thumbnail_source.jpg')
-   img = img.resize((600, 400), Image.Resampling.LANCZOS)
-   img.save('/tmp/thumbnail_desktop.jpg', 'JPEG', quality=74, optimize=True)
+img = Image.open('/tmp/thumbnail_source.jpg')
+img = img.resize((600, 400), Image.Resampling.LANCZOS)
+img.save('/tmp/thumbnail_desktop.jpg', 'JPEG', quality=74, optimize=True)
 
-   check = Image.open('/tmp/thumbnail_desktop.jpg')
-   assert check.size == (600, 400), check.size
-   assert check.format == 'JPEG', check.format
-   print('thumbnail ok: 600x400 JPEG')
-   " 2>&1""")
-   thumbnail_bytes = sandbox.read('/tmp/thumbnail_desktop.jpg', binary=True)
-   assert not (
-       isinstance(thumbnail_bytes, str)
-       and thumbnail_bytes.lstrip().startswith('/9j/')
-   ), 'thumbnail read returned base64 text; use binary=True before temper.write'
-   ```
+check = Image.open('/tmp/thumbnail_desktop.jpg')
+assert check.size == (600, 400), check.size
+assert check.format == 'JPEG', check.format
+print('thumbnail ok: 600x400 JPEG')
+PY
+""")
+assert '[exit code: 0]' in thumb_log and 'thumbnail ok: 600x400 JPEG' in thumb_log, thumb_log
+thumbnail_bytes = sandbox.read('/tmp/thumbnail_desktop.jpg', binary=True)
+assert isinstance(thumbnail_bytes, dict) and thumbnail_bytes.get('__temperpaw_image') is True, 'thumbnail read must return a sandbox image result'
+assert thumbnail_bytes.get('media_type') == 'image/jpeg', thumbnail_bytes
+```
 
    If thumbnail generation, resizing, or verification fails, fix the embodiment
    or screenshot command and retry. Do not attach a missing, blank, wrong-size,
@@ -137,7 +154,9 @@ For each language specified in the job input (or ALL languages if none specified
        'composition_count': '5',
        'embodiment_format': 'html'
    })
-   thumbnail_result = temper.write('/katagami/thumbnails/' + slug + '/desktop.jpg', thumbnail_bytes)
+   thumbnail_result = temper.write('/katagami/thumbnails/' + slug + '/desktop.jpg', thumbnail_bytes, {
+       'mime_type': 'image/jpeg'
+   })
    temper.action('DesignLanguages', lang_id, 'AttachThumbnail', {
        'thumbnail_file_id': thumbnail_result['file_id']
    })

--- a/katagami-curation/agents/curator/skills/synthesize-language/SKILL.md
+++ b/katagami-curation/agents/curator/skills/synthesize-language/SKILL.md
@@ -166,9 +166,21 @@ sandbox.write('/tmp/embodiment.html', html_code)
 ### Step 2 — Screenshot at three viewports
 
 ```python
-sandbox.bash('pip install playwright 2>&1 | tail -1')
-sandbox.bash('playwright install chromium 2>&1 | tail -1')
-sandbox.bash("""python3 -c "
+browser_setup_log = sandbox.bash("""set -eu
+python3 -m pip install --quiet playwright pillow
+python3 -m playwright install chromium >/dev/null
+python3 - <<'PY'
+from playwright.sync_api import sync_playwright
+p = sync_playwright().start()
+b = p.chromium.launch()
+b.close()
+p.stop()
+print('playwright ready')
+PY
+""")
+assert '[exit code: 0]' in browser_setup_log and 'playwright ready' in browser_setup_log, browser_setup_log
+
+shot_log = sandbox.bash("""python3 - <<'PY'
 from playwright.sync_api import sync_playwright
 viewports = [
     {'name': 'desktop', 'width': 1440, 'height': 960},
@@ -181,11 +193,14 @@ for vp in viewports:
     pg = b.new_page(viewport={'width': vp['width'], 'height': vp['height']})
     pg.goto('file:///tmp/embodiment.html')
     pg.wait_for_timeout(2000)
-    pg.screenshot(path=f'/tmp/shot_{vp[\"name\"]}.png', full_page=True)
+    pg.screenshot(path=f'/tmp/shot_{vp["name"]}.png', full_page=True)
     pg.close()
 b.close()
 p.stop()
-" 2>&1""")
+print('shots ok')
+PY
+""")
+assert '[exit code: 0]' in shot_log and 'shots ok' in shot_log, shot_log
 ```
 
 ### Step 3 — Evaluate
@@ -219,8 +234,7 @@ The thumbnail must be a stable desktop viewport crop, not a full-page strip:
   deterministic.
 
 ```python
-sandbox.bash('pip install pillow 2>&1 | tail -1')
-sandbox.bash("""python3 -c "
+thumb_log = sandbox.bash("""python3 - <<'PY'
 from playwright.sync_api import sync_playwright
 from PIL import Image
 
@@ -257,12 +271,12 @@ check = Image.open('/tmp/thumbnail_desktop.jpg')
 assert check.size == (600, 400), check.size
 assert check.format == 'JPEG', check.format
 print('thumbnail ok: 600x400 JPEG')
-" 2>&1""")
+PY
+""")
+assert '[exit code: 0]' in thumb_log and 'thumbnail ok: 600x400 JPEG' in thumb_log, thumb_log
 thumbnail_bytes = sandbox.read('/tmp/thumbnail_desktop.jpg', binary=True)
-assert not (
-    isinstance(thumbnail_bytes, str)
-    and thumbnail_bytes.lstrip().startswith('/9j/')
-), 'thumbnail read returned base64 text; use binary=True before temper.write'
+assert isinstance(thumbnail_bytes, dict) and thumbnail_bytes.get('__temperpaw_image') is True, 'thumbnail read must return a sandbox image result'
+assert thumbnail_bytes.get('media_type') == 'image/jpeg', thumbnail_bytes
 ```
 
 If thumbnail generation, resizing, or verification fails, fix the embodiment or
@@ -282,7 +296,9 @@ temper.action('DesignLanguages', eid, 'AttachEmbodiment', {
     'composition_count': '5',
     'embodiment_format': 'html'
 })
-thumbnail_result = temper.write('/katagami/thumbnails/' + slug + '/desktop.jpg', thumbnail_bytes)
+thumbnail_result = temper.write('/katagami/thumbnails/' + slug + '/desktop.jpg', thumbnail_bytes, {
+    'mime_type': 'image/jpeg'
+})
 temper.action('DesignLanguages', eid, 'AttachThumbnail', {
     'thumbnail_file_id': thumbnail_result['file_id']
 })

--- a/katagami-curation/tests/test_thumbnail_contract.py
+++ b/katagami-curation/tests/test_thumbnail_contract.py
@@ -149,8 +149,12 @@ class ThumbnailContractTests(unittest.TestCase):
             "1440x960",
             "600x400",
             "full_page=False",
+            "playwright ready",
+            "[exit code: 0]",
             "thumbnail ok: 600x400 JPEG",
             "binary=True",
+            "__temperpaw_image",
+            "'mime_type': 'image/jpeg'",
             "VerifyThumbnail",
             "Do not call `VerifyThumbnail` or `SubmitForReview`",
         ]:
@@ -158,6 +162,8 @@ class ThumbnailContractTests(unittest.TestCase):
 
         self.assertNotIn("'VerifyThumbnail', {})", skill)
         self.assertNotIn("'SubmitForReview', {})", skill)
+        self.assertNotIn("lstrip().startswith('/9j/')", skill)
+        self.assertNotIn("thumbnail read returned base64 text", skill)
 
     def test_quality_review_skill_generates_and_attaches_thumbnail(self):
         skill = (
@@ -177,12 +183,18 @@ class ThumbnailContractTests(unittest.TestCase):
             "1440x960",
             "600x400",
             "full_page=False",
+            "playwright ready",
+            "[exit code: 0]",
             "thumbnail ok: 600x400 JPEG",
             "binary=True",
+            "__temperpaw_image",
+            "'mime_type': 'image/jpeg'",
         ]:
             self.assertIn(fragment, skill)
 
         self.assertNotIn("'VerifyThumbnail', {})", skill)
+        self.assertNotIn("lstrip().startswith('/9j/')", skill)
+        self.assertNotIn("thumbnail read returned base64 text", skill)
 
     def test_curator_agent_lists_thumbnail_artifact_path(self):
         agent = (self.curation_root / "agents" / "curator" / "AGENT.md").read_text()


### PR DESCRIPTION
## Summary
- harden curator screenshot/thumbnail flow so failed browser commands stop execution
- require `sandbox.read(..., binary=True)` to return a sandbox image result before upload
- write thumbnails with explicit `image/jpeg` metadata

## Root Cause
The sandbox command returned Playwright launch failures as text with `[exit code: 1]`; the curator could continue and attempt to read a thumbnail file that was never generated.

## Validation
- `python3 -m unittest katagami-curation/tests/test_thumbnail_contract.py`
- `python3 -m unittest discover -s katagami-curation/tests`
