### PR TITLE
Fix lineage display normalization

### DIFF
--- a/.proofs/024-lineage-display-normalization.md
+++ b/.proofs/024-lineage-display-normalization.md
@@ -1,0 +1,251 @@
+# ProofPacket: Katagami lineage display normalization rework
+
+WorkRequest: `en-019e0b03-dd39-7671-aafe-39bbd1b6836d`
+FactoryCase: `en-019e0b03-ed5a-71f1-b00e-f0fb8f47c46b`
+WorkCycle: `wc-019e0b03-ee16-7771-bad9-29d40d78e4ed`
+Date: 2026-05-09
+
+## Summary
+
+Fixed the Katagami UI lineage display path so DesignLanguage rows returned by
+OData with flat CSDL/PascalCase fields normalize into the snake-case fields the
+UI reads. The specific reported child now resolves as:
+
+- `lineageType=evolution`
+- `generation=1`
+- `parentIds=["en-019d9bba-3cb4-7072-ab23-7914ed75c93e"]`
+
+The language detail page also renders a lineage band with the generation and
+parent link, so an evolved child no longer appears as original/gen 00.
+
+## Reviewer Rework
+
+Reviewer concern:
+
+> lineage normalization looks directionally correct, but I cannot approve
+> because the implementation is uncommitted outside the assigned branch and
+> bundled with unproved unrelated WASM/curation changes.
+
+Resolution:
+
+- Recreated the fix in a clean Katagami worktree:
+  `/Users/openclaw/Development/katagami-worktrees/lineage-display`
+- Branch: `codex/lineage-display-normalization`
+- Base: `origin/master` at `c57305d`
+- Kept the change set to Katagami UI files only.
+- Left the older dirty checkout at `/Users/openclaw/Development/katagami`
+  untouched; its curation/WASM changes are not part of this branch.
+- Added executable E2E coverage in
+  `ui/scripts/check-lineage-display-e2e.mjs`, so the mock OData UI proof is
+  packaged with the code.
+
+## Changed Files Map
+
+```mermaid
+flowchart TD
+  A[ui/src/lib/odata.ts] --> B[normalize flat OData DesignLanguage rows]
+  A --> C[lineageMetadata]
+  A --> D[lineageNodesFromLanguages]
+  D --> E[ui/src/app/(site)/lineage/page.tsx]
+  C --> F[ui/src/app/(site)/language/[id]/page.tsx]
+  G[ui/scripts/check-lineage-display.mjs] --> A
+  H[ui/scripts/check-lineage-display-e2e.mjs] --> I[mock Temper OData]
+  H --> J[live Next UI]
+  K[ui/package.json] --> G
+  K --> H
+```
+
+- `ui/src/lib/odata.ts`
+  - Exports `normalizeDesignLanguageRow`.
+  - Aliases flat fields like `LineageType`, `GenerationNumber`, `ParentIds`,
+    `Name`, and related PascalCase projection keys.
+  - Normalizes `getDesignLanguage`, not only list rows.
+  - Adds `lineageMetadata` and `lineageNodesFromLanguages`.
+- `ui/src/app/(site)/lineage/page.tsx`
+  - Uses the shared lineage node helper instead of reading only snake-case
+    fields inline.
+- `ui/src/app/(site)/language/[id]/page.tsx`
+  - Renders a lineage band showing lineage type, zero-padded generation, and
+    parent language links.
+- `ui/scripts/check-lineage-display.mjs`
+  - Unit-style regression for the exact flat OData row shape.
+- `ui/scripts/check-lineage-display-e2e.mjs`
+  - Starts mock OData and Next, then verifies the live pages render the child
+    as evolution/gen 01 with the parent name.
+- `ui/package.json`
+  - Adds `test:lineage` and `test:lineage:e2e`.
+
+## Lineage State Diagram
+
+```mermaid
+flowchart LR
+  P["WhimsiCollage Storybook<br/>DesignLanguage parent<br/>LineageType=original<br/>GenerationNumber=0<br/>ForkCount=1"]
+  C["Jelly Dew Story UI<br/>DesignLanguage child<br/>LineageType=evolution<br/>GenerationNumber=1<br/>ParentIds=[parent]"]
+  P -->|"ParentIds[0]"| C
+```
+
+## Render Pipeline
+
+```mermaid
+sequenceDiagram
+  participant O as OData
+  participant N as normalizeDesignLanguageRow
+  participant M as lineageMetadata
+  participant G as LineageGraph
+  participant D as LanguageDetailPage
+
+  O->>N: Flat row with LineageType, GenerationNumber, ParentIds
+  N->>N: Alias fields to lineage_type, generation_number, parent_ids
+  N->>M: Normalized DesignLanguage
+  M->>G: lineageType=evolution, generation=1, parentIds=[parent]
+  M->>D: lineageType=evolution, generation=1, parentIds=[parent]
+```
+
+## Red-Green TDD
+
+Red test added first:
+
+```text
+$ node scripts/check-lineage-display.mjs
+TypeError: normalizeDesignLanguageRow is not a function
+```
+
+Green:
+
+```text
+$ npm run test:lineage
+> ui@0.1.0 test:lineage
+> node scripts/check-lineage-display.mjs
+```
+
+The test constructs the failing flat OData shape:
+
+```json
+{
+  "Id": "en-child",
+  "Name": "Jelly Dew Story UI",
+  "LineageType": "evolution",
+  "GenerationNumber": 1,
+  "ParentIds": "[\"en-parent\"]"
+}
+```
+
+and asserts:
+
+```json
+{
+  "lineageType": "evolution",
+  "generation": 1,
+  "parentIds": ["en-parent"]
+}
+```
+
+## Verification
+
+Focused checks:
+
+```text
+$ npm run test:lineage
+passed
+
+$ npm run test:gallery
+passed
+
+$ npx eslint src/lib/odata.ts 'src/app/(site)/lineage/page.tsx' \
+  'src/app/(site)/language/[id]/page.tsx' \
+  scripts/check-lineage-display.mjs \
+  scripts/check-lineage-display-e2e.mjs
+passed
+
+$ npx tsc --noEmit
+passed
+
+$ npm run build
+Next.js 16.2.3 production build passed.
+```
+
+Full lint:
+
+```text
+$ npm run lint
+failed on pre-existing unrelated files:
+- ui/posters/agent-flow.tsx
+- ui/posters/curation-flow.tsx
+- ui/scripts/migrate-to-railway.mjs
+- ui/src/app/radix-test/page.tsx
+- ui/src/components/design-showcase.tsx
+- ui/src/components/embodiment-viewer.tsx
+- ui/src/components/embodiments/kukan-press-agent.tsx
+- ui/src/components/embodiments/kukan-press-radix.tsx
+- ui/src/components/embodiments/neo-kawaii-radix.tsx
+- ui/src/components/embodiments/neo-kawaii-tech.tsx
+- ui/src/components/safe-embodiment-frame.tsx
+- ui/src/lib/tsx-runtime.ts
+- ui/src/lib/use-theme.ts
+```
+
+Assigned TemperPaw worktree build check:
+
+```text
+$ cargo build --workspace
+Finished dev profile in 22.98s.
+```
+
+## Live/E2E Evidence
+
+Packaged command:
+
+```text
+$ npm run test:lineage:e2e
+> ui@0.1.0 test:lineage:e2e
+> node scripts/check-lineage-display-e2e.mjs
+E2E lineage display check passed for evolution child and parent link
+```
+
+The E2E script starts:
+
+- a mock Temper OData server on a random localhost port
+- a live Next dev server pointed at that mock OData server
+
+It verifies:
+
+- `GET /language/en-019e0af5-0d06-7fd1-a21c-ab36e45553b3`
+  renders `Jelly Dew Story UI`, `evolution`, `gen 01`, and
+  `WhimsiCollage Storybook`.
+- `GET /lineage?root=en-019e0af5-0d06-7fd1-a21c-ab36e45553b3`
+  renders `1 evolution`, `gen 01`, `first evolutions`,
+  `Jelly Dew Story UI`, and `WhimsiCollage Storybook`.
+- OData received requests for both the child and parent DesignLanguage rows.
+
+## OData Links
+
+Expected live OData links:
+
+- Child:
+  `http://localhost:3500/tdata/DesignLanguages('en-019e0af5-0d06-7fd1-a21c-ab36e45553b3')`
+- Parent:
+  `http://localhost:3500/tdata/DesignLanguages('en-019d9bba-3cb4-7072-ab23-7914ed75c93e')`
+- Lineage list:
+  `http://localhost:3500/tdata/DesignLanguages?$top=500`
+
+Packaged mock E2E paths:
+
+- `GET /tdata/DesignLanguages('en-019e0af5-0d06-7fd1-a21c-ab36e45553b3')`
+- `GET /tdata/DesignLanguages('en-019d9bba-3cb4-7072-ab23-7914ed75c93e')`
+- `GET /tdata/DesignLanguages?$top=500`
+
+## Risk Notes
+
+- Evidence-based risk triage: this is UI rendering/data-adapter behavior only.
+- No production deployment behavior changed.
+- No secrets touched.
+- No data migration touched.
+- No Cedar policies touched.
+- No Temper entity specs touched.
+- No WASM integrations touched.
+- Existing OData fetches already use `cache: "no-store"`; the issue was
+  projection shape normalization, not cache invalidation.
+- ADR decision: no ADR added because this is a narrow UI normalization/rendering
+  correction and does not alter Temper app architecture, entity state machines,
+  WASM orchestration, authorization, storage/provenance, triggers, deployment,
+  or agent capability surfaces.

--- a/.proofs/024-lineage-display-normalization.md
+++ b/.proofs/024-lineage-display-normalization.md
@@ -31,6 +31,8 @@ Resolution:
 - Recreated the fix in a clean Katagami worktree:
   `/Users/openclaw/Development/katagami-worktrees/lineage-display`
 - Branch: `codex/lineage-display-normalization`
+- Remote branch: `origin/codex/lineage-display-normalization`
+- Pull request: https://github.com/arni-labs/katagami/pull/26
 - Base: `origin/master` at `c57305d`
 - Kept the change set to Katagami UI files only.
 - Left the older dirty checkout at `/Users/openclaw/Development/katagami`
@@ -146,22 +148,37 @@ Focused checks:
 
 ```text
 $ npm run test:lineage
-passed
+> ui@0.1.0 test:lineage
+> node scripts/check-lineage-display.mjs
 
 $ npm run test:gallery
-passed
+> ui@0.1.0 test:gallery
+> node scripts/check-gallery-renders-all-cards.mjs
 
 $ npx eslint src/lib/odata.ts 'src/app/(site)/lineage/page.tsx' \
   'src/app/(site)/language/[id]/page.tsx' \
   scripts/check-lineage-display.mjs \
   scripts/check-lineage-display-e2e.mjs
-passed
+passed with no output
 
 $ npx tsc --noEmit
-passed
+passed with no output
 
 $ npm run build
 Next.js 16.2.3 production build passed.
+```
+
+Publish/review state:
+
+```text
+$ git push -u origin codex/lineage-display-normalization
+branch 'codex/lineage-display-normalization' set up to track 'origin/codex/lineage-display-normalization'.
+
+$ gh pr create --base master --head codex/lineage-display-normalization
+https://github.com/arni-labs/katagami/pull/26
+
+$ git status --short --branch
+## codex/lineage-display-normalization...origin/codex/lineage-display-normalization
 ```
 
 Full lint:

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test:gallery": "node scripts/check-gallery-renders-all-cards.mjs"
+    "test:gallery": "node scripts/check-gallery-renders-all-cards.mjs",
+    "test:lineage": "node scripts/check-lineage-display.mjs",
+    "test:lineage:e2e": "node scripts/check-lineage-display-e2e.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/ui/scripts/check-lineage-display-e2e.mjs
+++ b/ui/scripts/check-lineage-display-e2e.mjs
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import http from "node:http";
+import net from "node:net";
+import path from "node:path";
+
+const root = path.resolve(import.meta.dirname, "..");
+const childId = "en-019e0af5-0d06-7fd1-a21c-ab36e45553b3";
+const parentId = "en-019d9bba-3cb4-7072-ab23-7914ed75c93e";
+
+const child = {
+  Id: childId,
+  Status: "Published",
+  Name: "Jelly Dew Story UI",
+  Slug: "jelly-dew-story-ui",
+  LineageType: "evolution",
+  GenerationNumber: 1,
+  ParentIds: JSON.stringify([parentId]),
+};
+
+const parent = {
+  Id: parentId,
+  Status: "Published",
+  Name: "WhimsiCollage Storybook",
+  Slug: "whimsi-collage-storybook",
+  LineageType: "original",
+  GenerationNumber: 0,
+  ParentIds: "[]",
+  ForkCount: 1,
+};
+
+function json(res, status, body) {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+function startMockOData() {
+  const requests = [];
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    requests.push(`${req.method} ${url.pathname}${url.search}`);
+
+    if (url.pathname === "/tdata/DesignLanguages") {
+      json(res, 200, { value: [child, parent] });
+      return;
+    }
+    if (url.pathname === `/tdata/DesignLanguages('${childId}')`) {
+      json(res, 200, child);
+      return;
+    }
+    if (url.pathname === `/tdata/DesignLanguages('${parentId}')`) {
+      json(res, 200, parent);
+      return;
+    }
+
+    json(res, 404, { error: `unexpected mock OData path: ${url.pathname}` });
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      assert(address && typeof address === "object");
+      resolve({
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        requests,
+        close: () => new Promise((done) => server.close(done)),
+      });
+    });
+  });
+}
+
+function reservePort() {
+  const server = net.createServer();
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      assert(address && typeof address === "object");
+      const { port } = address;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+function startNext({ port, apiBase }) {
+  const bin = path.join(root, "node_modules", ".bin", "next");
+  const logs = [];
+  const proc = spawn(bin, ["dev", "--hostname", "127.0.0.1", "--port", String(port)], {
+    cwd: root,
+    env: {
+      ...process.env,
+      NEXT_PUBLIC_TEMPER_API_URL: apiBase,
+      NEXT_PUBLIC_TEMPER_TENANT: "default",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  proc.stdout.on("data", (chunk) => logs.push(String(chunk)));
+  proc.stderr.on("data", (chunk) => logs.push(String(chunk)));
+
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    logs,
+    stop: () =>
+      new Promise((resolve) => {
+        if (proc.exitCode !== null || proc.signalCode !== null) {
+          resolve();
+          return;
+        }
+        proc.once("exit", resolve);
+        proc.kill("SIGTERM");
+        setTimeout(() => {
+          if (proc.exitCode === null && proc.signalCode === null) proc.kill("SIGKILL");
+        }, 2000).unref();
+      }),
+  };
+}
+
+async function waitForRoute(baseUrl, route, logs) {
+  const deadline = Date.now() + 30000;
+  let lastError;
+
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${baseUrl}${route}`);
+      const body = await res.text();
+      if (res.ok) return body;
+      lastError = new Error(`HTTP ${res.status}: ${body.slice(0, 500)}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  throw new Error(
+    `Next route did not become ready: ${String(lastError)}\n${logs.join("")}`,
+  );
+}
+
+function pageText(html) {
+  return html
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+let odata;
+let next;
+try {
+  odata = await startMockOData();
+  const nextPort = await reservePort();
+  next = startNext({ port: nextPort, apiBase: odata.baseUrl });
+
+  const languageHtml = await waitForRoute(
+    next.baseUrl,
+    `/language/${childId}`,
+    next.logs,
+  );
+  const languageText = pageText(languageHtml);
+  assert.match(languageText, /Jelly Dew Story UI/);
+  assert.match(languageText, /evolution/);
+  assert.match(languageText, /gen 01/);
+  assert.match(languageText, /WhimsiCollage Storybook/);
+
+  const lineageHtml = await waitForRoute(
+    next.baseUrl,
+    `/lineage?root=${childId}`,
+    next.logs,
+  );
+  const lineageText = pageText(lineageHtml);
+  assert.match(lineageText, /1 evolution/);
+  assert.match(lineageText, /gen 01/);
+  assert.match(lineageText, /first evolutions/);
+  assert.match(lineageText, /Jelly Dew Story UI/);
+  assert.match(lineageText, /WhimsiCollage Storybook/);
+
+  assert(
+    odata.requests.some((request) => request.includes(`DesignLanguages('${childId}')`)),
+    `child OData request missing: ${odata.requests.join(", ")}`,
+  );
+  assert(
+    odata.requests.some((request) => request.includes(`DesignLanguages('${parentId}')`)),
+    `parent OData request missing: ${odata.requests.join(", ")}`,
+  );
+
+  console.log("E2E lineage display check passed for evolution child and parent link");
+} finally {
+  await next?.stop();
+  await odata?.close();
+}

--- a/ui/scripts/check-lineage-display.mjs
+++ b/ui/scripts/check-lineage-display.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+
+import ts from "typescript";
+
+const require = createRequire(import.meta.url);
+const root = path.resolve(import.meta.dirname, "..");
+const moduleCache = new Map();
+
+function loadTsModule(relativePath) {
+  const normalized = relativePath.replace(/\\/g, "/");
+  const absolutePath = path.join(root, normalized);
+  if (moduleCache.has(absolutePath)) return moduleCache.get(absolutePath).exports;
+
+  const source = fs.readFileSync(absolutePath, "utf8");
+  const output = ts.transpileModule(source, {
+    compilerOptions: {
+      esModuleInterop: true,
+      jsx: ts.JsxEmit.ReactJSX,
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: absolutePath,
+  }).outputText;
+
+  const mod = { exports: {} };
+  moduleCache.set(absolutePath, mod);
+
+  const localRequire = (specifier) => {
+    if (specifier.startsWith("@/")) {
+      return loadTsModule(path.join("src", specifier.slice(2)));
+    }
+    if (specifier.startsWith(".")) {
+      return loadTsModule(path.join(path.dirname(normalized), specifier));
+    }
+    return require(specifier);
+  };
+
+  vm.runInNewContext(
+    output,
+    {
+      exports: mod.exports,
+      module: mod,
+      process,
+      require: localRequire,
+    },
+    { filename: absolutePath },
+  );
+
+  return mod.exports;
+}
+
+const {
+  lineageMetadata,
+  lineageNodesFromLanguages,
+  normalizeDesignLanguageRow,
+} = loadTsModule("src/lib/odata.ts");
+
+const parent = normalizeDesignLanguageRow({
+  "@odata.id": "http://localhost:3500/tdata/DesignLanguages('en-parent')",
+  Id: "en-parent",
+  Status: "Published",
+  Name: "WhimsiCollage Storybook",
+  LineageType: "original",
+  GenerationNumber: 0,
+  ParentIds: "[]",
+  ForkCount: 1,
+});
+
+const child = normalizeDesignLanguageRow({
+  "@odata.id": "http://localhost:3500/tdata/DesignLanguages('en-child')",
+  Id: "en-child",
+  Status: "Published",
+  Name: "Jelly Dew Story UI",
+  LineageType: "evolution",
+  GenerationNumber: 1,
+  ParentIds: '["en-parent"]',
+});
+
+const plain = (value) => JSON.parse(JSON.stringify(value));
+
+assert.equal(child.fields.lineage_type, "evolution");
+assert.equal(child.fields.generation_number, "1");
+assert.equal(child.fields.parent_ids, '["en-parent"]');
+
+assert.deepEqual(plain(lineageMetadata(child)), {
+  lineageType: "evolution",
+  generation: 1,
+  parentIds: ["en-parent"],
+});
+
+const nodes = lineageNodesFromLanguages([child, parent]);
+assert.deepEqual(plain(nodes.find((node) => node.id === "en-child")), {
+  id: "en-child",
+  name: "Jelly Dew Story UI",
+  status: "Published",
+  lineageType: "evolution",
+  generation: 1,
+  parentIds: ["en-parent"],
+});
+
+assert.equal(nodes.find((node) => node.id === "en-parent")?.generation, 0);

--- a/ui/src/app/(site)/language/[id]/page.tsx
+++ b/ui/src/app/(site)/language/[id]/page.tsx
@@ -2,7 +2,12 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
-import { getDesignLanguage } from "@/lib/odata";
+import {
+  getDesignLanguage,
+  lineageMetadata,
+  type DesignLanguage,
+  type LineageMetadata,
+} from "@/lib/odata";
 import {
   designMdToMarkdown,
   katagamiSpecToMarkdown,
@@ -78,6 +83,19 @@ export default async function LanguageDetailPage({
   }
 
   const f = lang.fields;
+  const lineage = lineageMetadata(lang);
+  const parentLanguages = await Promise.all(
+    lineage.parentIds.map(async (parentId) => {
+      try {
+        return await getDesignLanguage(parentId);
+      } catch {
+        return null;
+      }
+    }),
+  );
+  const parents = parentLanguages.filter(
+    (parent): parent is DesignLanguage => parent !== null,
+  );
 
   const accent = statusColor[lang.status] ?? "teal";
   const name = f.name || "Untitled";
@@ -136,6 +154,8 @@ export default async function LanguageDetailPage({
           </>
         }
       />
+
+      <LineageBand lineage={lineage} parents={parents} />
 
       <SpecActions
         languageId={id}
@@ -217,6 +237,63 @@ export default async function LanguageDetailPage({
           generativeCanvas={f.generative_canvas}
         />
       </section>
+    </div>
+  );
+}
+
+function LineageBand({
+  lineage,
+  parents,
+}: {
+  lineage: LineageMetadata;
+  parents: DesignLanguage[];
+}) {
+  const color =
+    lineage.lineageType === "evolution"
+      ? "salad"
+      : lineage.lineageType === "remix"
+        ? "sumire"
+        : "teal";
+  const parentNames = new Map(
+    parents.map((parent) => [
+      parent.entity_id,
+      parent.fields.name || parent.entity_id.slice(0, 12),
+    ]),
+  );
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-2 border-y border-dashed border-border py-3">
+      <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+        lineage
+      </span>
+      <Stamp color={color as never}>{lineage.lineageType}</Stamp>
+      <span className="font-mono text-[11px] font-bold uppercase tracking-[0.16em] text-foreground">
+        gen {String(lineage.generation).padStart(2, "0")}
+      </span>
+      {lineage.parentIds.length > 0 ? (
+        <>
+          <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+            from
+          </span>
+          <span className="flex flex-wrap items-center gap-2">
+            {lineage.parentIds.map((parentId, index) => (
+              <span key={parentId} className="inline-flex items-center gap-2">
+                {index > 0 ? (
+                  <span className="font-mono text-[10px] text-muted-foreground/60">
+                    +
+                  </span>
+                ) : null}
+                <Link
+                  href={`/language/${parentId}`}
+                  className="font-display text-sm font-bold leading-none text-foreground underline decoration-[var(--ramune)] decoration-2 underline-offset-4 transition-colors hover:text-[var(--sumire)]"
+                >
+                  {parentNames.get(parentId) ?? parentId.slice(0, 12)}
+                </Link>
+              </span>
+            ))}
+          </span>
+        </>
+      ) : null}
     </div>
   );
 }

--- a/ui/src/app/(site)/lineage/page.tsx
+++ b/ui/src/app/(site)/lineage/page.tsx
@@ -1,4 +1,4 @@
-import { listDesignLanguages, parseJson } from "@/lib/odata";
+import { lineageNodesFromLanguages, listDesignLanguages } from "@/lib/odata";
 import { LineageGraph } from "@/components/lineage-graph";
 import { PageHero, Marker } from "@/components/page-hero";
 import {
@@ -33,14 +33,7 @@ export default async function LineagePage({
     );
   }
 
-  const nodes = languages.map((l) => ({
-    id: l.entity_id,
-    name: l.fields.name ?? l.entity_id.slice(0, 12),
-    status: l.status,
-    lineageType: l.fields.lineage_type ?? "original",
-    generation: parseInt(l.fields.generation_number ?? "0", 10),
-    parentIds: parseJson<string[]>(l.fields.parent_ids) ?? [],
-  }));
+  const nodes = lineageNodesFromLanguages(languages);
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-4 py-6 sm:space-y-10 sm:py-10">

--- a/ui/src/lib/odata.ts
+++ b/ui/src/lib/odata.ts
@@ -113,6 +113,18 @@ export interface DesignLanguage {
   booleans: Record<string, boolean> & { featured?: boolean };
 }
 
+export interface LineageMetadata {
+  lineageType: string;
+  generation: number;
+  parentIds: string[];
+}
+
+export interface LineageNode extends LineageMetadata {
+  id: string;
+  name: string;
+  status: string;
+}
+
 // The full set of fields needed to render a gallery card:
 // identifiers, status flags the badge/sort uses, embodiment pointers,
 // taxonomy/tags for filters, and the two heavy JSON blobs the card
@@ -174,6 +186,55 @@ const FLAT_COUNTER_KEYS = new Set([
   "composition_count",
   "usage_count",
 ]);
+
+const FLAT_FIELD_ALIASES: Record<string, keyof DesignLanguage["fields"]> = {
+  Name: "name",
+  Slug: "slug",
+  Philosophy: "philosophy",
+  Tokens: "tokens",
+  Rules: "rules",
+  LayoutPrinciples: "layout_principles",
+  Guidance: "guidance",
+  ImageryDirection: "imagery_direction",
+  GenerativeCanvas: "generative_canvas",
+  DesignMdFileId: "design_md_file_id",
+  DesignMdLintResult: "design_md_lint_result",
+  DesignMdFormatVersion: "design_md_format_version",
+  EmbodimentFileId: "embodiment_file_id",
+  ThumbnailFileId: "thumbnail_file_id",
+  ParentIds: "parent_ids",
+  LineageType: "lineage_type",
+  GenerationNumber: "generation_number",
+  TaxonomyIds: "taxonomy_ids",
+  Tags: "tags",
+  CuratorNotes: "curator_notes",
+  SourceIds: "source_ids",
+  QualityScore: "quality_score",
+  CreatedAt: "CreatedAt",
+  UpdatedAt: "UpdatedAt",
+  PublishedAt: "PublishedAt",
+};
+
+const FLAT_BOOLEAN_ALIASES: Record<string, string> = {
+  Featured: "featured",
+  EmbodimentVerified: "embodiment_verified",
+  HasEmbodiment: "has_embodiment",
+  HasThumbnail: "has_thumbnail",
+  ThumbnailVerified: "thumbnail_verified",
+  HasDesignMd: "has_design_md",
+  HasValidDesignMd: "has_valid_design_md",
+  DesignMdVerified: "design_md_verified",
+  QualityReviewPassed: "quality_review_passed",
+};
+
+const FLAT_COUNTER_ALIASES: Record<string, string> = {
+  DisplayOrder: "display_order",
+  ForkCount: "fork_count",
+  Version: "version",
+  ElementCount: "element_count",
+  CompositionCount: "composition_count",
+  UsageCount: "usage_count",
+};
 // OData envelope keys (kept at top level when normalizing):
 const ODATA_ENVELOPE_KEYS = new Set([
   "@odata.id",
@@ -197,13 +258,23 @@ const ODATA_ENVELOPE_KEYS = new Set([
 // of the nested {entity_id, status, fields:{...}, booleans:{...}, counters:{...}}
 // shape the rest of this codebase reads. Normalize so callers see the
 // nested shape regardless of how OData chose to project.
-function normalizeDesignLanguageRow(
+export function normalizeDesignLanguageRow(
   raw: Record<string, unknown>,
 ): DesignLanguage {
   if (raw && typeof raw.fields === "object" && raw.fields !== null) {
-    return raw as unknown as DesignLanguage;
+    const normalized = raw as unknown as DesignLanguage;
+    return {
+      ...normalized,
+      fields: normalizeFieldAliases(raw.fields as Record<string, unknown>),
+      booleans: normalized.booleans ?? {},
+      counters: normalized.counters ?? {},
+      status:
+        normalized.status ??
+        valueAsString((raw.fields as Record<string, unknown>).Status) ??
+        "",
+    };
   }
-  const fields: Record<string, unknown> = {};
+  const fields: Record<string, string | undefined> = {};
   const booleans: Record<string, boolean> = {};
   const counters: Record<string, number> = {};
   const top: Record<string, unknown> = {};
@@ -214,23 +285,26 @@ function normalizeDesignLanguageRow(
     }
     if (k === "Id") {
       top.entity_id = v;
-      fields.Id = v as string;
+      fields.Id = valueAsString(v);
       continue;
     }
     if (k === "Status") {
       top.status = v;
-      fields.Status = v as string;
+      fields.Status = valueAsString(v);
       continue;
     }
-    if (FLAT_BOOLEAN_KEYS.has(k) && typeof v === "boolean") {
-      booleans[k] = v;
+    const booleanKey = FLAT_BOOLEAN_ALIASES[k] ?? k;
+    if (FLAT_BOOLEAN_KEYS.has(booleanKey) && typeof v === "boolean") {
+      booleans[booleanKey] = v;
       continue;
     }
-    if (FLAT_COUNTER_KEYS.has(k) && typeof v === "number") {
-      counters[k] = v;
+    const counterKey = FLAT_COUNTER_ALIASES[k] ?? k;
+    if (FLAT_COUNTER_KEYS.has(counterKey) && typeof v === "number") {
+      counters[counterKey] = v;
       continue;
     }
-    fields[k] = v;
+    const fieldKey = FLAT_FIELD_ALIASES[k] ?? k;
+    fields[fieldKey] = valueAsString(v);
   }
   const canonicalId = parseODataEntityId(top["@odata.id"]);
   if (canonicalId) top.entity_id = canonicalId;
@@ -242,10 +316,134 @@ function normalizeDesignLanguageRow(
   } as unknown as DesignLanguage;
 }
 
+function normalizeFieldAliases(
+  rawFields: Record<string, unknown>,
+): DesignLanguage["fields"] {
+  const fields = { ...rawFields } as Record<string, string | undefined>;
+  for (const [k, v] of Object.entries(rawFields)) {
+    const alias = FLAT_FIELD_ALIASES[k];
+    if (alias && fields[alias] === undefined) {
+      fields[alias] = valueAsString(v);
+    }
+  }
+  return fields as DesignLanguage["fields"];
+}
+
+function valueAsString(value: unknown): string | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+}
+
 function parseODataEntityId(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const match = value.match(/DesignLanguages\('([^']+)'\)/);
   return match?.[1];
+}
+
+function readDesignLanguageValue(
+  lang: DesignLanguage,
+  keys: string[],
+): unknown {
+  const bags: unknown[] = [lang.fields, lang.counters, lang.booleans, lang];
+  for (const bag of bags) {
+    if (!bag || typeof bag !== "object") continue;
+    const record = bag as Record<string, unknown>;
+    for (const key of keys) {
+      const value = record[key];
+      if (value !== undefined && value !== null && value !== "") return value;
+    }
+  }
+  return undefined;
+}
+
+function readDesignLanguageString(
+  lang: DesignLanguage,
+  keys: string[],
+): string | undefined {
+  return valueAsString(readDesignLanguageValue(lang, keys));
+}
+
+function readDesignLanguageNumber(
+  lang: DesignLanguage,
+  keys: string[],
+  fallback = 0,
+): number {
+  const value = readDesignLanguageValue(lang, keys);
+  const parsed =
+    typeof value === "number" ? value : parseInt(String(value ?? ""), 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function parseParentIds(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter(
+      (id): id is string => typeof id === "string" && id.length > 0,
+    );
+  }
+  if (typeof value !== "string") return [];
+  const trimmed = value.trim();
+  if (!trimmed) return [];
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (Array.isArray(parsed)) {
+      return parsed.filter(
+        (id): id is string => typeof id === "string" && id.length > 0,
+      );
+    }
+  } catch {
+    return trimmed
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+export function lineageMetadata(lang: DesignLanguage): LineageMetadata {
+  return {
+    lineageType:
+      readDesignLanguageString(lang, [
+        "lineage_type",
+        "LineageType",
+        "lineageType",
+      ]) ?? "original",
+    generation: readDesignLanguageNumber(
+      lang,
+      ["generation_number", "GenerationNumber", "generationNumber"],
+      0,
+    ),
+    parentIds: parseParentIds(
+      readDesignLanguageValue(lang, ["parent_ids", "ParentIds", "parentIds"]),
+    ),
+  };
+}
+
+export function lineageNodesFromLanguages(
+  languages: DesignLanguage[],
+): LineageNode[] {
+  return languages.map((lang) => {
+    const id =
+      lang.entity_id ??
+      readDesignLanguageString(lang, ["Id", "id"]) ??
+      "unknown";
+    return {
+      id,
+      name: readDesignLanguageString(lang, ["name", "Name"]) ?? id.slice(0, 12),
+      status:
+        lang.status ??
+        readDesignLanguageString(lang, ["Status", "status"]) ??
+        "Draft",
+      ...lineageMetadata(lang),
+    };
+  });
 }
 
 // OData defaults to a finite page when no $top is given. Ask for a large page
@@ -271,7 +469,8 @@ export async function listDesignLanguages(
 }
 
 export async function getDesignLanguage(id: string): Promise<DesignLanguage> {
-  return odata<DesignLanguage>(`DesignLanguages('${id}')`);
+  const row = await odata<Record<string, unknown>>(`DesignLanguages('${id}')`);
+  return normalizeDesignLanguageRow(row);
 }
 
 // ── Taxonomy ──


### PR DESCRIPTION
## Summary
- normalize flat OData lineage fields into the UI DesignLanguage shape
- render evolved DesignLanguage rows with the backend generation and parent lineage
- add focused lineage and packaged E2E checks for the Jelly Dew evolution case

## Testing
- npm run test:lineage
- npm run test:gallery
- npx eslint src/lib/odata.ts 'src/app/(site)/lineage/page.tsx' 'src/app/(site)/language/[id]/page.tsx' scripts/check-lineage-display.mjs scripts/check-lineage-display-e2e.mjs
- npx tsc --noEmit
- npm run test:lineage:e2e