### PR TITLE
Publish Katagami app syncs through Genesis latest

### DIFF
--- a/katagami-commons/APP.md
+++ b/katagami-commons/APP.md
@@ -1,6 +1,8 @@
 # katagami-commons
 
-Core data layer for the Katagami Design Language Commons. Stores design languages, design elements, design sources, taxonomy, and the element manifest.
+Core data layer for the Katagami Design Language Commons. Stores design
+languages, palette systems, art styles, design elements, design sources,
+taxonomy, and the element manifest.
 
 ## Entity Types
 
@@ -27,6 +29,22 @@ does not block on governed file writes.
 
 **States:** `Submitted` -> `Indexed` | `Failed`
 
+### PaletteSystem
+
+A portable color system for remix lanes. Stores signature colors, neutral and
+semantic roles, proof scenes, token projections, usage guidance, source links,
+thumbnail evidence, and publication verification flags.
+
+**States:** `Draft` -> `UnderReview` -> `Published` -> `Archived`
+
+### ArtStyle
+
+A portable image-style recipe for remix lanes. Stores medium, prompt template
+with `{subject}` and `{palette}` holes, negative prompt, engine hints, slot
+recipes, usage guidance, preview evidence, and publication verification flags.
+
+**States:** `Draft` -> `UnderReview` -> `Published` -> `Archived`
+
 ### ElementManifest
 
 Defines the canonical set of ~75 UI elements that every design language must render. Versioned and evolvable.
@@ -52,4 +70,8 @@ until a later archival step creates a governed artifact.
 
 ## Integration with katagami-curation
 
-DesignSources are created by bootstrap agent `source_search` jobs. DesignLanguages are synthesized by `synthesize` jobs. Quality reviews are handled by curator agent `review` jobs.
+DesignSources are created by bootstrap agent `source_search` jobs.
+DesignLanguages are synthesized by `synthesize` jobs and quality-reviewed before
+taxonomy organization. Multi-lane remix jobs use `synthesize_palette` to publish
+PaletteSystem records and `synthesize_art_style` to publish ArtStyle records as
+terminal lanes after deterministic finalizer verification.

--- a/katagami-commons/app.toml
+++ b/katagami-commons/app.toml
@@ -1,5 +1,5 @@
 name = "katagami-commons"
-description = "Design Language Commons — core data layer for versioned, agent-maintained design languages with canonical UI element coverage."
+description = "Design Language Commons — core data layer for versioned, agent-maintained design languages, palette systems, art styles, and canonical UI element coverage."
 version = "0.1.0"
 startup_install = "core"
 dependencies = ["temperpaw/paw-fs@65f3ee9659500d11a54c22b9e5519d52dd0db1d4"]

--- a/katagami-curation/APP.md
+++ b/katagami-curation/APP.md
@@ -17,6 +17,8 @@ declared as Temper reactions.
 **Job Types:**
 - `source_search` — Research design movements and index compact authoritative source metadata
 - `synthesize` — Create DesignLanguage specs with embodiments and first-class shadcn/ui component artifacts
+- `synthesize_palette` — Create one PaletteSystem lane with signature colors, proof scenes, portable tokens, usage guidance, thumbnail evidence, and deterministic finalizer checks
+- `synthesize_art_style` — Create one ArtStyle lane with subject/palette prompt holes, negative prompts, engine hints, slot recipes, guidance, and preview evidence
 - `quality_review` — Validate DESIGN.md, derive shadcn/ui export, author/verify shadcn/ui component recipes and preview shots, fix embodiment fidelity against the spec, then publish
 - `organize_taxonomy` — Taxonomy maintenance and cross-referencing
 - `regenerate_embodiment` — Rebuild embodiment HTML for an existing language
@@ -74,6 +76,18 @@ belongs in a later artifact step.
 ## Pipeline
 
 `source_search` -> `CurationDirection` fan-out -> `synthesize` -> `quality_review` -> `organize_taxonomy` -> Completed
+
+Multi-lane remix work can also fan out into terminal palette and art-style
+lanes:
+
+`source_search` -> `synthesize_palette` -> `CompletePaletteSynthesis` -> Completed
+
+`source_search` -> `synthesize_art_style` -> `CompleteArtStyleSynthesis` -> Completed
+
+Palette and art-style lanes publish their commons entities directly after the
+finalizer verifies required files, contrast/prompt contracts, and referenced
+entity closure. They intentionally do not enter the language quality-review or
+taxonomy cascade.
 
 Each job spawns an agent session through a small WASM runtime bridge.
 `build_session_message` reads `CurationJobTemplate` records, loads the

--- a/katagami-curation/app.toml
+++ b/katagami-curation/app.toml
@@ -1,12 +1,12 @@
 name = "katagami-curation"
-description = "Agent work layer for katagami — CurationJob queue, curator sessions, CurationDirection fan-out, and template-owned curation pipeline."
+description = "Agent work layer for katagami — CurationJob queue, curator sessions, CurationDirection fan-out, and multi-lane language, palette, and art-style curation."
 version = "0.1.0"
 startup_install = "core"
 dependencies = [
   "temperpaw/paw-fs@65f3ee9659500d11a54c22b9e5519d52dd0db1d4",
   "temperpaw/paw-agent@65fbd22270e4bf7304de2d9b6895a465c332d602",
   "temperpaw/paw-research@910d01612b2632362fb5f537c4357a5fb6c7bcdd",
-  "katagami/katagami-commons@8d646d6de43670f04f00151271ddfe480ac04695",
+  "katagami/katagami-commons@9fb0622f3caa7a6d885856f233e42410fc19f3fc",
 ]
 
 # These declarations are REQUIRED — the installer only uploads WASM

--- a/katagami-curation/tests/test_genesis_source_contract.py
+++ b/katagami-curation/tests/test_genesis_source_contract.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+import tomllib
+import unittest
+
+
+CURATION_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = CURATION_ROOT.parent
+CURRENT_COMMONS_HASH = "9fb0622f3caa7a6d885856f233e42410fc19f3fc"
+
+
+class GenesisSourceContractTest(unittest.TestCase):
+    def test_curation_depends_on_current_genesis_commons(self):
+        app = tomllib.loads((CURATION_ROOT / "app.toml").read_text())
+        commons_deps = [
+            dep
+            for dep in app["dependencies"]
+            if dep.startswith("katagami/katagami-commons@")
+        ]
+
+        self.assertEqual([f"katagami/katagami-commons@{CURRENT_COMMONS_HASH}"], commons_deps)
+
+    def test_app_guides_describe_multi_lane_palette_and_art_style_jobs(self):
+        curation_guide = (CURATION_ROOT / "APP.md").read_text()
+        commons_guide = (REPO_ROOT / "katagami-commons" / "APP.md").read_text()
+
+        for expected in [
+            "synthesize_palette",
+            "CompletePaletteSynthesis",
+            "synthesize_art_style",
+            "CompleteArtStyleSynthesis",
+            "Multi-lane remix",
+        ]:
+            self.assertIn(expected, curation_guide)
+
+        for expected in ["PaletteSystem", "ArtStyle", "synthesize_palette", "synthesize_art_style"]:
+            self.assertIn(expected, commons_guide)
+
+    def test_genesis_sync_promotes_and_verifies_latest(self):
+        script = (REPO_ROOT / "scripts" / "sync-genesis-katagami.sh").read_text()
+
+        self.assertIn("Temper.Git.PublishNewVersion", script)
+        self.assertIn("LatestVersionHash", script)
+        self.assertIn("publish_latest", script)
+        self.assertIn("latest_hash_for", script)
+        self.assertNotIn("App.PublishNewVersion", script)
+        self.assertLess(
+            script.index('push_app "katagami-commons"'),
+            script.index('push_app "katagami-curation"'),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/sync-genesis-katagami.sh
+++ b/scripts/sync-genesis-katagami.sh
@@ -10,6 +10,82 @@ MODE="${1:-pull}"
 COMMONS_URL="${GENESIS_BASE}/katagami/katagami-commons.git"
 CURATION_URL="${GENESIS_BASE}/katagami/katagami-curation.git"
 
+curl_headers() {
+  printf '%s\n' "-H" "X-Tenant-Id: ${TENANT}"
+  if [[ -n "${GENESIS_API_KEY:-}" ]]; then
+    printf '%s\n' "-H" "Authorization: Bearer ${GENESIS_API_KEY}"
+  fi
+}
+
+app_id_for() {
+  local name="$1"
+  printf 'app-katagami-%s' "$name"
+}
+
+json_string() {
+  python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "$1"
+}
+
+genesis_get() {
+  local path="$1"
+  local headers=()
+
+  mapfile -t headers < <(curl_headers)
+  curl -fsS "${headers[@]}" "${GENESIS_BASE}${path}"
+}
+
+latest_hash_for() {
+  local name="$1"
+  local app_id
+
+  app_id="$(app_id_for "$name")"
+  genesis_get "/tdata/Apps('${app_id}')" \
+    | python3 -c 'import json, sys; print(json.load(sys.stdin).get("LatestVersionHash", ""))'
+}
+
+publish_latest() {
+  local name="$1"
+  local hash="$2"
+  local app_id latest body response
+  local headers=()
+
+  app_id="$(app_id_for "$name")"
+  latest="$(latest_hash_for "$name")"
+  if [[ "$latest" == "$hash" ]]; then
+    echo "${name}: Genesis latest already ${hash}"
+    return 0
+  fi
+
+  body="$(printf '{"NewHash":%s,"RefName":"main"}' "$(json_string "$hash")")"
+  mapfile -t headers < <(curl_headers)
+  headers+=("-H" "Content-Type: application/json")
+
+  echo "${name}: promoting Genesis latest to ${hash} via Temper.Git.PublishNewVersion"
+  if ! response="$(
+    curl -fsS -X POST "${headers[@]}" \
+      "${GENESIS_BASE}/tdata/Apps('${app_id}')/Temper.Git.PublishNewVersion?await_integration=true" \
+      --data "$body" 2>&1
+  )"; then
+    latest="$(latest_hash_for "$name" || true)"
+    if [[ "$latest" == "$hash" ]]; then
+      echo "${name}: publish returned an error, but Genesis latest verified as ${hash}"
+      return 0
+    fi
+    echo "${name}: failed to publish Genesis latest for ${hash}" >&2
+    echo "$response" >&2
+    return 1
+  fi
+
+  latest="$(latest_hash_for "$name")"
+  if [[ "$latest" != "$hash" ]]; then
+    echo "${name}: publish completed but LatestVersionHash is ${latest:-<empty>} not ${hash}" >&2
+    echo "$response" >&2
+    return 1
+  fi
+
+  echo "${name}: verified LatestVersionHash=${hash}"
+}
+
 clone_app() {
   local url="$1"
   local dest="$2"
@@ -38,11 +114,12 @@ push_app() {
 
   if git -C "$repo" diff --cached --quiet; then
     echo "${name}: Genesis already matches ${source}/"
-    return
+  else
+    git -C "$repo" commit -m "Sync ${name} from katagami monorepo"
+    git -C "$repo" push origin main
   fi
 
-  git -C "$repo" commit -m "Sync ${name} from katagami monorepo"
-  git -C "$repo" push origin main
+  publish_latest "$name" "$(git -C "$repo" rev-parse HEAD)"
 }
 
 usage() {
@@ -50,11 +127,13 @@ usage() {
 Usage: scripts/sync-genesis-katagami.sh [pull|push]
 
   pull  Refresh katagami-commons/ and katagami-curation/ from Genesis and stage them.
-  push  Commit the current folder states back to the two Genesis app repos.
+  push  Commit the current folder states back to the two Genesis app repos,
+        publish/promote the pushed hashes, and verify Genesis latest.
 
 Genesis is the source of truth for these two app folders. The script uses clean
 temporary clones with Git protocol v0 because direct non-empty fetches from the
-current Genesis smart-HTTP service can fail during pack negotiation.
+current Genesis smart-HTTP service can fail during pack negotiation. Set
+GENESIS_API_KEY when the target Genesis deployment requires a bearer token.
 USAGE
 }
 


### PR DESCRIPTION
## Summary
- Update katagami-curation to depend on the current Genesis-published katagami-commons hash.
- Document multi-lane palette and art-style curation metadata in Katagami app guides.
- Make scripts/sync-genesis-katagami.sh push, publish/promote via Temper.Git.PublishNewVersion, and verify LatestVersionHash for commons before curation.

## Verification
- bash -n scripts/sync-genesis-katagami.sh
- python3 -m unittest katagami-curation/tests/test_genesis_source_contract.py katagami-curation/tests/test_reaction_resolver_types.py

## Dependency Order
Merge after arni-labs/genesis#18 is deployed so canonical publish/verify actions are available live.