### PR TITLE
Exclude Rust build caches from Genesis sync

### DIFF
--- a/katagami-curation/tests/test_genesis_source_contract.py
+++ b/katagami-curation/tests/test_genesis_source_contract.py
@@ -48,8 +48,10 @@ class GenesisSourceContractTest(unittest.TestCase):
         self.assertIn("git -C \"$repo\" config --add \"$key\" \"X-Tenant-Id: ${TENANT}\"", script)
         self.assertIn("clean_generated_files", script)
         self.assertIn("find \"$dir\" -type d", script)
+        self.assertIn("-name 'target'", script)
         self.assertIn("--exclude='__pycache__/'", script)
         self.assertIn("--exclude='*.py[co]'", script)
+        self.assertIn("--exclude='target/'", script)
         self.assertNotIn("mapfile", script)
         self.assertNotIn("App.PublishNewVersion", script)
         self.assertLess(

--- a/scripts/sync-genesis-katagami.sh
+++ b/scripts/sync-genesis-katagami.sh
@@ -38,6 +38,7 @@ clean_generated_files() {
   local dir="$1"
 
   find "$dir" -type d \( -name '__pycache__' -o -name '.pytest_cache' \) -prune -exec rm -rf {} +
+  find "$dir" -type d -name 'target' -prune -exec rm -rf {} +
   find "$dir" -type f \( -name '*.pyc' -o -name '*.pyo' \) -delete
 }
 
@@ -128,6 +129,7 @@ sync_app() {
     --exclude='__pycache__/' \
     --exclude='*.py[co]' \
     --exclude='.pytest_cache/' \
+    --exclude='target/' \
     "${source}/" "${ROOT}/${dest}/"
   clean_generated_files "${ROOT}/${dest}"
 }
@@ -142,6 +144,7 @@ push_app() {
     --exclude='__pycache__/' \
     --exclude='*.py[co]' \
     --exclude='.pytest_cache/' \
+    --exclude='target/' \
     "${ROOT}/${source}/" "${repo}/"
   clean_generated_files "$repo"
   git -C "$repo" add -A


### PR DESCRIPTION
## Summary
- exclude Rust target/ directories during Genesis pull/push rsync
- clean any target/ directories that already exist in app sync destinations
- add a contract assertion so the sync script keeps excluding build caches

## Why
The first Genesis publish attempt after rebuilding Katagami WASM copied local Cargo target directories into the temporary Genesis clone and tried to commit generated build artifacts. Cleaning local caches avoided the immediate publish issue; this prevents the same class from recurring.

## Verification
- python3 -m unittest tests.test_genesis_source_contract (katagami-curation)
- git diff --check
