### PR TITLE
Propagate CurationJob parent sessions

### DIFF
--- a/katagami-curation/specs/curation_job.ioa.toml
+++ b/katagami-curation/specs/curation_job.ioa.toml
@@ -151,13 +151,18 @@ name = "session_id"
 type = "string"
 initial = ""
 
+[[state]]
+name = "parent_session_id"
+type = "string"
+initial = ""
+
 # --- Queued ---
 
 [[action]]
 name = "Configure"
 kind = "input"
 from = ["Queued"]
-params = ["job_type", "design_language_id", "direction_id", "workspace_id", "input", "model", "provider", "soul_id", "max_turns", "tools_enabled", "query_id", "completion_contract", "inline_job_docs"]
+params = ["job_type", "design_language_id", "direction_id", "workspace_id", "input", "model", "provider", "soul_id", "max_turns", "tools_enabled", "query_id", "completion_contract", "inline_job_docs", "parent_session_id"]
 hint = "Set or update job parameters before execution."
 
 [[action]]
@@ -165,7 +170,7 @@ name = "ConfigureAndSubmit"
 kind = "internal"
 from = ["Queued"]
 to = "Ready"
-params = ["job_type", "design_language_id", "direction_id", "workspace_id", "input", "model", "provider", "soul_id", "max_turns", "tools_enabled", "query_id", "completion_contract", "inline_job_docs"]
+params = ["job_type", "design_language_id", "direction_id", "workspace_id", "input", "model", "provider", "soul_id", "max_turns", "tools_enabled", "query_id", "completion_contract", "inline_job_docs", "parent_session_id"]
 hint = "Configure a trigger-created job and start session spawning in one transition."
 effect = [{ type = "trigger", name = "build_session_message" }]
 

--- a/katagami-curation/specs/model.csdl.xml
+++ b/katagami-curation/specs/model.csdl.xml
@@ -38,6 +38,7 @@
         <Property Name="MaxTurns" Type="Edm.String" Nullable="false" DefaultValue="250" />
         <Property Name="UserMessage" Type="Edm.String" Nullable="false" DefaultValue="" />
         <Property Name="SessionId" Type="Edm.String" Nullable="false" DefaultValue="" />
+        <Property Name="ParentSessionId" Type="Edm.String" Nullable="false" DefaultValue="" />
         <Property Name="QueryId" Type="Edm.String" Nullable="false" DefaultValue="" />
         <Property Name="CreatedAt" Type="Edm.DateTimeOffset" />
         <Property Name="UpdatedAt" Type="Edm.DateTimeOffset" />

--- a/katagami-curation/tests/test_curation_liveness_contract.py
+++ b/katagami-curation/tests/test_curation_liveness_contract.py
@@ -57,6 +57,28 @@ class CurationLivenessContractTest(unittest.TestCase):
             for trigger in triggers:
                 self.assertEqual(trigger.get("timeout_secs"), "300")
 
+    def test_curation_job_preserves_parent_session_for_approval_routing(self):
+        spec = load_spec("curation_job.ioa.toml")
+        model = (ROOT / "specs" / "model.csdl.xml").read_text()
+        build_session = (
+            ROOT / "wasm" / "build_session_message" / "src" / "lib.rs"
+        ).read_text()
+        finalizer = (
+            ROOT / "wasm" / "finalize_spawned_session" / "src" / "lib.rs"
+        ).read_text()
+
+        state_names = {state["name"] for state in spec.get("state", [])}
+        self.assertIn("parent_session_id", state_names)
+        for action_name in ["Configure", "ConfigureAndSubmit"]:
+            self.assertIn("parent_session_id", action_by_name(spec, action_name)["params"])
+
+        self.assertIn('<Property Name="ParentSessionId" Type="Edm.String"', model)
+        self.assertIn('"ParentSessionId": parent_session_id.clone()', build_session)
+        self.assertIn('"parent_session_id".to_string()', build_session)
+        self.assertIn("parent_session_id_from_fields", finalizer)
+        self.assertIn("curation_job_create_body(parent_session_id)", finalizer)
+        self.assertIn("add_parent_session_id(&mut configure_body, parent_session_id)", finalizer)
+
     def test_curation_direction_synthesizing_times_out_to_failed(self):
         spec = load_spec("curation_direction.ioa.toml")
         timeouts = state_timeout_map(spec)

--- a/katagami-curation/wasm/build_session_message/src/lib.rs
+++ b/katagami-curation/wasm/build_session_message/src/lib.rs
@@ -114,6 +114,9 @@ pub extern "C" fn run(_ctx_ptr: i32, _ctx_len: i32) -> i32 {
             .and_then(|v| v.as_str())
             .unwrap_or(&ctx.entity_id)
             .to_string();
+        let parent_session_id = field_str(&fields, &["parent_session_id", "ParentSessionId"])
+            .filter(|value| value.starts_with("ss-"))
+            .unwrap_or_default();
 
         let template = lookup_active_template(&ctx, &api_url, &headers, &job_type)?;
         let skill = template.skill_id.as_str();
@@ -253,11 +256,16 @@ temper.done("{job_type} failed")
         );
 
         // --- Create Session entity ---
+        let session_create_body = if parent_session_id.is_empty() {
+            json!({"fields": {}})
+        } else {
+            json!({"fields": {"ParentSessionId": parent_session_id.clone()}})
+        };
         let create_resp = ctx.http_call(
             "POST",
             &format!("{api_url}/tdata/Sessions"),
             &headers,
-            &json!({"fields": {}}).to_string(),
+            &session_create_body.to_string(),
         )?;
         if !(200..300).contains(&create_resp.status) {
             return Err(format!(
@@ -295,6 +303,13 @@ temper.done("{job_type} failed")
             "max_turns": max_turns,
             "workspace_id": workspace_id,
         });
+
+        if !parent_session_id.is_empty() {
+            config_body.as_object_mut().unwrap().insert(
+                "parent_session_id".to_string(),
+                json!(parent_session_id.clone()),
+            );
+        }
 
         if needs_sandbox {
             // Read sandbox provider from server env (set via SANDBOX_PROVIDER)
@@ -377,6 +392,7 @@ temper.done("{job_type} failed")
                 "job_type": job_type,
                 "skill": skill,
                 "template_version": template.template_version,
+                "parent_session_id": parent_session_id,
             }),
         );
         Ok(())

--- a/katagami-curation/wasm/finalize_spawned_session/src/lib.rs
+++ b/katagami-curation/wasm/finalize_spawned_session/src/lib.rs
@@ -42,6 +42,7 @@ pub extern "C" fn run(_ctx_ptr: i32, _ctx_len: i32) -> i32 {
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string();
+        let parent_session_id = parent_session_id_from_fields(&fields);
         let job_id = ctx
             .entity_state
             .get("entity_id")
@@ -241,6 +242,7 @@ pub extern "C" fn run(_ctx_ptr: i32, _ctx_len: i32) -> i32 {
                             &headers,
                             &workspace_id,
                             &query_id,
+                            &parent_session_id,
                             input_json.as_ref(),
                             output_json.as_ref(),
                         )?;
@@ -274,6 +276,7 @@ pub extern "C" fn run(_ctx_ptr: i32, _ctx_len: i32) -> i32 {
                             &headers,
                             &workspace_id,
                             &query_id,
+                            &parent_session_id,
                             output_json.as_ref(),
                         )?;
                         if !query_id.is_empty() {
@@ -322,6 +325,7 @@ pub extern "C" fn run(_ctx_ptr: i32, _ctx_len: i32) -> i32 {
                             &headers,
                             &workspace_id,
                             &query_id,
+                            &parent_session_id,
                             review_output.as_ref(),
                         )?;
                         JobProgression {
@@ -4492,6 +4496,7 @@ fn run_typed_completion_fallback(
                     &direction_workspace,
                     &direction_query,
                     Some(direction_id),
+                    &parent_session_id_from_fields(fields),
                     &synth_input,
                 )?;
                 actions.push(json!({
@@ -4565,6 +4570,7 @@ fn run_typed_completion_fallback(
                     workspace_id,
                     query_id,
                     None,
+                    &parent_session_id_from_fields(fields),
                     &review_input,
                 )?;
                 actions
@@ -4603,6 +4609,7 @@ fn run_typed_completion_fallback(
                     workspace_id,
                     query_id,
                     None,
+                    &parent_session_id_from_fields(fields),
                     &organize_input,
                 )?;
                 actions
@@ -4633,6 +4640,7 @@ fn run_typed_completion_fallback(
                     workspace_id,
                     query_id,
                     None,
+                    &parent_session_id_from_fields(fields),
                     &review_input,
                 )?;
                 actions.push(json!({
@@ -4681,6 +4689,26 @@ fn string_field(fields: &serde_json::Value, name: &str, default: &str) -> String
         .filter(|s| !s.is_empty())
         .unwrap_or(default)
         .to_string()
+}
+
+fn parent_session_id_from_fields(fields: &serde_json::Value) -> String {
+    string_field_any(fields, "parent_session_id", "")
+        .trim()
+        .to_string()
+}
+
+fn curation_job_create_body(parent_session_id: &str) -> serde_json::Value {
+    if parent_session_id.starts_with("ss-") {
+        json!({"fields": {"ParentSessionId": parent_session_id}})
+    } else {
+        json!({"fields": {}})
+    }
+}
+
+fn add_parent_session_id(body: &mut serde_json::Value, parent_session_id: &str) {
+    if parent_session_id.starts_with("ss-") {
+        body["parent_session_id"] = serde_json::Value::String(parent_session_id.to_string());
+    }
 }
 
 fn parse_json_string_array(value: Option<&serde_json::Value>) -> Vec<String> {
@@ -4831,13 +4859,15 @@ fn create_configure_submit_job(
     workspace_id: &str,
     query_id: &str,
     direction_id: Option<&str>,
+    parent_session_id: &str,
     input: &str,
 ) -> Result<String, String> {
+    let create_body = curation_job_create_body(parent_session_id);
     let create_resp = ctx.http_call(
         "POST",
         &format!("{api_url}/tdata/CurationJobs"),
         headers,
-        "{}",
+        &create_body.to_string(),
     )?;
     if !(200..300).contains(&create_resp.status) {
         return Err(format!(
@@ -4864,6 +4894,7 @@ fn create_configure_submit_job(
     if let Some(direction_id) = direction_id.filter(|id| !id.is_empty()) {
         body["direction_id"] = serde_json::Value::String(direction_id.to_string());
     }
+    add_parent_session_id(&mut body, parent_session_id);
 
     dispatch_action(
         ctx,
@@ -4944,6 +4975,7 @@ fn spawn_synth_followup(
     headers: &[(String, String)],
     workspace_id: &str,
     query_id: &str,
+    parent_session_id: &str,
     input_json: Option<&serde_json::Value>,
     output_json: Option<&serde_json::Value>,
 ) -> Result<Option<String>, String> {
@@ -5040,11 +5072,12 @@ fn spawn_synth_followup(
         });
 
         // Create new CurationJob
+        let create_body = curation_job_create_body(parent_session_id);
         let create_resp = ctx.http_call(
             "POST",
             &format!("{api_url}/tdata/CurationJobs"),
             headers,
-            r#"{"fields":{}}"#,
+            &create_body.to_string(),
         )?;
         if !(200..300).contains(&create_resp.status) {
             ctx.log(
@@ -5065,13 +5098,14 @@ fn spawn_synth_followup(
             .to_string();
 
         // Configure with synthesize job_type
-        let configure_body = json!({
+        let mut configure_body = json!({
             "job_type": "synthesize",
             "workspace_id": workspace_id,
             "input": synth_input.to_string(),
             "query_id": query_id,
             "inline_job_docs": true
         });
+        add_parent_session_id(&mut configure_body, parent_session_id);
         let configure_resp = ctx.http_call(
             "POST",
             &format!("{api_url}/tdata/CurationJobs('{synth_job_id}')/Katagami.Curation.Configure"),
@@ -5129,6 +5163,7 @@ fn spawn_quality_review_followup(
     headers: &[(String, String)],
     workspace_id: &str,
     query_id: &str,
+    parent_session_id: &str,
     output_json: Option<&serde_json::Value>,
 ) -> Result<Option<String>, String> {
     let language_ids = string_array(output_json.and_then(|v| v.get("language_ids")));
@@ -5146,11 +5181,12 @@ fn spawn_quality_review_followup(
     });
 
     // Create new CurationJob
+    let create_body = curation_job_create_body(parent_session_id);
     let create_resp = ctx.http_call(
         "POST",
         &format!("{api_url}/tdata/CurationJobs"),
         headers,
-        r#"{"fields":{}}"#,
+        &create_body.to_string(),
     )?;
     if !(200..300).contains(&create_resp.status) {
         return Err(format!(
@@ -5169,13 +5205,14 @@ fn spawn_quality_review_followup(
         .to_string();
 
     // Configure
-    let configure_body = json!({
+    let mut configure_body = json!({
         "job_type": "quality_review",
         "workspace_id": workspace_id,
         "input": review_input.to_string(),
         "query_id": query_id,
         "inline_job_docs": true
     });
+    add_parent_session_id(&mut configure_body, parent_session_id);
     let configure_resp = ctx.http_call(
         "POST",
         &format!("{api_url}/tdata/CurationJobs('{review_job_id}')/Katagami.Curation.Configure"),
@@ -5220,6 +5257,7 @@ fn spawn_organize_followup(
     headers: &[(String, String)],
     workspace_id: &str,
     query_id: &str,
+    parent_session_id: &str,
     output_json: Option<&serde_json::Value>,
 ) -> Result<Option<String>, String> {
     let language_ids = string_array(output_json.and_then(|v| v.get("language_ids")));
@@ -5237,11 +5275,12 @@ fn spawn_organize_followup(
     });
 
     // Create new CurationJob
+    let create_body = curation_job_create_body(parent_session_id);
     let create_resp = ctx.http_call(
         "POST",
         &format!("{api_url}/tdata/CurationJobs"),
         headers,
-        r#"{"fields":{}}"#,
+        &create_body.to_string(),
     )?;
     if !(200..300).contains(&create_resp.status) {
         return Err(format!(
@@ -5259,12 +5298,13 @@ fn spawn_organize_followup(
         .to_string();
 
     // Configure
-    let configure_body = json!({
+    let mut configure_body = json!({
         "job_type": "organize_taxonomy",
         "workspace_id": workspace_id,
         "input": organize_input.to_string(),
         "query_id": query_id
     });
+    add_parent_session_id(&mut configure_body, parent_session_id);
     let configure_resp = ctx.http_call(
         "POST",
         &format!("{api_url}/tdata/CurationJobs('{organize_job_id}')/Katagami.Curation.Configure"),


### PR DESCRIPTION
## Summary
- add parent_session_id to CurationJob state, actions, and CSDL metadata
- propagate ParentSessionId into spawned OpenPaw sessions and follow-up CurationJobs
- cover the approval-routing contract in Katagami curation tests

## Verification
- python3 -m unittest katagami-curation/tests/test_curation_liveness_contract.py
- cargo check --manifest-path katagami-curation/wasm/build_session_message/Cargo.toml
- cargo check --manifest-path katagami-curation/wasm/finalize_spawned_session/Cargo.toml
- python3 -m unittest discover katagami-curation/tests