### PR TITLE
Point curation at current Genesis commons

### DIFF
--- a/katagami-curation/app.toml
+++ b/katagami-curation/app.toml
@@ -6,7 +6,7 @@ dependencies = [
   "temperpaw/paw-fs@65f3ee9659500d11a54c22b9e5519d52dd0db1d4",
   "temperpaw/paw-agent@65fbd22270e4bf7304de2d9b6895a465c332d602",
   "temperpaw/paw-research@910d01612b2632362fb5f537c4357a5fb6c7bcdd",
-  "katagami/katagami-commons@9fb0622f3caa7a6d885856f233e42410fc19f3fc",
+  "katagami/katagami-commons@1cc425ef14205e9d63bdec5f8289bb110e4d4b3f",
 ]
 
 # These declarations are REQUIRED — the installer only uploads WASM

--- a/katagami-curation/tests/test_genesis_source_contract.py
+++ b/katagami-curation/tests/test_genesis_source_contract.py
@@ -5,7 +5,7 @@ import unittest
 
 CURATION_ROOT = Path(__file__).resolve().parents[1]
 REPO_ROOT = CURATION_ROOT.parent
-CURRENT_COMMONS_HASH = "9fb0622f3caa7a6d885856f233e42410fc19f3fc"
+CURRENT_COMMONS_HASH = "1cc425ef14205e9d63bdec5f8289bb110e4d4b3f"
 
 
 class GenesisSourceContractTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- update katagami-curation to depend on the current Genesis latest katagami-commons hash
- keep the Genesis source contract test aligned with the live LatestVersionHash

## Verification
- python3 -m unittest katagami-curation.tests.test_genesis_source_contract
- python3 -m unittest discover katagami-curation/tests

## Live Genesis evidence
- app-katagami-katagami-commons LatestVersionHash = 1cc425ef14205e9d63bdec5f8289bb110e4d4b3f
