### PR TITLE
Use public artifact read plane for published gallery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 **/wasm/*/target/
 **/wasm/*/Cargo.lock
 
+# Python test artifacts
+__pycache__/
+*.pyc
+
 # Local database
 .data/
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -10,6 +10,7 @@ Browser ──HTTPS──▶ Vercel (Next.js)  ──HTTPS + Bearer──▶  Ra
                    Server Actions                          /tdata/.../KatagamiCommons.X
                    /api/file/[id] proxy                    /tdata/Files('..')/$value
                                                            Turso ← entities · R2 ← file blobs
+Browser ──HTTPS──▶ assets.katagami.ai (Cloudflare Worker) ─▶ R2 published prefixes
                    DNS via Cloudflare (DNS-only, no proxy)
 ```
 
@@ -42,6 +43,8 @@ The browser never sees the Bearer token. All Temper calls go through Vercel-side
 - Server Actions in `ui/src/app/actions.ts` (delete, add curator notes).
 - File proxy at `ui/src/app/api/file/[id]/route.ts` — same-origin from the browser, server-side fetch with `Authorization` to Railway.
 
+Published thumbnails and embodiments should prefer immutable `*_asset_url` fields when present. Those URLs are produced by Temper's `POST /api/files/publish-asset` flow and served from `https://assets.katagami.ai/<content-addressed-key>` through the Cloudflare Worker in `infra/cloudflare/katagami-assets-worker`. The Worker only exposes allow-listed published prefixes from R2; raw PowerFS file paths remain private and governed.
+
 ### Rotating the Temper API key
 
 ```sh
@@ -70,6 +73,7 @@ Zone `katagami.ai` is on Cloudflare. The registrar's nameservers point at Cloudf
 | A | `@` | `216.150.1.1` | 60 | DNS only |
 | A | `@` | `216.150.16.1` | 60 | DNS only |
 | CNAME | `www` | `aa05af15fecbf657.vercel-dns-016.com` | 60 | DNS only |
+| Worker route | `assets` | `katagami-assets` → R2 published prefixes | Cloudflare | Proxied |
 
 The two apex IPs are Vercel's load-balancer pool. The CNAME target encodes the project's TLS material — don't reuse it for other projects. Both are public (Vercel surfaces them in its domain config endpoint).
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -5,7 +5,7 @@ How Katagami is hosted and served. No secrets in this file — env values, API t
 ## Architecture
 
 ```
-Browser ──HTTPS──▶ Vercel (Next.js)  ──HTTPS + Bearer──▶  Railway (OpenPaw / Temper)
+Browser ──HTTPS──▶ Vercel (Next.js)  ──HTTPS + Bearer──▶  Railway (temperpaw / Temper)
                    Server Components                       /tdata/{EntitySet}     ← reads/writes
                    Server Actions                          /tdata/.../KatagamiCommons.X
                    /api/file/[id] proxy                    /tdata/Files('..')/$value
@@ -14,7 +14,7 @@ Browser ──HTTPS──▶ assets.katagami.ai (Cloudflare Worker) ─▶ R2 pu
                    DNS via Cloudflare (DNS-only, no proxy)
 ```
 
-The frontend is the only thing on Vercel. The backend (entity store, agent runtime, file blobs) is the OpenPaw server on Railway, shared with other Temper apps.
+The frontend is the only thing on Vercel. The backend (entity store, agent runtime, file blobs) is the temperpaw server on Railway, shared with other Temper apps.
 
 ## Frontend (Vercel)
 
@@ -33,7 +33,7 @@ Set in Vercel project settings (Production + Preview):
 
 | Name | Public? | Purpose |
 |---|---|---|
-| `NEXT_PUBLIC_TEMPER_API_URL` | yes | Public Railway URL of the OpenPaw backend |
+| `NEXT_PUBLIC_TEMPER_API_URL` | yes | Public Railway URL of the temperpaw backend |
 | `NEXT_PUBLIC_TEMPER_TENANT` | yes | Tenant identifier passed as `X-Tenant-Id` |
 | `TEMPER_API_KEY` | **server-only** | Bearer token for Railway. Read only by Server Components, Server Actions, and the file-proxy route handler. No `NEXT_PUBLIC_` prefix → never shipped to the browser bundle |
 | `KATAGAMI_OWNER_SECRET` | **server-only** | Passphrase for `/owner`. When unlocked, Vercel sets an HTTP-only owner cookie that reveals delete controls and gates destructive Server Actions |
@@ -43,7 +43,7 @@ The browser never sees the Bearer token. All Temper calls go through Vercel-side
 - Server Actions in `ui/src/app/actions.ts` (delete, add curator notes).
 - File proxy at `ui/src/app/api/file/[id]/route.ts` — same-origin from the browser, server-side fetch with `Authorization` to Railway.
 
-Published thumbnails and embodiments should prefer immutable `*_asset_url` fields when present. Those URLs are produced by Temper's `POST /api/files/publish-asset` flow and served from `https://assets.katagami.ai/<content-addressed-key>` through the Cloudflare Worker in `infra/cloudflare/katagami-assets-worker`. The Worker only exposes allow-listed published prefixes from R2; raw PowerFS file paths remain private and governed.
+Published thumbnails, embodiments, and `DESIGN.md` exports should prefer immutable `*_asset_url` fields when present. Those URLs are produced by Temper's generic `POST /api/files/publish-artifact` flow and served from `https://assets.katagami.ai/<content-addressed-key>` through the Cloudflare Worker in `infra/cloudflare/katagami-assets-worker`. The Worker only exposes allow-listed published prefixes from R2; raw PowerFS file paths remain private and governed.
 
 ### Rotating the Temper API key
 
@@ -79,9 +79,9 @@ The two apex IPs are Vercel's load-balancer pool. The CNAME target encodes the p
 
 ## Backend (Railway)
 
-The frontend talks to a separate Railway project (OpenPaw/Temper server, shared infra). From Vercel's perspective:
+The frontend talks to a separate Railway project (temperpaw/Temper server, shared infra). From Vercel's perspective:
 
-- **URL:** `https://openpaw-production.up.railway.app`
+- **URL:** `https://temperpaw-production.up.railway.app`
 - **Tenant:** `default`
 - **OData prefix:** `/tdata/`
 - **Auth:** `Authorization: Bearer <TEMPER_API_KEY>` + `X-Tenant-Id: default` on every request
@@ -109,7 +109,7 @@ To force-refresh stale unfurls:
 
 ## Migration tooling
 
-`ui/scripts/migrate-to-railway.mjs` — one-shot script for moving entities from a local OpenPaw to Railway. Dry-run by default; pass `--apply` to execute. Reads source URL, target URL, and Bearer token from env vars (`LOCAL_URL`, `RAILWAY_URL`, `RAILWAY_TOKEN`, `TENANT`). Header at the top of the file documents the exact invocation.
+`ui/scripts/migrate-to-railway.mjs` — one-shot script for moving entities from a local temperpaw/Temper server to Railway. Dry-run by default; pass `--apply` to execute. Reads source URL, target URL, and Bearer token from env vars (`LOCAL_URL`, `RAILWAY_URL`, `RAILWAY_TOKEN`, `TENANT`). Header at the top of the file documents the exact invocation.
 
 ## Useful URLs
 
@@ -117,10 +117,10 @@ To force-refresh stale unfurls:
 - Repo: https://github.com/arni-labs/katagami
 - Vercel project (team: `rita-agafonovas-projects`): https://vercel.com/dashboard
 - Cloudflare zone: https://dash.cloudflare.com/
-- Railway project (`openpaw-seshendranalla`): https://railway.com/dashboard
+- Railway project (`temperpaw-seshendranalla`): https://railway.com/dashboard
 
 ## Observability
 
 - Vercel runtime logs: `vercel logs <deployment-url>` or the Vercel dashboard.
-- Railway service logs: `railway service logs --service openpaw` (after `railway link --project openpaw-seshendranalla`).
-- Datadog has the deeper traces from the OpenPaw side; access lives on the Railway service env (not duplicated here).
+- Railway service logs: `railway service logs --service temperpaw` (after `railway link --project temperpaw-seshendranalla`).
+- Datadog has the deeper traces from the temperpaw side; access lives on the Railway service env (not duplicated here).

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Katagami's internal model is richer than `DESIGN.md`: it stores curated research
 
 ## Architecture
 
-Built on [Temper](https://github.com/nerdsane/temper) and [TemperPaw](https://github.com/nerdsane/temper) (OpenPaw).
+Built on [Temper](https://github.com/nerdsane/temper) and temperpaw.
 
-Temper is a policy-driven runtime where all state is expressed as communicating state machines (I/O Automata). Cross-entity workflow is declared with native reactions, and external runtime effects run inside WASM bridges with Cedar authorization policies deciding what's allowed. TemperPaw is the agent platform built on top of it.
+Temper is a policy-driven runtime where all state is expressed as communicating state machines (I/O Automata). Cross-entity workflow is declared with native reactions, and external runtime effects run inside WASM bridges with Cedar authorization policies deciding what's allowed. temperpaw is the agent platform built on top of it.
 
 The synthesize agent writes Python that calls Temper's API — every call is a state machine transition:
 
@@ -138,14 +138,14 @@ from TemperFS at runtime, so prompt policy lives in Katagami files rather than
 Rust source. Follow-up jobs are created by Temper reactions; source-search
 fan-out is modeled as `CurationDirection` records instead of Rust spawning
 loops. The curation finalizer keeps a small idempotent fallback for current
-local OpenPaw installs that do not yet register app reaction files.
+local temperpaw installs that do not yet register app reaction files.
 
 ## Running locally
 
-Katagami runs as OS apps inside a TemperPaw server. The apps are symlinked into the server's `os-apps/` directory:
+Katagami runs as OS apps inside a temperpaw server. The apps are symlinked into the server's `os-apps/` directory:
 
 ```bash
-# In your TemperPaw checkout
+# In your temperpaw checkout
 ln -s /path/to/katagami/katagami-commons os-apps/katagami-commons
 ln -s /path/to/katagami/katagami-curation os-apps/katagami-curation
 
@@ -162,7 +162,7 @@ The gallery runs on `localhost:3000` and talks to the Temper OData API.
 ## Related
 
 - [Temper](https://github.com/nerdsane/temper) — Policy-driven runtime for governed state machines
-- [TemperPaw](https://github.com/nerdsane/temper) (OpenPaw) — Agent platform built on Temper
+- temperpaw — Agent platform built on Temper
 - [DESIGN.md](https://github.com/google-labs-code/design.md) — Google's alpha format for design-system context in coding agents
 - [Blog post](https://x.com/) — "Katagami: Organizing the Chaos of Design with Agents"
 

--- a/docs/adrs/0001-bitter-lesson-knowledge-in-files.md
+++ b/docs/adrs/0001-bitter-lesson-knowledge-in-files.md
@@ -21,7 +21,7 @@ This violates the bitter lesson: hand-engineering knowledge into code scales wor
 
 Extract all domain knowledge from compiled WASM into two kinds of editable markdown files:
 
-**SKILL.md files** — one per job type, stored at `skills/{skill-id}/SKILL.md`. These are loaded by the OpenPaw agent framework at session time via TemperFS auto-discovery. Each skill contains the process, entity shapes, and quality standards for one type of work.
+**SKILL.md files** — one per job type, stored at `skills/{skill-id}/SKILL.md`. These are loaded by the temperpaw agent framework at session time via TemperFS auto-discovery. Each skill contains the process, entity shapes, and quality standards for one type of work.
 
 **Workspace knowledge files** — stored at `/katagami/knowledge/` in TemperFS. These are read by agents via `temper.read()` and contain shared knowledge that spans skills: design principles, quality thresholds, and accumulated human feedback.
 
@@ -53,6 +53,6 @@ Two agents (bootstrap + curator) are consolidated into one (curator) with a skil
 ## References
 
 - Palimpsest `spawn_job_agent` pattern: `palimpsest/knowledge-bank/wasm/spawn_job_agent/src/lib.rs`
-- OpenPaw skill auto-discovery: `llm_caller` loads SKILL.md from TemperFS paths
+- temperpaw skill auto-discovery: `llm_caller` loads SKILL.md from TemperFS paths
 - ADR-0005: Temper-Native Rule (stateful orchestration via entity state machines + WASM)
 - Sutton, R. "The Bitter Lesson" (2019) — general methods that leverage computation scale better than human-engineered knowledge

--- a/docs/adrs/0003-inline-action-triggers-hard-cut.md
+++ b/docs/adrs/0003-inline-action-triggers-hard-cut.md
@@ -10,7 +10,7 @@ Katagami curation had been partially migrated to inline `[[action.triggers]]`, b
 1. readers could not tell whether `curation_job.ioa.toml` was the real workflow contract or only a partial mirror of older reaction files
 2. the migration risked drift between visible entity state transitions and hidden cross-entity wiring
 
-Katagami runs through the OpenPaw server, so the migration is only complete when the current Katagami worktree is proven live through that runtime path.
+Katagami runs through the temperpaw server, so the migration is only complete when the current Katagami worktree is proven live through that runtime path.
 
 ## Decision
 
@@ -19,7 +19,7 @@ Katagami adopts the Temper ADR-0046 model without fallback:
 - `katagami-curation/specs/curation_job.ioa.toml` and `katagami-curation/specs/curation_query.ioa.toml` are the authoritative workflow wiring
 - legacy `reactions.toml` files remain deleted
 - trigger params that copy source fields use `[action.triggers.params_from]`
-- merge readiness requires a live OpenPaw proof that the current Katagami worktree is the one loaded by the server
+- merge readiness requires a live temperpaw proof that the current Katagami worktree is the one loaded by the server
 
 ## Consequences
 
@@ -29,10 +29,10 @@ Katagami adopts the Temper ADR-0046 model without fallback:
 - Live verification now proves the real runtime path instead of only local static checks.
 
 **Negative:**
-- Katagami's trigger verification depends on coordinated OpenPaw proof runs, not only local crate tests.
+- Katagami's trigger verification depends on coordinated temperpaw proof runs, not only local crate tests.
 
 **Risk:**
-- If OpenPaw points at the wrong local Katagami checkout during proof, verification could accidentally certify the wrong code. The proof record must state exactly which worktree was loaded.
+- If temperpaw points at the wrong local Katagami checkout during proof, verification could accidentally certify the wrong code. The proof record must state exactly which worktree was loaded.
 
 ## References
 

--- a/docs/adrs/0004-temper-native-curation-orchestration.md
+++ b/docs/adrs/0004-temper-native-curation-orchestration.md
@@ -21,13 +21,13 @@ WASM runtime effects remain declared as IOA `effect = [{ type = "trigger", ... }
 plus `[[integration]]` entries.
 
 That means Katagami can express most cross-entity workflow directly in app data.
-The remaining imperative boundary is external runtime integration: OpenPaw
+The remaining imperative boundary is external runtime integration: temperpaw
 session creation, session finalization, and workspace provisioning.
 
 ## Decision
 
 Katagami curation workflow is modeled in Temper entities and reactions. WASM
-remains only where it bridges to OpenPaw runtime behavior.
+remains only where it bridges to temperpaw runtime behavior.
 
 The implementation adds:
 
@@ -43,7 +43,7 @@ The implementation adds:
   start a follow-up job in one target action
 
 New jobs use `completion_contract = "typed-v1"`. For those jobs,
-`finalize_spawned_session` records the OpenPaw session result and finalizes the
+`finalize_spawned_session` records the temperpaw session result and finalizes the
 job. It also carries an idempotent compatibility fallback for already-running
 legacy jobs. The fallback checks existing query/direction/job state and stands
 down rather than duplicating the inline-trigger cascade.
@@ -77,6 +77,6 @@ keeps cross-entity workflow hidden in Rust.
 
 Move every runtime effect into inline triggers immediately.
 
-Rejected because OpenPaw session creation/finalization and workspace ensuring
+Rejected because temperpaw session creation/finalization and workspace ensuring
 are still external runtime effects. Those stay in small WASM bridges until
 Temper has native replacements.

--- a/docs/adrs/0005-agent-storage-taxonomy.md
+++ b/docs/adrs/0005-agent-storage-taxonomy.md
@@ -8,7 +8,7 @@ Accepted for immediate unblock. The final storage architecture remains a follow-
 
 ## Context
 
-Katagami curation jobs depend on TemperPaw sessions. The old hot session path
+Katagami curation jobs depend on temperpaw sessions. The old hot session path
 stored every turn by rebuilding a session JSONL document and writing it through
 PawFS `Files('{id}')/$value`. That looked like an append, but it was a full
 versioned file replacement. The write synchronously waited for blob storage,
@@ -58,7 +58,7 @@ Katagami agents use these storage surfaces by intent:
 
 ## Immediate Implementation
 
-TemperPaw introduces `SessionEntry` as a Temper-native hot session log. New
+temperpaw introduces `SessionEntry` as a Temper-native hot session log. New
 sessions store the session tree as one small entity per entry rather than as a
 rewritten PawFS JSONL file. Existing sessions that already point at PawFS JSONL
 continue to read through the legacy path.

--- a/docs/adrs/0007-monty-json-helper-contract.md
+++ b/docs/adrs/0007-monty-json-helper-contract.md
@@ -21,7 +21,7 @@ source-search smoke session confirmed that `json` was undefined.
 
 ## Decision
 
-OpenPaw preloads a safe `json` helper in every Monty REPL session. Katagami
+temperpaw preloads a safe `json` helper in every Monty REPL session. Katagami
 skills use `json.dumps(...)` and `json.loads(...)` without importing.
 
 Katagami skills must continue to serialize every array or object action

--- a/infra/cloudflare/katagami-assets-worker/src/index.js
+++ b/infra/cloudflare/katagami-assets-worker/src/index.js
@@ -1,0 +1,114 @@
+const ALLOWED_PREFIXES = [
+  "katagami/design-languages/",
+  "published-assets/",
+];
+
+const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
+
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: corsHeaders() });
+    }
+
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return new Response("method not allowed", {
+        status: 405,
+        headers: { Allow: "GET, HEAD, OPTIONS", ...corsHeaders() },
+      });
+    }
+
+    const key = objectKeyFromPath(url.pathname);
+    if (!isAllowedPublicAssetKey(key)) {
+      return notFound();
+    }
+
+    if (request.method === "GET") {
+      const cached = await caches.default.match(request);
+      if (cached) {
+        return withAssetCacheHeader(cached, "HIT");
+      }
+    }
+
+    const object = request.method === "HEAD"
+      ? await env.PUBLISHED_ASSETS.head(key)
+      : await env.PUBLISHED_ASSETS.get(key);
+
+    if (!object) {
+      return notFound();
+    }
+
+    const headers = assetHeaders(object, key);
+    const response = new Response(request.method === "HEAD" ? null : object.body, { headers });
+
+    if (request.method === "GET") {
+      ctx.waitUntil(caches.default.put(request, response.clone()));
+    }
+
+    return withAssetCacheHeader(response, "MISS");
+  },
+};
+
+function objectKeyFromPath(pathname) {
+  const trimmed = pathname.replace(/^\/+/, "");
+  try {
+    return decodeURIComponent(trimmed);
+  } catch {
+    return "";
+  }
+}
+
+function isAllowedPublicAssetKey(key) {
+  if (!key || key.includes("\0")) return false;
+  if (key.split("/").some((segment) => segment === "." || segment === "..")) return false;
+  return ALLOWED_PREFIXES.some((prefix) => key.startsWith(prefix));
+}
+
+function assetHeaders(object, key) {
+  const headers = new Headers(corsHeaders());
+  object.writeHttpMetadata(headers);
+  if (!headers.has("Content-Type")) {
+    headers.set("Content-Type", fallbackContentType(key));
+  }
+  headers.set("Cache-Control", IMMUTABLE_CACHE_CONTROL);
+  headers.set("CDN-Cache-Control", IMMUTABLE_CACHE_CONTROL);
+  headers.set("ETag", object.httpEtag);
+  headers.set("X-Content-Type-Options", "nosniff");
+  return headers;
+}
+
+function fallbackContentType(key) {
+  if (key.endsWith(".html")) return "text/html; charset=utf-8";
+  if (key.endsWith(".jpg") || key.endsWith(".jpeg")) return "image/jpeg";
+  if (key.endsWith(".png")) return "image/png";
+  if (key.endsWith(".webp")) return "image/webp";
+  if (key.endsWith(".gif")) return "image/gif";
+  return "application/octet-stream";
+}
+
+function corsHeaders() {
+  return {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, If-None-Match, If-Modified-Since",
+  };
+}
+
+function notFound() {
+  return new Response("not found", {
+    status: 404,
+    headers: { "Cache-Control": "public, max-age=60", ...corsHeaders() },
+  });
+}
+
+function withAssetCacheHeader(response, value) {
+  const headers = new Headers(response.headers);
+  headers.set("X-Katagami-Asset-Cache", value);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/infra/cloudflare/katagami-assets-worker/wrangler.toml
+++ b/infra/cloudflare/katagami-assets-worker/wrangler.toml
@@ -1,0 +1,12 @@
+name = "katagami-assets"
+main = "src/index.js"
+compatibility_date = "2026-05-09"
+workers_dev = false
+
+routes = [
+  { pattern = "assets.katagami.ai/*", zone_name = "katagami.ai" },
+]
+
+[[r2_buckets]]
+binding = "PUBLISHED_ASSETS"
+bucket_name = "openpaw-fs-seshendranalla"

--- a/infra/cloudflare/katagami-assets-worker/wrangler.toml
+++ b/infra/cloudflare/katagami-assets-worker/wrangler.toml
@@ -9,4 +9,4 @@ routes = [
 
 [[r2_buckets]]
 binding = "PUBLISHED_ASSETS"
-bucket_name = "temperpaw-public-artifacts-seshendranalla"
+bucket_name = "katagami-published-assets"

--- a/infra/cloudflare/katagami-assets-worker/wrangler.toml
+++ b/infra/cloudflare/katagami-assets-worker/wrangler.toml
@@ -9,4 +9,4 @@ routes = [
 
 [[r2_buckets]]
 binding = "PUBLISHED_ASSETS"
-bucket_name = "openpaw-fs-seshendranalla"
+bucket_name = "temperpaw-public-artifacts-seshendranalla"

--- a/infra/cloudflare/katagami-assets-worker/wrangler.toml
+++ b/infra/cloudflare/katagami-assets-worker/wrangler.toml
@@ -9,4 +9,4 @@ routes = [
 
 [[r2_buckets]]
 binding = "PUBLISHED_ASSETS"
-bucket_name = "katagami-published-assets"
+bucket_name = "openpaw-fs-seshendranalla"

--- a/katagami-commons/specs/design_language.ioa.toml
+++ b/katagami-commons/specs/design_language.ioa.toml
@@ -278,10 +278,10 @@ hint = "Mark the attached thumbnail as verified after the finalizer has read the
 [[action]]
 name = "AttachVerifiedThumbnail"
 kind = "internal"
-from = ["Draft", "UnderReview", "Published"]
+from = ["Draft", "UnderReview"]
 effect = [{ type = "set_bool", var = "has_thumbnail", value = "true" }, { type = "set_bool", var = "thumbnail_verified", value = "true" }, { type = "set_bool", var = "has_published_assets", value = "false" }]
 params = ["thumbnail_file_id"]
-hint = "Attach a thumbnail that the finalizer or backfill job has already validated. Used for verified backfills and published-language repair without temporarily violating published thumbnail invariants."
+hint = "Attach a thumbnail that the finalizer or backfill job has already validated. Published languages must Revise first because changing source media invalidates public artifacts."
 
 [[action]]
 name = "AttachPublishedAssets"

--- a/katagami-commons/specs/design_language.ioa.toml
+++ b/katagami-commons/specs/design_language.ioa.toml
@@ -85,6 +85,11 @@ type = "bool"
 initial = "false"
 
 [[state]]
+name = "has_published_assets"
+type = "bool"
+initial = "false"
+
+[[state]]
 name = "embodiment_format"
 type = "string"
 initial = "html"
@@ -140,7 +145,7 @@ initial = 0
 name = "SetName"
 kind = "input"
 from = ["Draft", "UnderReview"]
-effect = [{ type = "set_bool", var = "has_design_md", value = "false" }, { type = "set_bool", var = "has_valid_design_md", value = "false" }, { type = "set_bool", var = "design_md_verified", value = "false" }, { type = "set_bool", var = "quality_review_passed", value = "false" }]
+effect = [{ type = "set_bool", var = "has_design_md", value = "false" }, { type = "set_bool", var = "has_valid_design_md", value = "false" }, { type = "set_bool", var = "design_md_verified", value = "false" }, { type = "set_bool", var = "has_published_assets", value = "false" }, { type = "set_bool", var = "quality_review_passed", value = "false" }]
 params = ["name", "slug"]
 hint = "Set the design language name and URL-safe slug."
 
@@ -157,6 +162,7 @@ effect = [
   { type = "set_bool", var = "has_design_md", value = "false" },
   { type = "set_bool", var = "has_valid_design_md", value = "false" },
   { type = "set_bool", var = "design_md_verified", value = "false" },
+  { type = "set_bool", var = "has_published_assets", value = "false" },
   { type = "set_bool", var = "quality_review_passed", value = "false" }
 ]
 params = ["name", "slug", "philosophy", "tokens", "rules", "layout_principles", "guidance", "tags"]
@@ -166,7 +172,7 @@ hint = "Set the complete core spec for a newly synthesized or substantially revi
 name = "WritePhilosophy"
 kind = "input"
 from = ["Draft", "UnderReview"]
-effect = [{ type = "set_bool", var = "has_philosophy", value = "true" }, { type = "set_bool", var = "has_design_md", value = "false" }, { type = "set_bool", var = "has_valid_design_md", value = "false" }, { type = "set_bool", var = "design_md_verified", value = "false" }, { type = "set_bool", var = "quality_review_passed", value = "false" }]
+effect = [{ type = "set_bool", var = "has_philosophy", value = "true" }, { type = "set_bool", var = "has_design_md", value = "false" }, { type = "set_bool", var = "has_valid_design_md", value = "false" }, { type = "set_bool", var = "design_md_verified", value = "false" }, { type = "set_bool", var = "has_published_assets", value = "false" }, { type = "set_bool", var = "quality_review_passed", value = "false" }]
 params = ["philosophy"]
 hint = "Write or update the Philosophy section (values, anti-values, aesthetic lineage)."
 
@@ -174,7 +180,7 @@ hint = "Write or update the Philosophy section (values, anti-values, aesthetic l
 name = "SetTokens"
 kind = "input"
 from = ["Draft", "UnderReview"]
-effect = [{ type = "set_bool", var = "has_tokens", value = "true" }, { type = "set_bool", var = "has_design_md", value = "false" }, { type = "set_bool", var = "has_valid_design_md", value = "false" }, { type = "set_bool", var = "design_md_verified", value = "false" }, { type = "set_bool", var = "quality_review_passed", value = "false" }]
+effect = [{ type = "set_bool", var = "has_tokens", value = "true" }, { type = "set_bool", var = "has_design_md", value = "false" }, { type = "set_bool", var = "has_valid_design_md", value = "false" }, { type = "set_bool", var = "design_md_verified", value = "false" }, { type = "set_bool", var = "has_published_assets", value = "false" }, { type = "set_bool", var = "quality_review_passed", value = "false" }]
 params = ["tokens"]
 hint = "Set design tokens (colors, typography, spacing, radii, shadows, elevation, motion, opacity)."
 
@@ -182,7 +188,7 @@ hint = "Set design tokens (colors, typography, spacing, radii, shadows, elevatio
 name = "SetRules"
 kind = "input"
 from = ["Draft", "UnderReview"]
-effect = [{ type = "set_bool", var = "has_rules", value = "true" }, { type = "set_bool", var = "has_design_md", value = "false" }, { type = "set_bool", var = "has_valid_design_md", value = "false" }, { type = "set_bool", var = "design_md_verified", value = "false" }, { type = "set_bool", var = "quality_review_passed", value = "false" }]
+effect = [{ type = "set_bool", var = "has_rules", value = "true" }, { type = "set_bool", var = "has_design_md", value = "false" }, { type = "set_bool", var = "has_valid_design_md", value = "false" }, { type = "set_bool", var = "design_md_verified", value = "false" }, { type = "set_bool", var = "has_published_assets", value = "false" }, { type = "set_bool", var = "quality_review_passed", value = "false" }]
 params = ["rules"]
 hint = "Set compositional rules (how tokens combine to form elements)."
 
@@ -190,7 +196,7 @@ hint = "Set compositional rules (how tokens combine to form elements)."
 name = "SetLayout"
 kind = "input"
 from = ["Draft", "UnderReview"]
-effect = [{ type = "set_bool", var = "has_layout", value = "true" }, { type = "set_bool", var = "has_design_md", value = "false" }, { type = "set_bool", var = "has_valid_design_md", value = "false" }, { type = "set_bool", var = "design_md_verified", value = "false" }, { type = "set_bool", var = "quality_review_passed", value = "false" }]
+effect = [{ type = "set_bool", var = "has_layout", value = "true" }, { type = "set_bool", var = "has_design_md", value = "false" }, { type = "set_bool", var = "has_valid_design_md", value = "false" }, { type = "set_bool", var = "design_md_verified", value = "false" }, { type = "set_bool", var = "has_published_assets", value = "false" }, { type = "set_bool", var = "quality_review_passed", value = "false" }]
 params = ["layout_principles"]
 hint = "Set layout principles (density, grid, whitespace, responsive)."
 
@@ -198,7 +204,7 @@ hint = "Set layout principles (density, grid, whitespace, responsive)."
 name = "SetGuidance"
 kind = "input"
 from = ["Draft", "UnderReview"]
-effect = [{ type = "set_bool", var = "has_guidance", value = "true" }, { type = "set_bool", var = "has_design_md", value = "false" }, { type = "set_bool", var = "has_valid_design_md", value = "false" }, { type = "set_bool", var = "design_md_verified", value = "false" }, { type = "set_bool", var = "quality_review_passed", value = "false" }]
+effect = [{ type = "set_bool", var = "has_guidance", value = "true" }, { type = "set_bool", var = "has_design_md", value = "false" }, { type = "set_bool", var = "has_valid_design_md", value = "false" }, { type = "set_bool", var = "design_md_verified", value = "false" }, { type = "set_bool", var = "has_published_assets", value = "false" }, { type = "set_bool", var = "quality_review_passed", value = "false" }]
 params = ["guidance"]
 hint = "Set guidance section (do's, don'ts, usage context)."
 
@@ -206,7 +212,7 @@ hint = "Set guidance section (do's, don'ts, usage context)."
 name = "SetImageryDirection"
 kind = "input"
 from = ["Draft", "UnderReview"]
-effect = [{ type = "set_bool", var = "has_design_md", value = "false" }, { type = "set_bool", var = "has_valid_design_md", value = "false" }, { type = "set_bool", var = "design_md_verified", value = "false" }, { type = "set_bool", var = "quality_review_passed", value = "false" }]
+effect = [{ type = "set_bool", var = "has_design_md", value = "false" }, { type = "set_bool", var = "has_valid_design_md", value = "false" }, { type = "set_bool", var = "design_md_verified", value = "false" }, { type = "set_bool", var = "has_published_assets", value = "false" }, { type = "set_bool", var = "quality_review_passed", value = "false" }]
 params = ["imagery_direction"]
 hint = "Set imagery & illustration direction (illustration_style, hero_image_direction, icon_style, image_gen_prompts)."
 
@@ -214,7 +220,7 @@ hint = "Set imagery & illustration direction (illustration_style, hero_image_dir
 name = "SetGenerativeCanvas"
 kind = "input"
 from = ["Draft", "UnderReview"]
-effect = [{ type = "set_bool", var = "has_design_md", value = "false" }, { type = "set_bool", var = "has_valid_design_md", value = "false" }, { type = "set_bool", var = "design_md_verified", value = "false" }, { type = "set_bool", var = "quality_review_passed", value = "false" }]
+effect = [{ type = "set_bool", var = "has_design_md", value = "false" }, { type = "set_bool", var = "has_valid_design_md", value = "false" }, { type = "set_bool", var = "design_md_verified", value = "false" }, { type = "set_bool", var = "has_published_assets", value = "false" }, { type = "set_bool", var = "quality_review_passed", value = "false" }]
 params = ["generative_canvas"]
 hint = "Set generative/interactive canvas direction (WebGL techniques, canvas effects, shader palette, animation philosophy)."
 
@@ -224,7 +230,7 @@ hint = "Set generative/interactive canvas direction (WebGL techniques, canvas ef
 name = "AttachEmbodiment"
 kind = "input"
 from = ["Draft", "UnderReview"]
-effect = [{ type = "set_bool", var = "has_embodiment", value = "true" }, { type = "set_bool", var = "embodiment_verified", value = "false" }, { type = "set_bool", var = "has_thumbnail", value = "false" }, { type = "set_bool", var = "thumbnail_verified", value = "false" }, { type = "set_bool", var = "has_design_md", value = "false" }, { type = "set_bool", var = "has_valid_design_md", value = "false" }, { type = "set_bool", var = "design_md_verified", value = "false" }, { type = "set_bool", var = "quality_review_passed", value = "false" }]
+effect = [{ type = "set_bool", var = "has_embodiment", value = "true" }, { type = "set_bool", var = "embodiment_verified", value = "false" }, { type = "set_bool", var = "has_thumbnail", value = "false" }, { type = "set_bool", var = "thumbnail_verified", value = "false" }, { type = "set_bool", var = "has_design_md", value = "false" }, { type = "set_bool", var = "has_valid_design_md", value = "false" }, { type = "set_bool", var = "design_md_verified", value = "false" }, { type = "set_bool", var = "has_published_assets", value = "false" }, { type = "set_bool", var = "quality_review_passed", value = "false" }]
 params = ["embodiment_file_id", "element_count", "composition_count", "embodiment_format"]
 hint = "Attach embodiment file. Set embodiment_format to 'tsx' for Radix TSX or 'html' for legacy HTML. Re-attaching an embodiment invalidates the derived gallery thumbnail until regenerated and verified."
 
@@ -240,7 +246,7 @@ hint = "Mark the attached embodiment as verified after the finalizer has read th
 name = "AttachDesignMd"
 kind = "input"
 from = ["Draft", "UnderReview"]
-effect = [{ type = "set_bool", var = "has_design_md", value = "true" }, { type = "set_bool", var = "has_valid_design_md", value = "false" }, { type = "set_bool", var = "design_md_verified", value = "false" }, { type = "set_bool", var = "quality_review_passed", value = "false" }]
+effect = [{ type = "set_bool", var = "has_design_md", value = "true" }, { type = "set_bool", var = "has_valid_design_md", value = "false" }, { type = "set_bool", var = "design_md_verified", value = "false" }, { type = "set_bool", var = "has_published_assets", value = "false" }, { type = "set_bool", var = "quality_review_passed", value = "false" }]
 params = ["design_md_file_id", "design_md_lint_result", "design_md_format_version"]
 hint = "Attach a generated DESIGN.md artifact candidate. Published languages must Revise first because this invalidates publish-required verification booleans until the finalizer verifies the referenced file."
 
@@ -256,7 +262,7 @@ hint = "Mark the attached DESIGN.md as verified after the finalizer has read the
 name = "AttachThumbnail"
 kind = "input"
 from = ["Draft", "UnderReview"]
-effect = [{ type = "set_bool", var = "has_thumbnail", value = "true" }, { type = "set_bool", var = "thumbnail_verified", value = "false" }]
+effect = [{ type = "set_bool", var = "has_thumbnail", value = "true" }, { type = "set_bool", var = "thumbnail_verified", value = "false" }, { type = "set_bool", var = "has_published_assets", value = "false" }]
 params = ["thumbnail_file_id"]
 hint = "Attach or update the static desktop gallery thumbnail image. The finalizer must VerifyThumbnail after it confirms the referenced file is an image payload."
 
@@ -273,7 +279,7 @@ hint = "Mark the attached thumbnail as verified after the finalizer has read the
 name = "AttachVerifiedThumbnail"
 kind = "internal"
 from = ["Draft", "UnderReview", "Published"]
-effect = [{ type = "set_bool", var = "has_thumbnail", value = "true" }, { type = "set_bool", var = "thumbnail_verified", value = "true" }]
+effect = [{ type = "set_bool", var = "has_thumbnail", value = "true" }, { type = "set_bool", var = "thumbnail_verified", value = "true" }, { type = "set_bool", var = "has_published_assets", value = "false" }]
 params = ["thumbnail_file_id"]
 hint = "Attach a thumbnail that the finalizer or backfill job has already validated. Used for verified backfills and published-language repair without temporarily violating published thumbnail invariants."
 
@@ -281,8 +287,9 @@ hint = "Attach a thumbnail that the finalizer or backfill job has already valida
 name = "AttachPublishedAssets"
 kind = "internal"
 from = ["Draft", "UnderReview", "Published"]
-params = ["thumbnail_asset_id", "thumbnail_asset_url", "embodiment_asset_id", "embodiment_asset_url"]
-hint = "Attach immutable public asset URLs created by the server-side publish-asset flow. PawFS file ids remain the governed source artifacts; asset URLs are the public serving plane for thumbnails and embodiments."
+effect = [{ type = "set_bool", var = "has_published_assets", value = "true" }]
+params = ["thumbnail_asset_id", "thumbnail_asset_url", "embodiment_asset_id", "embodiment_asset_url", "design_md_asset_id", "design_md_asset_url"]
+hint = "Attach immutable public artifact URLs created by the generic Temper publish-artifact flow. PawFS file ids remain the governed source artifacts; asset URLs are the public serving plane for thumbnails, embodiments, and DESIGN.md."
 
 # --- Actions: Classification ---
 
@@ -345,9 +352,9 @@ name = "Publish"
 kind = "internal"
 from = ["UnderReview"]
 to = "Published"
-guard = [{ type = "is_true", var = "has_philosophy" }, { type = "is_true", var = "has_tokens" }, { type = "is_true", var = "has_rules" }, { type = "is_true", var = "has_layout" }, { type = "is_true", var = "has_guidance" }, { type = "is_true", var = "has_embodiment" }, { type = "is_true", var = "embodiment_verified" }, { type = "is_true", var = "has_thumbnail" }, { type = "is_true", var = "thumbnail_verified" }, { type = "is_true", var = "has_design_md" }, { type = "is_true", var = "has_valid_design_md" }, { type = "is_true", var = "design_md_verified" }, { type = "is_true", var = "quality_review_passed" }]
+guard = [{ type = "is_true", var = "has_philosophy" }, { type = "is_true", var = "has_tokens" }, { type = "is_true", var = "has_rules" }, { type = "is_true", var = "has_layout" }, { type = "is_true", var = "has_guidance" }, { type = "is_true", var = "has_embodiment" }, { type = "is_true", var = "embodiment_verified" }, { type = "is_true", var = "has_thumbnail" }, { type = "is_true", var = "thumbnail_verified" }, { type = "is_true", var = "has_design_md" }, { type = "is_true", var = "has_valid_design_md" }, { type = "is_true", var = "design_md_verified" }, { type = "is_true", var = "has_published_assets" }, { type = "is_true", var = "quality_review_passed" }]
 effect = [{ type = "increment", field = "version" }]
-hint = "Curator approves and publishes. Requires verified spec sections, embodiment, thumbnail, DESIGN.md, and quality review."
+hint = "Curator approves and publishes. Requires verified spec sections, embodiment, thumbnail, DESIGN.md, immutable public artifacts, and quality review."
 
 [[action]]
 name = "Revise"
@@ -448,6 +455,11 @@ assert = "has_valid_design_md"
 name = "PublishedRequiresVerifiedDesignMd"
 when = ["Published"]
 assert = "design_md_verified"
+
+[[invariant]]
+name = "PublishedRequiresPublicAssets"
+when = ["Published"]
+assert = "has_published_assets"
 
 [[invariant]]
 name = "PublishedRequiresQualityReview"

--- a/katagami-commons/specs/design_language.ioa.toml
+++ b/katagami-commons/specs/design_language.ioa.toml
@@ -277,6 +277,13 @@ effect = [{ type = "set_bool", var = "has_thumbnail", value = "true" }, { type =
 params = ["thumbnail_file_id"]
 hint = "Attach a thumbnail that the finalizer or backfill job has already validated. Used for verified backfills and published-language repair without temporarily violating published thumbnail invariants."
 
+[[action]]
+name = "AttachPublishedAssets"
+kind = "internal"
+from = ["Draft", "UnderReview", "Published"]
+params = ["thumbnail_asset_id", "thumbnail_asset_url", "embodiment_asset_id", "embodiment_asset_url"]
+hint = "Attach immutable public asset URLs created by the server-side publish-asset flow. PawFS file ids remain the governed source artifacts; asset URLs are the public serving plane for thumbnails and embodiments."
+
 # --- Actions: Classification ---
 
 [[action]]

--- a/katagami-commons/specs/model.csdl.xml
+++ b/katagami-commons/specs/model.csdl.xml
@@ -27,6 +27,8 @@
         <Property Name="GenerativeCanvas" Type="Edm.String" Nullable="false" DefaultValue="" />
         <!-- DESIGN.md: generated portable agent handoff artifact -->
         <Property Name="DesignMdFileId" Type="Edm.String" Nullable="false" DefaultValue="" />
+        <Property Name="DesignMdAssetId" Type="Edm.String" Nullable="false" DefaultValue="" />
+        <Property Name="DesignMdAssetUrl" Type="Edm.String" Nullable="false" DefaultValue="" />
         <Property Name="DesignMdLintResult" Type="Edm.String" Nullable="false" DefaultValue="{}" />
         <Property Name="DesignMdFormatVersion" Type="Edm.String" Nullable="false" DefaultValue="alpha" />
         <Property Name="DesignMdVerified" Type="Edm.Boolean" Nullable="false" DefaultValue="false" />
@@ -40,6 +42,7 @@
         <Property Name="ThumbnailAssetUrl" Type="Edm.String" Nullable="false" DefaultValue="" />
         <Property Name="HasThumbnail" Type="Edm.Boolean" Nullable="false" DefaultValue="false" />
         <Property Name="ThumbnailVerified" Type="Edm.Boolean" Nullable="false" DefaultValue="false" />
+        <Property Name="HasPublishedAssets" Type="Edm.Boolean" Nullable="false" DefaultValue="false" />
         <Property Name="ElementCount" Type="Edm.Int32" Nullable="false" DefaultValue="0" />
         <Property Name="CompositionCount" Type="Edm.Int32" Nullable="false" DefaultValue="0" />
         <!-- Lineage -->

--- a/katagami-commons/specs/model.csdl.xml
+++ b/katagami-commons/specs/model.csdl.xml
@@ -32,8 +32,12 @@
         <Property Name="DesignMdVerified" Type="Edm.Boolean" Nullable="false" DefaultValue="false" />
         <!-- Embodiment: self-contained HTML file in paw-fs -->
         <Property Name="EmbodimentFileId" Type="Edm.String" Nullable="false" DefaultValue="" />
+        <Property Name="EmbodimentAssetId" Type="Edm.String" Nullable="false" DefaultValue="" />
+        <Property Name="EmbodimentAssetUrl" Type="Edm.String" Nullable="false" DefaultValue="" />
         <Property Name="EmbodimentVerified" Type="Edm.Boolean" Nullable="false" DefaultValue="false" />
         <Property Name="ThumbnailFileId" Type="Edm.String" Nullable="false" DefaultValue="" />
+        <Property Name="ThumbnailAssetId" Type="Edm.String" Nullable="false" DefaultValue="" />
+        <Property Name="ThumbnailAssetUrl" Type="Edm.String" Nullable="false" DefaultValue="" />
         <Property Name="HasThumbnail" Type="Edm.Boolean" Nullable="false" DefaultValue="false" />
         <Property Name="ThumbnailVerified" Type="Edm.Boolean" Nullable="false" DefaultValue="false" />
         <Property Name="ElementCount" Type="Edm.Int32" Nullable="false" DefaultValue="0" />

--- a/katagami-curation/APP.md
+++ b/katagami-curation/APP.md
@@ -55,9 +55,9 @@ belongs in a later artifact step.
 
 Each job spawns an agent session through a small WASM runtime bridge.
 `build_session_message` reads `CurationJobTemplate` records, loads the
-referenced skill and knowledge files from TemperFS, and creates OpenPaw
+referenced skill and knowledge files from TemperFS, and creates temperpaw
 sessions. Follow-up jobs and parent-query transitions are declared as Temper
 reactions. `finalize_spawned_session` records session results for typed jobs,
 keeps a legacy completion path for already-running old sessions, and contains
-an idempotent fallback while the OpenPaw OS app installer catches up to app
+an idempotent fallback while the temperpaw OS app installer catches up to app
 reaction loading.

--- a/katagami-curation/tests/test_design_md_contract.py
+++ b/katagami-curation/tests/test_design_md_contract.py
@@ -37,6 +37,7 @@ class DesignMdContractTests(unittest.TestCase):
     def test_design_language_tracks_design_md_validity(self):
         self.assertIn("has_design_md", self.states)
         self.assertIn("has_valid_design_md", self.states)
+        self.assertIn("has_published_assets", self.states)
 
         attach = self.actions["AttachDesignMd"]
         self.assertEqual(attach["from"], ["Draft", "UnderReview"])
@@ -55,6 +56,25 @@ class DesignMdContractTests(unittest.TestCase):
         self.assertTrue(
             self._sets_bool("AttachDesignMd", "design_md_verified", "false")
         )
+        self.assertTrue(
+            self._sets_bool("AttachDesignMd", "has_published_assets", "false")
+        )
+
+        attach_assets = self.actions["AttachPublishedAssets"]
+        self.assertEqual(
+            attach_assets["params"],
+            [
+                "thumbnail_asset_id",
+                "thumbnail_asset_url",
+                "embodiment_asset_id",
+                "embodiment_asset_url",
+                "design_md_asset_id",
+                "design_md_asset_url",
+            ],
+        )
+        self.assertTrue(
+            self._sets_bool("AttachPublishedAssets", "has_published_assets", "true")
+        )
 
     def test_published_languages_revise_before_design_md_reattach(self):
         attach = self.actions["AttachDesignMd"]
@@ -68,6 +88,7 @@ class DesignMdContractTests(unittest.TestCase):
             "has_valid_design_md",
             "design_md_verified",
             "embodiment_verified",
+            "has_published_assets",
             "quality_review_passed",
         ]:
             self.assertIn({"type": "is_true", "var": var}, guards)
@@ -82,6 +103,10 @@ class DesignMdContractTests(unittest.TestCase):
         self.assertEqual(
             invariants["PublishedRequiresVerifiedDesignMd"]["assert"],
             "design_md_verified",
+        )
+        self.assertEqual(
+            invariants["PublishedRequiresPublicAssets"]["assert"],
+            "has_published_assets",
         )
 
     def test_source_spec_changes_invalidate_design_md(self):
@@ -106,6 +131,9 @@ class DesignMdContractTests(unittest.TestCase):
                 )
                 self.assertTrue(
                     self._sets_bool(action_name, "design_md_verified", "false")
+                )
+                self.assertTrue(
+                    self._sets_bool(action_name, "has_published_assets", "false")
                 )
                 self.assertTrue(
                     self._sets_bool(action_name, "quality_review_passed", "false")
@@ -167,10 +195,13 @@ class DesignMdContractTests(unittest.TestCase):
 
         for prop in [
             "DesignMdFileId",
+            "DesignMdAssetId",
+            "DesignMdAssetUrl",
             "DesignMdLintResult",
             "DesignMdFormatVersion",
             "DesignMdVerified",
             "EmbodimentVerified",
+            "HasPublishedAssets",
             "QualityReviewPassed",
         ]:
             self.assertIn(prop, props)

--- a/katagami-curation/tests/test_thumbnail_contract.py
+++ b/katagami-curation/tests/test_thumbnail_contract.py
@@ -39,6 +39,9 @@ class ThumbnailContractTests(unittest.TestCase):
         self.assertIn('Property Name="ThumbnailAssetUrl"', csdl)
         self.assertIn('Property Name="EmbodimentAssetId"', csdl)
         self.assertIn('Property Name="EmbodimentAssetUrl"', csdl)
+        self.assertIn('Property Name="DesignMdAssetId"', csdl)
+        self.assertIn('Property Name="DesignMdAssetUrl"', csdl)
+        self.assertIn('Property Name="HasPublishedAssets"', csdl)
         self.assertIn('Property Name="HasThumbnail"', csdl)
         self.assertIn('Property Name="ThumbnailVerified"', csdl)
 
@@ -66,6 +69,7 @@ class ThumbnailContractTests(unittest.TestCase):
         guards = publish.get("guard", [])
         self.assertIn({"type": "is_true", "var": "has_thumbnail"}, guards)
         self.assertIn({"type": "is_true", "var": "thumbnail_verified"}, guards)
+        self.assertIn({"type": "is_true", "var": "has_published_assets"}, guards)
 
         invariants = {
             invariant["name"]: invariant for invariant in self.spec["invariant"]
@@ -77,6 +81,10 @@ class ThumbnailContractTests(unittest.TestCase):
         self.assertEqual(
             invariants["PublishedRequiresVerifiedThumbnail"]["assert"],
             "thumbnail_verified",
+        )
+        self.assertEqual(
+            invariants["PublishedRequiresPublicAssets"]["assert"],
+            "has_published_assets",
         )
 
     def test_submit_for_review_requires_thumbnail(self):
@@ -104,7 +112,16 @@ class ThumbnailContractTests(unittest.TestCase):
         self.assertIn('"thumbnail"', source)
         self.assertIn("fn publish_public_assets", source)
         self.assertIn('"AttachPublishedAssets"', source)
-        self.assertIn("/api/files/publish-asset", source)
+        self.assertIn("/api/files/publish-artifact", source)
+        self.assertNotIn("/api/files/publish-asset", source)
+        self.assertIn('"owner_ref_type": "DesignLanguage"', source)
+        self.assertIn('"owner_ref_id": language_id', source)
+        self.assertIn('"namespace": "katagami/design-languages"', source)
+        self.assertIn('"label": label', source)
+        self.assertIn('"artifact"', source)
+        self.assertIn('"design_md"', source)
+        self.assertIn('"design_md_asset_id"', source)
+        self.assertIn('"design_md_asset_url"', source)
         self.assertIn('"image/jpeg"', source)
         self.assertIn("upload decoded browser-renderable image bytes", source)
         self.assertIn("not browser-renderable image bytes", source)

--- a/katagami-curation/tests/test_thumbnail_contract.py
+++ b/katagami-curation/tests/test_thumbnail_contract.py
@@ -33,6 +33,10 @@ class ThumbnailContractTests(unittest.TestCase):
             self._sets_bool("VerifyThumbnail", "thumbnail_verified", "true")
         )
 
+        attach_verified = self.actions["AttachVerifiedThumbnail"]
+        self.assertEqual(attach_verified["from"], ["Draft", "UnderReview"])
+        self.assertIn("Revise first", attach_verified["hint"])
+
         csdl = (self.commons_root / "specs" / "model.csdl.xml").read_text()
         self.assertIn('Property Name="ThumbnailFileId"', csdl)
         self.assertIn('Property Name="ThumbnailAssetId"', csdl)

--- a/katagami-curation/tests/test_thumbnail_contract.py
+++ b/katagami-curation/tests/test_thumbnail_contract.py
@@ -35,6 +35,10 @@ class ThumbnailContractTests(unittest.TestCase):
 
         csdl = (self.commons_root / "specs" / "model.csdl.xml").read_text()
         self.assertIn('Property Name="ThumbnailFileId"', csdl)
+        self.assertIn('Property Name="ThumbnailAssetId"', csdl)
+        self.assertIn('Property Name="ThumbnailAssetUrl"', csdl)
+        self.assertIn('Property Name="EmbodimentAssetId"', csdl)
+        self.assertIn('Property Name="EmbodimentAssetUrl"', csdl)
         self.assertIn('Property Name="HasThumbnail"', csdl)
         self.assertIn('Property Name="ThumbnailVerified"', csdl)
 
@@ -98,14 +102,22 @@ class ThumbnailContractTests(unittest.TestCase):
         self.assertIn('"VerifyThumbnail"', source)
         self.assertIn('"thumbnail_file_id"', source)
         self.assertIn('"thumbnail"', source)
+        self.assertIn("fn publish_public_assets", source)
+        self.assertIn('"AttachPublishedAssets"', source)
+        self.assertIn("/api/files/publish-asset", source)
         self.assertIn('"image/jpeg"', source)
         self.assertIn("upload decoded browser-renderable image bytes", source)
         self.assertIn("not browser-renderable image bytes", source)
 
         self.assertLess(
             source.index("verify_and_mark_thumbnail(ctx, api_url, headers, language_id, &language)?"),
+            source.index("publish_public_assets(ctx, api_url, headers, language_id, &language)?"),
+            "public assets must be published after thumbnail verification",
+        )
+        self.assertLess(
+            source.index("publish_public_assets(ctx, api_url, headers, language_id, &language)?"),
             source.index('"MarkQualityPassed"'),
-            "thumbnail verification must happen before quality can pass",
+            "public assets must be attached before quality can pass",
         )
 
     def test_synthesis_finalizer_gates_on_thumbnail(self):

--- a/katagami-curation/wasm/finalize_spawned_session/src/lib.rs
+++ b/katagami-curation/wasm/finalize_spawned_session/src/lib.rs
@@ -733,6 +733,7 @@ fn verify_quality_reviewed_languages(
         verify_language_core(ctx, api_url, headers, language_id, &language)?;
         verify_design_md(ctx, api_url, headers, workspace_id, language_id, &language)?;
         verify_and_mark_thumbnail(ctx, api_url, headers, language_id, &language)?;
+        publish_public_assets(ctx, api_url, headers, language_id, &language)?;
         dispatch_action(
             ctx,
             api_url,
@@ -1017,6 +1018,56 @@ fn verify_and_mark_thumbnail(
         language_id,
         "VerifyThumbnail",
         &json!({}),
+    )?;
+    Ok(())
+}
+
+fn publish_public_assets(
+    ctx: &Context,
+    api_url: &str,
+    headers: &[(String, String)],
+    language_id: &str,
+    language: &serde_json::Value,
+) -> Result<(), String> {
+    let fields = entity_fields(language);
+    let thumbnail_file_id = string_field_any(&fields, "thumbnail_file_id", "");
+    let embodiment_file_id = string_field_any(&fields, "embodiment_file_id", "");
+    if thumbnail_file_id.is_empty() || embodiment_file_id.is_empty() {
+        return Err(format!(
+            "DesignLanguage '{language_id}' cannot publish public assets without thumbnail_file_id and embodiment_file_id"
+        ));
+    }
+
+    let thumbnail = publish_file_asset(
+        ctx,
+        api_url,
+        headers,
+        language_id,
+        &thumbnail_file_id,
+        "thumbnail",
+    )?;
+    let embodiment = publish_file_asset(
+        ctx,
+        api_url,
+        headers,
+        language_id,
+        &embodiment_file_id,
+        "embodiment",
+    )?;
+
+    dispatch_action(
+        ctx,
+        api_url,
+        headers,
+        "DesignLanguages",
+        language_id,
+        "AttachPublishedAssets",
+        &json!({
+            "thumbnail_asset_id": thumbnail.asset_id,
+            "thumbnail_asset_url": thumbnail.public_url,
+            "embodiment_asset_id": embodiment.asset_id,
+            "embodiment_asset_url": embodiment.public_url
+        }),
     )?;
     Ok(())
 }
@@ -1527,6 +1578,60 @@ fn read_file_value(
         ));
     }
     Ok(resp.body)
+}
+
+struct PublishedAssetRef {
+    asset_id: String,
+    public_url: String,
+}
+
+fn publish_file_asset(
+    ctx: &Context,
+    api_url: &str,
+    headers: &[(String, String)],
+    language_id: &str,
+    file_id: &str,
+    kind: &str,
+) -> Result<PublishedAssetRef, String> {
+    let body = json!({
+        "file_id": file_id,
+        "kind": kind,
+        "owner_entity_type": "DesignLanguage",
+        "owner_entity_id": language_id,
+        "public_key_prefix": "katagami/design-languages"
+    });
+    let resp = ctx.http_call(
+        "POST",
+        &format!("{api_url}/api/files/publish-asset"),
+        headers,
+        &body.to_string(),
+    )?;
+    if !(200..300).contains(&resp.status) {
+        return Err(format!(
+            "Failed to publish {kind} asset for DesignLanguage '{language_id}' from file '{file_id}': HTTP {}: {}",
+            resp.status,
+            &resp.body[..resp.body.len().min(300)]
+        ));
+    }
+    let parsed: serde_json::Value = serde_json::from_str(&resp.body)
+        .map_err(|e| format!("Failed to parse publish-asset response: {e}"))?;
+    let asset = parsed
+        .get("asset")
+        .ok_or_else(|| "publish-asset response has no asset object".to_string())?;
+    let asset_id = asset
+        .get("id")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| "publish-asset response asset has no id".to_string())?
+        .to_string();
+    let public_url = asset
+        .get("public_url")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| "publish-asset response asset has no public_url".to_string())?
+        .to_string();
+    Ok(PublishedAssetRef {
+        asset_id,
+        public_url,
+    })
 }
 
 fn design_md_projection_refresh_reason(

--- a/katagami-curation/wasm/finalize_spawned_session/src/lib.rs
+++ b/katagami-curation/wasm/finalize_spawned_session/src/lib.rs
@@ -3,7 +3,7 @@ use temper_wasm_sdk::prelude::*;
 /// Finalize a CurationJob's spawned session.
 ///
 /// Typed-v1 jobs use entity triggers for follow-up orchestration, so this
-/// module only records the OpenPaw session result and moves the job to
+/// module only records the temperpaw session result and moves the job to
 /// Completed. Legacy Complete(output) jobs keep the old cascade path for one
 /// compatibility window so already-running sessions can finish.
 #[unsafe(no_mangle)]
@@ -1032,13 +1032,15 @@ fn publish_public_assets(
     let fields = entity_fields(language);
     let thumbnail_file_id = string_field_any(&fields, "thumbnail_file_id", "");
     let embodiment_file_id = string_field_any(&fields, "embodiment_file_id", "");
-    if thumbnail_file_id.is_empty() || embodiment_file_id.is_empty() {
+    let design_md_file_id = string_field_any(&fields, "design_md_file_id", "");
+    if thumbnail_file_id.is_empty() || embodiment_file_id.is_empty() || design_md_file_id.is_empty()
+    {
         return Err(format!(
-            "DesignLanguage '{language_id}' cannot publish public assets without thumbnail_file_id and embodiment_file_id"
+            "DesignLanguage '{language_id}' cannot publish public artifacts without thumbnail_file_id, embodiment_file_id, and design_md_file_id"
         ));
     }
 
-    let thumbnail = publish_file_asset(
+    let thumbnail = publish_file_artifact(
         ctx,
         api_url,
         headers,
@@ -1046,13 +1048,21 @@ fn publish_public_assets(
         &thumbnail_file_id,
         "thumbnail",
     )?;
-    let embodiment = publish_file_asset(
+    let embodiment = publish_file_artifact(
         ctx,
         api_url,
         headers,
         language_id,
         &embodiment_file_id,
         "embodiment",
+    )?;
+    let design_md = publish_file_artifact(
+        ctx,
+        api_url,
+        headers,
+        language_id,
+        &design_md_file_id,
+        "design_md",
     )?;
 
     dispatch_action(
@@ -1066,7 +1076,9 @@ fn publish_public_assets(
             "thumbnail_asset_id": thumbnail.asset_id,
             "thumbnail_asset_url": thumbnail.public_url,
             "embodiment_asset_id": embodiment.asset_id,
-            "embodiment_asset_url": embodiment.public_url
+            "embodiment_asset_url": embodiment.public_url,
+            "design_md_asset_id": design_md.asset_id,
+            "design_md_asset_url": design_md.public_url
         }),
     )?;
     Ok(())
@@ -1580,55 +1592,55 @@ fn read_file_value(
     Ok(resp.body)
 }
 
-struct PublishedAssetRef {
+struct PublishedArtifactRef {
     asset_id: String,
     public_url: String,
 }
 
-fn publish_file_asset(
+fn publish_file_artifact(
     ctx: &Context,
     api_url: &str,
     headers: &[(String, String)],
     language_id: &str,
     file_id: &str,
-    kind: &str,
-) -> Result<PublishedAssetRef, String> {
+    label: &str,
+) -> Result<PublishedArtifactRef, String> {
     let body = json!({
         "file_id": file_id,
-        "kind": kind,
-        "owner_entity_type": "DesignLanguage",
-        "owner_entity_id": language_id,
-        "public_key_prefix": "katagami/design-languages"
+        "label": label,
+        "owner_ref_type": "DesignLanguage",
+        "owner_ref_id": language_id,
+        "namespace": "katagami/design-languages"
     });
     let resp = ctx.http_call(
         "POST",
-        &format!("{api_url}/api/files/publish-asset"),
+        &format!("{api_url}/api/files/publish-artifact"),
         headers,
         &body.to_string(),
     )?;
     if !(200..300).contains(&resp.status) {
         return Err(format!(
-            "Failed to publish {kind} asset for DesignLanguage '{language_id}' from file '{file_id}': HTTP {}: {}",
+            "Failed to publish {label} artifact for DesignLanguage '{language_id}' from file '{file_id}': HTTP {}: {}",
             resp.status,
             &resp.body[..resp.body.len().min(300)]
         ));
     }
     let parsed: serde_json::Value = serde_json::from_str(&resp.body)
-        .map_err(|e| format!("Failed to parse publish-asset response: {e}"))?;
-    let asset = parsed
-        .get("asset")
-        .ok_or_else(|| "publish-asset response has no asset object".to_string())?;
-    let asset_id = asset
+        .map_err(|e| format!("Failed to parse publish-artifact response: {e}"))?;
+    let artifact = parsed
+        .get("artifact")
+        .ok_or_else(|| "publish-artifact response has no artifact object".to_string())?;
+    let asset_id = artifact
         .get("id")
         .and_then(|value| value.as_str())
-        .ok_or_else(|| "publish-asset response asset has no id".to_string())?
+        .ok_or_else(|| "publish-artifact response artifact has no id".to_string())?
         .to_string();
-    let public_url = asset
+    let public_url = artifact
         .get("public_url")
         .and_then(|value| value.as_str())
-        .ok_or_else(|| "publish-asset response asset has no public_url".to_string())?
+        .ok_or_else(|| "publish-artifact response artifact has no public_url".to_string())?
         .to_string();
-    Ok(PublishedAssetRef {
+    Ok(PublishedArtifactRef {
         asset_id,
         public_url,
     })

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "backfill:published-assets": "node scripts/backfill-published-assets.mjs",
     "test:gallery": "node scripts/check-gallery-renders-all-cards.mjs"
   },
   "dependencies": {

--- a/ui/posters/agent-flow.tsx
+++ b/ui/posters/agent-flow.tsx
@@ -355,7 +355,7 @@ export default function AgentFlowPoster() {
         >
           Agents fan out from one seed into parallel sessions — each writes a
           full spec and embodiment, organizes itself, and publishes to the
-          gallery. No human in the loop after "go".
+          gallery. No human in the loop after &quot;go&quot;.
         </p>
         <div
           style={{

--- a/ui/posters/system-diagram.tsx
+++ b/ui/posters/system-diagram.tsx
@@ -1,7 +1,7 @@
 /**
  * Katagami — System Diagram (minimalistic)
  *
- * Human → Any agent → (Katagami ⇄ TemperPaw → Modal / TensorLake) → Temper → Datadog.
+ * Human → Any agent → (Katagami ⇄ temperpaw → Modal / TensorLake) → Temper → Datadog.
  * Minimalistic Hobonichi feel: Bricolage / Nunito / Geist Mono,
  * palette-tinted cards with thin top ribbons, STRAIGHT connectors,
  * readable stamp labels, dot-grid paper. Only two washi strips pinning
@@ -485,11 +485,11 @@ export default function SystemDiagramPoster() {
         </div>
       </Card>
 
-      {/* ─────── TEMPERPAW ─────── */}
+      {/* ─────── temperpaw ─────── */}
       <Card x={710} y={515} w={360} h={300} tint={C.matcha}>
         <div style={eyebrow}>agent runtime</div>
         <div style={{ ...title, fontSize: T.titleBig, marginTop: 4 }}>
-          TemperPaw
+          temperpaw
         </div>
         <div
           style={{
@@ -570,7 +570,7 @@ export default function SystemDiagramPoster() {
         </div>
       </Card>
 
-      {/* Katagami ↔ TemperPaw — labels now live entirely inside the 270-px
+      {/* Katagami ↔ temperpaw — labels now live entirely inside the 270-px
           gap between the two cards, centered on the arrow line. No bullet
           overlap anywhere. */}
       <HArrow
@@ -593,7 +593,7 @@ export default function SystemDiagramPoster() {
         labelYOffset={-17}
         direction="left"
       />
-      {/* TemperPaw → sandboxes */}
+      {/* temperpaw → sandboxes */}
       <HArrow x1={1072} x2={1102} y={580} color={C.yuzu} direction="right" />
       <HArrow x1={1072} x2={1102} y={755} color={C.ramune} direction="right" />
 

--- a/ui/scripts/backfill-published-assets.mjs
+++ b/ui/scripts/backfill-published-assets.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+
+const apiUrl = requiredEnv("TEMPER_API_URL").replace(/\/+$/, "");
+const apiKey = requiredEnv("TEMPER_API_KEY");
+const tenant = process.env.TEMPER_TENANT || "default";
+const limit = Number(process.env.KATAGAMI_BACKFILL_LIMIT || "0");
+const force = process.argv.includes("--force");
+const dryRun = process.argv.includes("--dry-run");
+
+const headers = {
+  "Authorization": `Bearer ${apiKey}`,
+  "Content-Type": "application/json",
+  "X-Tenant-Id": tenant,
+};
+
+const languages = await fetchPublishedLanguages();
+const candidates = languages
+  .filter((language) => {
+    const fields = language.fields ?? {};
+    if (!fields.thumbnail_file_id || !fields.embodiment_file_id) return false;
+    if (force) return true;
+    return !fields.thumbnail_asset_url || !fields.embodiment_asset_url;
+  })
+  .slice(0, limit > 0 ? limit : undefined);
+
+console.log(`published languages: ${languages.length}`);
+console.log(`asset backfill candidates: ${candidates.length}`);
+if (dryRun) {
+  for (const language of candidates) {
+    console.log(`${language.entity_id}\t${language.fields?.name ?? ""}`);
+  }
+  process.exit(0);
+}
+
+let updated = 0;
+for (const language of candidates) {
+  const fields = language.fields ?? {};
+  const languageId = language.entity_id;
+  const name = fields.name ?? languageId;
+
+  const thumbnail = await publishAsset(languageId, fields.thumbnail_file_id, "thumbnail");
+  const embodiment = await publishAsset(languageId, fields.embodiment_file_id, "embodiment");
+
+  await postJson(
+    `/tdata/DesignLanguages('${encodeODataKey(languageId)}')/Temper.AttachPublishedAssets`,
+    {
+      thumbnail_asset_id: thumbnail.id,
+      thumbnail_asset_url: thumbnail.public_url,
+      embodiment_asset_id: embodiment.id,
+      embodiment_asset_url: embodiment.public_url,
+    },
+  );
+
+  updated += 1;
+  console.log(`updated ${updated}/${candidates.length}: ${languageId}\t${name}`);
+}
+
+console.log(`done: ${updated} language asset records attached`);
+
+async function fetchPublishedLanguages() {
+  const rows = [];
+  let path = "/tdata/DesignLanguages?$filter=Status%20eq%20%27Published%27&$top=200";
+  while (path) {
+    const page = await getJson(path);
+    rows.push(...(page.value ?? []));
+    path = page["@odata.nextLink"]
+      ? page["@odata.nextLink"].replace(apiUrl, "")
+      : "";
+  }
+  return rows;
+}
+
+async function publishAsset(languageId, fileId, kind) {
+  const response = await postJson("/api/files/publish-asset", {
+    file_id: fileId,
+    kind,
+    owner_entity_type: "DesignLanguage",
+    owner_entity_id: languageId,
+    public_key_prefix: "katagami/design-languages",
+  });
+  return response.asset;
+}
+
+async function getJson(path) {
+  const response = await fetch(`${apiUrl}${path}`, { headers });
+  return parseResponse(response, path);
+}
+
+async function postJson(path, body) {
+  const response = await fetch(`${apiUrl}${path}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  return parseResponse(response, path);
+}
+
+async function parseResponse(response, path) {
+  const text = await response.text();
+  let body = {};
+  if (text) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = { raw: text };
+    }
+  }
+  if (!response.ok) {
+    const message = body?.error?.message || body?.error || text || response.statusText;
+    throw new Error(`${path} failed with HTTP ${response.status}: ${message}`);
+  }
+  return body;
+}
+
+function encodeODataKey(value) {
+  return String(value).replaceAll("'", "''");
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}

--- a/ui/scripts/backfill-published-assets.mjs
+++ b/ui/scripts/backfill-published-assets.mjs
@@ -17,9 +17,15 @@ const languages = await fetchPublishedLanguages();
 const candidates = languages
   .filter((language) => {
     const fields = language.fields ?? {};
-    if (!fields.thumbnail_file_id || !fields.embodiment_file_id) return false;
+    if (!fields.thumbnail_file_id || !fields.embodiment_file_id || !fields.design_md_file_id) {
+      return false;
+    }
     if (force) return true;
-    return !fields.thumbnail_asset_url || !fields.embodiment_asset_url;
+    return (
+      !fields.thumbnail_asset_url ||
+      !fields.embodiment_asset_url ||
+      !fields.design_md_asset_url
+    );
   })
   .slice(0, limit > 0 ? limit : undefined);
 
@@ -38,8 +44,9 @@ for (const language of candidates) {
   const languageId = language.entity_id;
   const name = fields.name ?? languageId;
 
-  const thumbnail = await publishAsset(languageId, fields.thumbnail_file_id, "thumbnail");
-  const embodiment = await publishAsset(languageId, fields.embodiment_file_id, "embodiment");
+  const thumbnail = await publishArtifact(languageId, fields.thumbnail_file_id, "thumbnail");
+  const embodiment = await publishArtifact(languageId, fields.embodiment_file_id, "embodiment");
+  const designMd = await publishArtifact(languageId, fields.design_md_file_id, "design_md");
 
   await postJson(
     `/tdata/DesignLanguages('${encodeODataKey(languageId)}')/Temper.AttachPublishedAssets`,
@@ -48,6 +55,8 @@ for (const language of candidates) {
       thumbnail_asset_url: thumbnail.public_url,
       embodiment_asset_id: embodiment.id,
       embodiment_asset_url: embodiment.public_url,
+      design_md_asset_id: designMd.id,
+      design_md_asset_url: designMd.public_url,
     },
   );
 
@@ -70,15 +79,15 @@ async function fetchPublishedLanguages() {
   return rows;
 }
 
-async function publishAsset(languageId, fileId, kind) {
-  const response = await postJson("/api/files/publish-asset", {
+async function publishArtifact(languageId, fileId, label) {
+  const response = await postJson("/api/files/publish-artifact", {
     file_id: fileId,
-    kind,
-    owner_entity_type: "DesignLanguage",
-    owner_entity_id: languageId,
-    public_key_prefix: "katagami/design-languages",
+    label,
+    owner_ref_type: "DesignLanguage",
+    owner_ref_id: languageId,
+    namespace: "katagami/design-languages",
   });
-  return response.asset;
+  return response.artifact;
 }
 
 async function getJson(path) {

--- a/ui/scripts/migrate-to-railway.mjs
+++ b/ui/scripts/migrate-to-railway.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-// One-shot migration: local OpenPaw/Temper -> Railway OpenPaw/Temper.
+// One-shot migration: local temperpaw/Temper -> Railway temperpaw/Temper.
 //
 // Usage:
 //   LOCAL_URL=http://localhost:3500 \
-//   RAILWAY_URL=https://openpaw-production.up.railway.app \
+//   RAILWAY_URL=https://temperpaw-production.up.railway.app \
 //   RAILWAY_TOKEN=<bearer> \
 //   TENANT=default \
 //   node ui/scripts/migrate-to-railway.mjs [--apply]
@@ -16,7 +16,7 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 
 const L  = process.env.LOCAL_URL  || "http://localhost:3500";
-const R  = process.env.RAILWAY_URL || "https://openpaw-production.up.railway.app";
+const R  = process.env.RAILWAY_URL || "https://temperpaw-production.up.railway.app";
 const LT = process.env.LOCAL_TENANT || "default";
 const RT = process.env.TENANT || "default";
 const TOKEN = process.env.RAILWAY_TOKEN || "";

--- a/ui/src/app/(site)/compare/page.tsx
+++ b/ui/src/app/(site)/compare/page.tsx
@@ -126,7 +126,10 @@ async function ComparisonView({ idA, idB }: { idA: string; idB: string }) {
               <div className="relative rounded-[2px] border border-border bg-card p-3 pb-8 shadow-[0_3px_12px_rgba(30,35,45,0.07)]">
                 {lang.fields.embodiment_file_id &&
                 (lang.fields.embodiment_format ?? "html") !== "tsx" ? (
-                  <EmbodimentViewer fileId={lang.fields.embodiment_file_id} />
+                  <EmbodimentViewer
+                    fileId={lang.fields.embodiment_file_id}
+                    src={lang.fields.embodiment_asset_url}
+                  />
                 ) : lang.fields.embodiment_file_id ? (
                   <div className="flex h-[500px] items-center justify-center p-6 text-center font-mono text-xs uppercase tracking-widest text-muted-foreground">
                     tsx preview not rendered

--- a/ui/src/app/(site)/compare/page.tsx
+++ b/ui/src/app/(site)/compare/page.tsx
@@ -124,21 +124,38 @@ async function ComparisonView({ idA, idB }: { idA: string; idB: string }) {
                 width={90}
               />
               <div className="relative rounded-[2px] border border-border bg-card p-3 pb-8 shadow-[0_3px_12px_rgba(30,35,45,0.07)]">
-                {lang.fields.embodiment_file_id &&
-                (lang.fields.embodiment_format ?? "html") !== "tsx" ? (
-                  <EmbodimentViewer
-                    fileId={lang.fields.embodiment_file_id}
-                    src={lang.fields.embodiment_asset_url}
-                  />
-                ) : lang.fields.embodiment_file_id ? (
-                  <div className="flex h-[500px] items-center justify-center p-6 text-center font-mono text-xs uppercase tracking-widest text-muted-foreground">
-                    tsx preview not rendered
-                  </div>
-                ) : (
-                  <div className="flex h-[500px] items-center justify-center font-mono text-xs uppercase tracking-widest text-muted-foreground">
-                    no embodiment
-                  </div>
-                )}
+                {(() => {
+                  const isPublished = lang.status === "Published";
+                  const embodimentFileId = isPublished
+                    ? undefined
+                    : lang.fields.embodiment_file_id;
+                  const embodimentSrc = lang.fields.embodiment_asset_url;
+                  if (
+                    (embodimentSrc || embodimentFileId) &&
+                    (lang.fields.embodiment_format ?? "html") !== "tsx"
+                  ) {
+                    return (
+                      <EmbodimentViewer
+                        fileId={embodimentFileId}
+                        src={embodimentSrc}
+                      />
+                    );
+                  }
+                  if (lang.fields.embodiment_file_id) {
+                    return (
+                      <div className="flex h-[500px] items-center justify-center p-6 text-center font-mono text-xs uppercase tracking-widest text-muted-foreground">
+                        {isPublished && !embodimentSrc
+                          ? "public embodiment is still publishing"
+                          : "tsx preview not rendered"}
+                      </div>
+                    );
+                  }
+                  return (
+                    <div className="flex h-[500px] items-center justify-center font-mono text-xs uppercase tracking-widest text-muted-foreground">
+                      no embodiment
+                    </div>
+                  );
+                })()}
                 <span className="absolute bottom-2 left-0 right-0 text-center font-mono text-[10px] uppercase tracking-[0.22em] text-muted-foreground/80">
                   {lang.fields.name ?? "side"}
                 </span>

--- a/ui/src/app/(site)/language/[id]/DESIGN.md/route.ts
+++ b/ui/src/app/(site)/language/[id]/DESIGN.md/route.ts
@@ -39,12 +39,23 @@ export async function GET(
 
   const f = lang.fields;
   const filename = f.slug ? `${f.slug}-DESIGN.md` : "DESIGN.md";
+  const isPublished = lang.status === "Published";
   const storedDesignMdStatus =
     lang.booleans?.has_valid_design_md && lang.booleans?.design_md_verified
       ? "validated"
       : "stored-unverified";
 
-  if (f.design_md_file_id) {
+  if (isPublished && f.design_md_asset_url) {
+    return NextResponse.redirect(f.design_md_asset_url, {
+      status: 307,
+      headers: {
+        "cache-control": "public, max-age=60, s-maxage=300",
+        "x-katagami-design-md-status": "public-artifact",
+      },
+    });
+  }
+
+  if (!isPublished && f.design_md_file_id) {
     const stored = await readStoredFile(f.design_md_file_id);
     if (stored) {
       return new NextResponse(stored, {
@@ -77,7 +88,9 @@ export async function GET(
       "content-type": "text/markdown; charset=utf-8",
       "content-disposition": `inline; filename="${filename}"`,
       "cache-control": "public, max-age=60, s-maxage=300",
-      "x-katagami-design-md-status": "generated-preview",
+      "x-katagami-design-md-status": isPublished
+        ? "missing-public-artifact-generated-preview"
+        : "generated-preview",
     },
   });
 }

--- a/ui/src/app/(site)/language/[id]/page.tsx
+++ b/ui/src/app/(site)/language/[id]/page.tsx
@@ -81,6 +81,13 @@ export default async function LanguageDetailPage({
 
   const accent = statusColor[lang.status] ?? "teal";
   const name = f.name || "Untitled";
+  const isPublished = lang.status === "Published";
+  const embodimentFileId = isPublished ? undefined : f.embodiment_file_id;
+  const embodimentSrc = f.embodiment_asset_url;
+  const canRenderEmbodiment = Boolean(
+    (embodimentSrc || embodimentFileId) &&
+      (f.embodiment_format ?? "html") !== "tsx",
+  );
   const specProps = {
     languageId: id,
     name,
@@ -163,8 +170,7 @@ export default async function LanguageDetailPage({
             <SectionHeading eyebrow="in the wild" eyebrowColor="sakura">
               <Marker color="salad">design embodiment</Marker>
             </SectionHeading>
-            {f.embodiment_file_id &&
-            (f.embodiment_format ?? "html") !== "tsx" ? (
+            {canRenderEmbodiment ? (
               <div className="relative">
                 <WashiTape
                   color="sakura"
@@ -180,8 +186,8 @@ export default async function LanguageDetailPage({
                 />
                 <div className="relative rounded-[2px] border border-border bg-card p-3 pb-10 shadow-[0_4px_16px_rgba(30,35,45,0.08)]">
                   <EmbodimentViewer
-                    fileId={f.embodiment_file_id}
-                    src={f.embodiment_asset_url}
+                    fileId={embodimentFileId}
+                    src={embodimentSrc}
                   />
                   <span className="absolute bottom-3 left-0 right-0 text-center font-mono text-[10px] uppercase tracking-[0.22em] text-muted-foreground/80">
                     preview · {f.slug || id.slice(0, 12)}
@@ -195,7 +201,9 @@ export default async function LanguageDetailPage({
             ) : (
               <StickyNote className="flex items-center justify-center p-16 text-center font-mono text-sm text-muted-foreground">
                 {f.embodiment_file_id
-                  ? "tsx preview is not rendered — view the spec for details"
+                  ? isPublished && !embodimentSrc
+                    ? "public embodiment is still publishing"
+                    : "tsx preview is not rendered — view the spec for details"
                   : "no embodiment or tokens defined yet"}
               </StickyNote>
             )}

--- a/ui/src/app/(site)/page.tsx
+++ b/ui/src/app/(site)/page.tsx
@@ -4,64 +4,29 @@ import {
   DESIGN_LANGUAGE_GALLERY_FIELDS,
   listDesignLanguages,
   listTaxonomies,
-  parseJson,
 } from "@/lib/odata";
-import { GalleryFilters } from "@/components/gallery-filters";
 import { LanguageGallery } from "@/components/language-gallery";
 import { isOwner } from "@/lib/owner";
-
-function parseMaybeJson(value: unknown): unknown {
-  if (typeof value !== "string") return value;
-  return parseJson<unknown>(value) ?? value;
-}
-
-function searchText(value: unknown): string {
-  const parsed = parseMaybeJson(value);
-  if (parsed === null || parsed === undefined) return "";
-  if (typeof parsed === "string") return parsed;
-  if (typeof parsed === "number" || typeof parsed === "boolean") {
-    return String(parsed);
-  }
-  if (Array.isArray(parsed)) return parsed.map(searchText).join(" ");
-  if (typeof parsed === "object") {
-    return Object.values(parsed).map(searchText).join(" ");
-  }
-  return "";
-}
-
-function listFieldIncludes(value: unknown, expected: string): boolean {
-  const parsed = parseMaybeJson(value);
-  if (Array.isArray(parsed)) {
-    return parsed.some((item) => String(item) === expected);
-  }
-  return searchText(parsed).includes(expected);
-}
 
 async function GalleryGrid({
   status,
   taxonomy,
   search,
   demo,
+  taxonomies,
 }: {
   status?: string;
   taxonomy?: string;
   search?: string;
   demo?: boolean;
+  taxonomies: { entity_id: string; fields: { name?: string } }[];
 }) {
   const canDelete = demo ? false : await isOwner();
-  let filter: string | undefined;
-  if (status === "all") {
-    filter = `Status ne 'Archived'`;
-  } else if (status) {
-    filter = `Status eq '${status}'`;
-  } else {
-    filter = `Status eq 'Published'`;
-  }
 
   let languages: Awaited<ReturnType<typeof listDesignLanguages>>;
   try {
     languages = await listDesignLanguages(
-      filter,
+      undefined,
       undefined,
       DESIGN_LANGUAGE_GALLERY_FIELDS,
     );
@@ -76,24 +41,6 @@ async function GalleryGrid({
 
   // Filter out empty drafts (no name set = incomplete/abandoned)
   languages = languages.filter((l) => l.fields.name);
-
-  // Client-side filters for taxonomy and search (OData filter on JSON fields
-  // is not yet reliable in Temper)
-  if (taxonomy && taxonomy !== "all") {
-    languages = languages.filter((l) => {
-      const fields = l.fields as Record<string, unknown>;
-      return listFieldIncludes(fields.taxonomy_ids, taxonomy);
-    });
-  }
-  const normalizedSearch = search?.trim().toLowerCase();
-  if (normalizedSearch) {
-    languages = languages.filter((l) => {
-      const fields = l.fields as Record<string, unknown>;
-      const name = searchText(fields.name).toLowerCase();
-      const tags = searchText(fields.tags).toLowerCase();
-      return name.includes(normalizedSearch) || tags.includes(normalizedSearch);
-    });
-  }
 
   if (languages.length === 0) {
     return (
@@ -194,7 +141,18 @@ async function GalleryGrid({
     return a.entity_id.localeCompare(b.entity_id);
   });
 
-  return <LanguageGallery languages={languages} canDelete={canDelete} />;
+  return (
+    <LanguageGallery
+      languages={languages}
+      canDelete={canDelete}
+      taxonomies={taxonomies}
+      initialFilters={{
+        status: status ?? "Published",
+        taxonomy: taxonomy ?? "all",
+        search: search ?? "",
+      }}
+    />
+  );
 }
 
 export default async function GalleryPage({
@@ -707,7 +665,6 @@ export default async function GalleryPage({
           </div>
           <span className="stamp text-[var(--salad)]">details inside</span>
         </div>
-        <GalleryFilters taxonomies={taxonomies} />
       </section>
 
       <Suspense
@@ -727,6 +684,7 @@ export default async function GalleryPage({
           taxonomy={sp.taxonomy}
           search={sp.q}
           demo={demo}
+          taxonomies={taxonomies}
         />
       </Suspense>
     </div>

--- a/ui/src/app/api/file/[id]/route.ts
+++ b/ui/src/app/api/file/[id]/route.ts
@@ -3,11 +3,10 @@ import { NextRequest, NextResponse } from "next/server";
 const API_BASE = process.env.NEXT_PUBLIC_TEMPER_API_URL || "http://localhost:3500";
 const TENANT = process.env.NEXT_PUBLIC_TEMPER_TENANT || "default";
 const API_KEY = process.env.TEMPER_API_KEY || "";
-const DEFAULT_CACHE_CONTROL = "public, max-age=3600";
-const IMAGE_BROWSER_CACHE_CONTROL =
-  "public, max-age=86400, stale-while-revalidate=604800";
-const IMAGE_VERCEL_CACHE_CONTROL =
-  "public, max-age=86400, stale-while-revalidate=604800";
+const ASSET_BROWSER_CACHE_CONTROL =
+  "public, max-age=3600, stale-while-revalidate=86400";
+const ASSET_CDN_CACHE_CONTROL =
+  "public, s-maxage=86400, stale-while-revalidate=604800";
 
 function decodeBase64ImageValue(
   bytes: ArrayBuffer,
@@ -71,19 +70,15 @@ export async function GET(
   }
 
   const contentType = res.headers.get("content-type") || "text/html";
-  const isImage = contentType.startsWith("image/");
   const upstreamBody = await res.arrayBuffer();
   const body = decodeBase64ImageValue(upstreamBody, contentType);
   const responseHeaders = new Headers({
     "Content-Type": contentType,
-    "Cache-Control": isImage
-      ? IMAGE_BROWSER_CACHE_CONTROL
-      : DEFAULT_CACHE_CONTROL,
+    "Cache-Control": ASSET_BROWSER_CACHE_CONTROL,
+    "CDN-Cache-Control": ASSET_CDN_CACHE_CONTROL,
+    "Vercel-CDN-Cache-Control": ASSET_CDN_CACHE_CONTROL,
   });
   responseHeaders.set("Content-Length", String(body.byteLength));
-  if (isImage) {
-    responseHeaders.set("Vercel-CDN-Cache-Control", IMAGE_VERCEL_CACHE_CONTROL);
-  }
 
   return new NextResponse(body, {
     headers: responseHeaders,

--- a/ui/src/app/radix-test/page.tsx
+++ b/ui/src/app/radix-test/page.tsx
@@ -101,7 +101,7 @@ export default function RadixTestPage() {
           </div>
 
           <span className="text-xs text-muted-foreground ml-auto">
-            {source === "agent" ? "Agent-generated (OpenPaw + gpt-5.4)" : "Manually crafted"} Radix embodiments
+            {source === "agent" ? "Agent-generated (temperpaw + gpt-5.4)" : "Manually crafted"} Radix embodiments
           </span>
         </div>
       </div>

--- a/ui/src/components/embodiment-viewer.tsx
+++ b/ui/src/components/embodiment-viewer.tsx
@@ -53,12 +53,13 @@ export function EmbodimentViewer({
   fileId,
   src,
 }: {
-  fileId: string;
+  fileId?: string;
   src?: string;
 }) {
   // Auto-render the safety-patched preview by default. The srcdoc
   // injection caps layout from first paint, so mounting is safe.
-  const url = src ?? getFileUrl(fileId);
+  const url = src ?? (fileId ? getFileUrl(fileId) : "");
+  if (!url) return <UnavailablePreview />;
   return <SafePreview url={url} />;
 }
 
@@ -149,14 +150,7 @@ function SafePreview({ url }: { url: string }) {
   }
 
   if (status === "failed") {
-    return (
-      <div
-        className="flex w-full items-center justify-center border border-dashed border-border bg-muted text-center font-mono text-xs uppercase tracking-[0.22em] text-muted-foreground"
-        style={{ aspectRatio: `${VIEWPORT_WIDTH} / ${DEFAULT_HEIGHT}` }}
-      >
-        embodiment not available
-      </div>
-    );
+    return <UnavailablePreview />;
   }
 
   const scaledHeight = contentHeight * scale;
@@ -194,6 +188,17 @@ function SafePreview({ url }: { url: string }) {
         <span className="sm:hidden">full</span>
         <ExternalLink className="h-3 w-3" />
       </a>
+    </div>
+  );
+}
+
+function UnavailablePreview() {
+  return (
+    <div
+      className="flex w-full items-center justify-center border border-dashed border-border bg-muted text-center font-mono text-xs uppercase tracking-[0.22em] text-muted-foreground"
+      style={{ aspectRatio: `${VIEWPORT_WIDTH} / ${DEFAULT_HEIGHT}` }}
+    >
+      embodiment not available
     </div>
   );
 }

--- a/ui/src/components/embodiments/kukan-press-agent.tsx
+++ b/ui/src/components/embodiments/kukan-press-agent.tsx
@@ -711,7 +711,7 @@ function KukanPressGrid() {
             <div className="scheduleHeader">
               <div>
                 <div className="kicker">Desk schedule / by district</div>
-                <h3>Tonight's field log</h3>
+                <h3>Tonight&rsquo;s field log</h3>
               </div>
               <span className="metaText">{activeDistrict.line}</span>
             </div>

--- a/ui/src/components/embodiments/neo-kawaii-tech.tsx
+++ b/ui/src/components/embodiments/neo-kawaii-tech.tsx
@@ -1274,7 +1274,7 @@ export function NeoKawaiiTech() {
                         <div className="type-caption">Body / Inter or system-ui</div>
                       </div>
                       <div className="type-sample code-sample">
-                        const glow = \"pink + blue + blur(24px)\";
+                        const glow = &quot;pink + blue + blur(24px)&quot;;
                         <div className="type-caption">Code / JetBrains Mono</div>
                       </div>
                     </div>

--- a/ui/src/components/gallery-filters.tsx
+++ b/ui/src/components/gallery-filters.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
 import { Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import {
@@ -17,41 +16,74 @@ const fieldBase =
 
 export function GalleryFilters({
   taxonomies,
+  initialStatus = "Published",
+  initialTaxonomy = "all",
+  initialSearch = "",
 }: {
   taxonomies: { entity_id: string; fields: { name?: string } }[];
+  initialStatus?: string;
+  initialTaxonomy?: string;
+  initialSearch?: string;
 }) {
-  const router = useRouter();
-  const searchParams = useSearchParams();
+  const [status, setStatus] = useState(initialStatus);
+  const [taxonomy, setTaxonomy] = useState(initialTaxonomy);
+  const [search, setSearch] = useState(initialSearch);
 
-  const [status, setStatus] = useState(
-    searchParams.get("status") ?? "Published",
-  );
-  const [taxonomy, setTaxonomy] = useState(
-    searchParams.get("taxonomy") ?? "all",
-  );
-  const [search, setSearch] = useState(searchParams.get("q") ?? "");
+  const applyFilters = useCallback(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+    const cards = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-gallery-card]"),
+    );
+    let visibleCount = 0;
 
-  const navigate = useCallback(
-    (key: string, value: string) => {
-      const params = new URLSearchParams(searchParams.toString());
-      if (key === "status") {
-        if (value && value !== "Published") {
-          params.set(key, value);
-        } else {
-          params.delete(key);
-        }
-        router.push(`/?${params.toString()}`);
-        return;
-      }
-      if (value && value !== "all") {
-        params.set(key, value);
+    for (const card of cards) {
+      const cardStatus = card.dataset.status ?? "";
+      const cardTaxonomies = (card.dataset.taxonomyIds ?? "")
+        .split("\t")
+        .filter(Boolean);
+      const cardSearch = card.dataset.searchText ?? "";
+      const matchesStatus = status === "all" || cardStatus === status;
+      const matchesTaxonomy =
+        taxonomy === "all" || cardTaxonomies.includes(taxonomy);
+      const matchesSearch =
+        !normalizedSearch || cardSearch.includes(normalizedSearch);
+      const visible = matchesStatus && matchesTaxonomy && matchesSearch;
+      card.hidden = !visible;
+      if (visible) visibleCount += 1;
+    }
+
+    const empty = document.querySelector<HTMLElement>("[data-gallery-empty]");
+    if (empty) empty.hidden = visibleCount > 0;
+  }, [status, taxonomy, search]);
+
+  useEffect(() => {
+    applyFilters();
+  }, [applyFilters]);
+
+  useEffect(() => {
+    const handle = window.setTimeout(() => {
+      const params = new URLSearchParams(window.location.search);
+      if (status && status !== "Published") {
+        params.set("status", status);
       } else {
-        params.delete(key);
+        params.delete("status");
       }
-      router.push(`/?${params.toString()}`);
-    },
-    [router, searchParams],
-  );
+      if (taxonomy && taxonomy !== "all") {
+        params.set("taxonomy", taxonomy);
+      } else {
+        params.delete("taxonomy");
+      }
+      if (search.trim()) {
+        params.set("q", search.trim());
+      } else {
+        params.delete("q");
+      }
+      const query = params.toString();
+      const next = `${window.location.pathname}${query ? `?${query}` : ""}${window.location.hash}`;
+      window.history.replaceState(null, "", next);
+    }, 180);
+    return () => window.clearTimeout(handle);
+  }, [status, taxonomy, search]);
 
   return (
     <div className="relative flex flex-wrap items-center gap-x-5 gap-y-3 bg-card/65 px-5 py-4 shadow-[0_1px_2px_rgba(30,35,45,0.04),0_4px_14px_rgba(30,35,45,0.05)] backdrop-blur-[4px]">
@@ -87,7 +119,6 @@ export function GalleryFilters({
           value={search}
           onChange={(e) => {
             setSearch(e.target.value);
-            navigate("q", e.target.value);
           }}
         />
       </div>
@@ -100,7 +131,6 @@ export function GalleryFilters({
           onValueChange={(v) => {
             const next = v ?? "all";
             setStatus(next);
-            navigate("status", next);
           }}
         >
           <SelectTrigger className={`${fieldBase} h-8 w-32 gap-2 sm:w-36`}>
@@ -123,7 +153,6 @@ export function GalleryFilters({
               onValueChange={(v) => {
                 const next = v ?? "all";
                 setTaxonomy(next);
-                navigate("taxonomy", next);
               }}
             >
               <SelectTrigger className={`${fieldBase} h-8 w-36 gap-2 sm:w-40`}>

--- a/ui/src/components/language-card.tsx
+++ b/ui/src/components/language-card.tsx
@@ -190,6 +190,7 @@ function FullCard({
   const summary = compactSummary(philosophy?.summary);
   const embodimentFormat = (f.embodiment_format as "html" | "tsx") ?? "html";
   const thumbnailFileId = f.thumbnail_file_id;
+  const thumbnailAssetUrl = f.thumbnail_asset_url;
 
   const tapeColor = tapeTintFor(paletteColors, id);
   const tapeRot = ((hashInt(id, "ra") % 11) - 5) * 0.55 - 3;
@@ -235,9 +236,10 @@ function FullCard({
               className="relative w-full overflow-hidden rounded-[1px] bg-muted"
               style={{ aspectRatio: "3 / 2" }}
             >
-              {thumbnailFileId ? (
+              {thumbnailFileId || thumbnailAssetUrl ? (
                 <ThumbnailPreview
                   fileId={thumbnailFileId}
+                  src={thumbnailAssetUrl}
                   alt={`${f.name || "Design language"} preview`}
                   eager={eagerThumbnail}
                   placeholderTint={stickyTint}

--- a/ui/src/components/language-card.tsx
+++ b/ui/src/components/language-card.tsx
@@ -191,6 +191,9 @@ function FullCard({
   const embodimentFormat = (f.embodiment_format as "html" | "tsx") ?? "html";
   const thumbnailFileId = f.thumbnail_file_id;
   const thumbnailAssetUrl = f.thumbnail_asset_url;
+  const isPublished = lang.status === "Published";
+  const thumbnailProxyFileId = isPublished ? undefined : thumbnailFileId;
+  const hasThumbnailPreview = Boolean(thumbnailAssetUrl || thumbnailProxyFileId);
 
   const tapeColor = tapeTintFor(paletteColors, id);
   const tapeRot = ((hashInt(id, "ra") % 11) - 5) * 0.55 - 3;
@@ -236,9 +239,9 @@ function FullCard({
               className="relative w-full overflow-hidden rounded-[1px] bg-muted"
               style={{ aspectRatio: "3 / 2" }}
             >
-              {thumbnailFileId || thumbnailAssetUrl ? (
+              {hasThumbnailPreview ? (
                 <ThumbnailPreview
-                  fileId={thumbnailFileId}
+                  fileId={thumbnailProxyFileId}
                   src={thumbnailAssetUrl}
                   alt={`${f.name || "Design language"} preview`}
                   eager={eagerThumbnail}

--- a/ui/src/components/language-gallery.tsx
+++ b/ui/src/components/language-gallery.tsx
@@ -1,23 +1,126 @@
 import type { DesignLanguage } from "@/lib/odata";
 import { LanguageCard } from "@/components/language-card";
+import { GalleryFilters } from "@/components/gallery-filters";
 
 export function LanguageGallery({
   languages,
   canDelete,
+  taxonomies = [],
+  initialFilters,
 }: {
   languages: DesignLanguage[];
   canDelete: boolean;
+  taxonomies?: { entity_id: string; fields: { name?: string } }[];
+  initialFilters?: {
+    status?: string;
+    taxonomy?: string;
+    search?: string;
+  };
 }) {
+  const filters = {
+    status: initialFilters?.status ?? "Published",
+    taxonomy: initialFilters?.taxonomy ?? "all",
+    search: initialFilters?.search ?? "",
+  };
+
   return (
-    <div className="grid gap-7 sm:grid-cols-2 lg:grid-cols-3">
-      {languages.map((lang, index) => (
-        <LanguageCard
-          key={lang.entity_id}
-          lang={lang}
-          index={index}
-          canDelete={canDelete}
-        />
-      ))}
-    </div>
+    <>
+      <GalleryFilters
+        taxonomies={taxonomies}
+        initialStatus={filters.status}
+        initialTaxonomy={filters.taxonomy}
+        initialSearch={filters.search}
+      />
+
+      <div className="grid gap-7 sm:grid-cols-2 lg:grid-cols-3">
+        {languages.map((lang, index) => {
+          const attrs = galleryCardAttributes(lang);
+          return (
+            <div
+              key={lang.entity_id}
+              data-gallery-card
+              data-status={attrs.status}
+              data-taxonomy-ids={attrs.taxonomyIds}
+              data-search-text={attrs.searchText}
+              hidden={!matchesFilters(attrs, filters)}
+            >
+              <LanguageCard
+                lang={lang}
+                index={index}
+                canDelete={canDelete}
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      <div
+        data-gallery-empty
+        hidden={languages.some((lang) =>
+          matchesFilters(galleryCardAttributes(lang), filters),
+        )}
+        className="paper-card mx-auto max-w-md rounded-[var(--radius-lg)] p-8 text-center text-sm text-muted-foreground"
+      >
+        No design languages found.
+        <div className="mt-1 font-mono text-[11px]">
+          adjust the gallery filters
+        </div>
+      </div>
+    </>
   );
+}
+
+function galleryCardAttributes(lang: DesignLanguage) {
+  const fields = lang.fields as Record<string, unknown>;
+  const taxonomyIds = listFieldValues(fields.taxonomy_ids).join("\t");
+  const searchText = [fields.name, fields.tags]
+    .map(searchTextFromValue)
+    .join(" ")
+    .toLowerCase();
+  return {
+    status: lang.status,
+    taxonomyIds,
+    searchText,
+  };
+}
+
+function matchesFilters(
+  attrs: ReturnType<typeof galleryCardAttributes>,
+  filters: { status: string; taxonomy: string; search: string },
+) {
+  const matchesStatus = filters.status === "all" || attrs.status === filters.status;
+  const matchesTaxonomy =
+    filters.taxonomy === "all" ||
+    attrs.taxonomyIds.split("\t").includes(filters.taxonomy);
+  const query = filters.search.trim().toLowerCase();
+  const matchesSearch = !query || attrs.searchText.includes(query);
+  return matchesStatus && matchesTaxonomy && matchesSearch;
+}
+
+function parseMaybeJson(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function listFieldValues(value: unknown): string[] {
+  const parsed = parseMaybeJson(value);
+  if (Array.isArray(parsed)) return parsed.map((item) => String(item));
+  if (typeof parsed === "string" && parsed.trim()) return [parsed.trim()];
+  return [];
+}
+
+function searchTextFromValue(value: unknown): string {
+  const parsed = parseMaybeJson(value);
+  if (parsed === null || parsed === undefined) return "";
+  if (typeof parsed === "string") return parsed;
+  if (typeof parsed === "number" || typeof parsed === "boolean") return String(parsed);
+  if (Array.isArray(parsed)) return parsed.map(searchTextFromValue).join(" ");
+  if (typeof parsed === "object") {
+    return Object.values(parsed).map(searchTextFromValue).join(" ");
+  }
+  return "";
 }

--- a/ui/src/components/safe-embodiment-frame.tsx
+++ b/ui/src/components/safe-embodiment-frame.tsx
@@ -68,11 +68,16 @@ export function SafeEmbodimentFrame({
   );
 
   useEffect(() => {
-    if (patchedCache.has(fileId)) {
-      setSrcDoc(patchedCache.get(fileId)!);
-      return;
-    }
     let cancelled = false;
+    const cached = patchedCache.get(fileId);
+    if (cached !== undefined) {
+      queueMicrotask(() => {
+        if (!cancelled) setSrcDoc(cached);
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
     fetch(url)
       .then((r) => (r.ok ? r.text() : Promise.reject()))
       .then((html) => {

--- a/ui/src/components/thumbnail-preview.tsx
+++ b/ui/src/components/thumbnail-preview.tsx
@@ -236,8 +236,8 @@ export function ThumbnailPreview({
           placeholderTint={placeholderTint}
         />
       ) : (
-        // Direct file-proxy delivery is intentional: thumbnail_file_id already
-        // points at a generated, card-sized PawFS image.
+        // Published cards pass immutable asset URLs; file ids are reserved for
+        // draft/admin previews where governed file access is still expected.
         // eslint-disable-next-line @next/next/no-img-element
         <img
           src={src}

--- a/ui/src/components/thumbnail-preview.tsx
+++ b/ui/src/components/thumbnail-preview.tsx
@@ -151,12 +151,14 @@ function getThumbnailPreloadObserver(): IntersectionObserver | null {
 
 export function ThumbnailPreview({
   fileId,
+  src: assetSrc,
   alt,
   placeholderTint,
   paletteColors = [],
   eager = false,
 }: {
-  fileId: string;
+  fileId?: string;
+  src?: string;
   alt: string;
   placeholderTint: string;
   paletteColors?: string[];
@@ -167,9 +169,10 @@ export function ThumbnailPreview({
   const queuedRef = useRef(false);
   const [shouldLoad, setShouldLoad] = useState(eager);
   const [failed, setFailed] = useState(false);
-  const src = getFileUrl(fileId);
+  const src = assetSrc ?? (fileId ? getFileUrl(fileId) : "");
 
   useEffect(() => {
+    if (!src) return;
     if (eager) return;
     const el = rootRef.current;
     const observer = getThumbnailPreloadObserver();
@@ -193,6 +196,7 @@ export function ThumbnailPreview({
   }, [eager, src]);
 
   useEffect(() => {
+    if (!src) return;
     if (eager) return;
     const el = rootRef.current;
     const observer = getThumbnailObserver();
@@ -217,7 +221,7 @@ export function ThumbnailPreview({
       loadTicketRef.current?.cancel();
       loadTicketRef.current = null;
     };
-  }, [eager]);
+  }, [eager, src]);
 
   const finishThumbnailLoad = () => {
     loadTicketRef.current?.finish();
@@ -226,7 +230,7 @@ export function ThumbnailPreview({
 
   return (
     <div ref={rootRef} className="absolute inset-0">
-      {failed || !shouldLoad ? (
+      {failed || !shouldLoad || !src ? (
         <ThumbnailPlaceholder
           paletteColors={paletteColors}
           placeholderTint={placeholderTint}
@@ -245,7 +249,7 @@ export function ThumbnailPreview({
           fetchPriority={eager ? "high" : "low"}
           className="absolute inset-0 h-full w-full object-cover"
           data-katagami-thumbnail="true"
-          data-file-id={fileId}
+          data-file-id={fileId ?? undefined}
           onLoad={() => {
             preloadedUrls.add(src);
             finishThumbnailLoad();

--- a/ui/src/lib/odata.ts
+++ b/ui/src/lib/odata.ts
@@ -86,6 +86,8 @@ export interface DesignLanguage {
     imagery_direction?: string;
     generative_canvas?: string;
     design_md_file_id?: string;
+    design_md_asset_url?: string;
+    design_md_asset_id?: string;
     design_md_lint_result?: string;
     design_md_format_version?: string;
     embodiment_file_id?: string;
@@ -153,6 +155,7 @@ export const DESIGN_LANGUAGE_GALLERY_FIELDS = [
   "has_design_md",
   "has_valid_design_md",
   "design_md_verified",
+  "has_published_assets",
   "CreatedAt",
   "UpdatedAt",
   "PublishedAt",
@@ -171,6 +174,7 @@ const FLAT_BOOLEAN_KEYS = new Set([
   "has_design_md",
   "has_valid_design_md",
   "design_md_verified",
+  "has_published_assets",
   "quality_review_passed",
 ]);
 // Counters used for sort/badge/usage:

--- a/ui/src/lib/odata.ts
+++ b/ui/src/lib/odata.ts
@@ -1,7 +1,7 @@
 const API_BASE = process.env.NEXT_PUBLIC_TEMPER_API_URL || "http://localhost:3500";
 const TENANT = process.env.NEXT_PUBLIC_TEMPER_TENANT || "default";
 const API_KEY = process.env.TEMPER_API_KEY || "";
-const FILE_PROXY_CACHE_VERSION = "thumbnail-binary-2026-05-08";
+const FILE_PROXY_CACHE_VERSION = "asset-cdn-v2";
 
 interface ODataResponse<T> {
   value: T[];
@@ -89,7 +89,11 @@ export interface DesignLanguage {
     design_md_lint_result?: string;
     design_md_format_version?: string;
     embodiment_file_id?: string;
+    embodiment_asset_url?: string;
+    embodiment_asset_id?: string;
     thumbnail_file_id?: string;
+    thumbnail_asset_url?: string;
+    thumbnail_asset_id?: string;
     parent_ids?: string;
     lineage_type?: string;
     generation_number?: string;
@@ -126,10 +130,14 @@ export const DESIGN_LANGUAGE_GALLERY_FIELDS = [
   "slug",
   "name",
   "embodiment_file_id",
+  "embodiment_asset_url",
+  "embodiment_asset_id",
   "embodiment_format",
   "embodiment_verified",
   "has_embodiment",
   "thumbnail_file_id",
+  "thumbnail_asset_url",
+  "thumbnail_asset_id",
   "has_thumbnail",
   "thumbnail_verified",
   "taxonomy_ids",

--- a/ui/src/lib/tsx-runtime.ts
+++ b/ui/src/lib/tsx-runtime.ts
@@ -78,16 +78,19 @@ const lucideIconProxy = new Proxy(
   {
     get: () =>
       (props: Record<string, unknown>) =>
-        React.createElement("svg", {
-          ...props,
-          width: 16,
-          height: 16,
-          viewBox: "0 0 24 24",
-          fill: "none",
-          stroke: "currentColor",
-          strokeWidth: 2,
-          children: React.createElement("circle", { cx: 12, cy: 12, r: 4 }),
-        }),
+        React.createElement(
+          "svg",
+          {
+            ...props,
+            width: 16,
+            height: 16,
+            viewBox: "0 0 24 24",
+            fill: "none",
+            stroke: "currentColor",
+            strokeWidth: 2,
+          },
+          React.createElement("circle", { cx: 12, cy: 12, r: 4 }),
+        ),
   },
 );
 
@@ -221,7 +224,6 @@ export async function compileTsx(
 `;
 
   // Step 4: Evaluate using Function constructor (safer than eval, same CSP requirements)
-  // eslint-disable-next-line no-new-func
   const factory = new Function("return " + wrappedCode)();
   // For unknown modules, return a Proxy so any named/default import still
   // resolves to *something* — a noop function that returns null React element.

--- a/ui/src/lib/use-theme.ts
+++ b/ui/src/lib/use-theme.ts
@@ -16,8 +16,11 @@ export function useTheme() {
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
-    setTheme(readInitial());
-    setMounted(true);
+    const frame = window.requestAnimationFrame(() => {
+      setTheme(readInitial());
+      setMounted(true);
+    });
+    return () => window.cancelAnimationFrame(frame);
   }, []);
 
   const apply = useCallback((next: Theme) => {


### PR DESCRIPTION
## Summary
- switch published Katagami cards/detail/DESIGN.md reads to immutable generic Temper public artifact URLs, with draft/admin file reads preserved
- require thumbnail, embodiment, and DESIGN.md artifacts before Publish so public pages do not fall back to governed file value reads
- move gallery filtering client-side to avoid OData refetches for front-page filter changes
- update backfill/deploy docs and Cloudflare worker binding for the separate public artifact bucket

## Verification
- python3 -m unittest discover katagami-curation/tests
- cargo test --manifest-path katagami-curation/wasm/finalize_spawned_session/Cargo.toml
- npm run test:gallery
- npm run lint (passes with 12 existing warnings)
- npm run build
- local browser check: published gallery filter updates visibility without navigation/refetch