### PR TITLE
Align curation dependencies with Genesis latest apps

### DIFF
--- a/katagami-curation/app.toml
+++ b/katagami-curation/app.toml
@@ -3,8 +3,8 @@ description = "Agent work layer for katagami — CurationJob queue, curator sess
 version = "0.1.0"
 startup_install = "core"
 dependencies = [
-  "temperpaw/paw-fs@65f3ee9659500d11a54c22b9e5519d52dd0db1d4",
-  "temperpaw/paw-agent@65fbd22270e4bf7304de2d9b6895a465c332d602",
+  "temperpaw/paw-fs@bff862b415505f5a563998265a2f6ac29472f899",
+  "temperpaw/paw-agent@81d8beb78923dc22aeda850828f510f3c6eab510",
   "temperpaw/paw-research@910d01612b2632362fb5f537c4357a5fb6c7bcdd",
   "katagami/katagami-commons@1cc425ef14205e9d63bdec5f8289bb110e4d4b3f",
 ]

--- a/katagami-curation/tests/test_genesis_source_contract.py
+++ b/katagami-curation/tests/test_genesis_source_contract.py
@@ -5,19 +5,20 @@ import unittest
 
 CURATION_ROOT = Path(__file__).resolve().parents[1]
 REPO_ROOT = CURATION_ROOT.parent
-CURRENT_COMMONS_HASH = "1cc425ef14205e9d63bdec5f8289bb110e4d4b3f"
+CURRENT_GENESIS_DEPS = {
+    "temperpaw/paw-fs": "bff862b415505f5a563998265a2f6ac29472f899",
+    "temperpaw/paw-agent": "81d8beb78923dc22aeda850828f510f3c6eab510",
+    "temperpaw/paw-research": "910d01612b2632362fb5f537c4357a5fb6c7bcdd",
+    "katagami/katagami-commons": "1cc425ef14205e9d63bdec5f8289bb110e4d4b3f",
+}
 
 
 class GenesisSourceContractTest(unittest.TestCase):
-    def test_curation_depends_on_current_genesis_commons(self):
+    def test_curation_depends_on_current_genesis_apps(self):
         app = tomllib.loads((CURATION_ROOT / "app.toml").read_text())
-        commons_deps = [
-            dep
-            for dep in app["dependencies"]
-            if dep.startswith("katagami/katagami-commons@")
-        ]
+        pinned_deps = dict(dep.rsplit("@", 1) for dep in app["dependencies"])
 
-        self.assertEqual([f"katagami/katagami-commons@{CURRENT_COMMONS_HASH}"], commons_deps)
+        self.assertEqual(CURRENT_GENESIS_DEPS, pinned_deps)
 
     def test_app_guides_describe_multi_lane_palette_and_art_style_jobs(self):
         curation_guide = (CURATION_ROOT / "APP.md").read_text()


### PR DESCRIPTION
## Summary
- update katagami-curation to depend on current Genesis latest refs for paw-fs, paw-agent, paw-research, and katagami-commons
- expand the Genesis source contract so all pinned curation dependencies are guarded, not only commons

## Verification
- python3 -m unittest katagami-curation.tests.test_genesis_source_contract
- python3 -m unittest discover katagami-curation/tests

## Live Genesis evidence
- temperpaw/paw-fs@bff862b415505f5a563998265a2f6ac29472f899
- temperpaw/paw-agent@81d8beb78923dc22aeda850828f510f3c6eab510
- temperpaw/paw-research@910d01612b2632362fb5f537c4357a5fb6c7bcdd
- katagami/katagami-commons@1cc425ef14205e9d63bdec5f8289bb110e4d4b3f
