### PR TITLE
Fix palette synthesis naming and public rendering

### DIFF
--- a/katagami-curation/agents/curator/skills/synthesize-art-style/SKILL.md
+++ b/katagami-curation/agents/curator/skills/synthesize-art-style/SKILL.md
@@ -46,6 +46,7 @@ art = temper.create('ArtStyles', {})
 eid = art['entity_id']
 created_ids.append(eid)
 
+temper.action('ArtStyles', eid, 'SetName', {'name': name, 'slug': slug})
 temper.action('ArtStyles', eid, 'SetMedium', {'medium': 'print'})  # illustration|photography|painting|print|3d|collage|mixed
 ```
 

--- a/katagami-curation/agents/curator/skills/synthesize-palette/SKILL.md
+++ b/katagami-curation/agents/curator/skills/synthesize-palette/SKILL.md
@@ -47,6 +47,7 @@ name = 'Muted Hobonichi Ink'
 ps = temper.create('PaletteSystems', {})
 eid = ps['entity_id']
 created_ids.append(eid)
+temper.action('PaletteSystems', eid, 'SetName', {'name': name, 'slug': slug})
 ```
 
 **Core — the palette's identity.** A palette IS its **signature** (1–4 key colors,

--- a/ui/scripts/check-gallery-renders-all-cards.mjs
+++ b/ui/scripts/check-gallery-renders-all-cards.mjs
@@ -12,8 +12,13 @@ const ownerControlsSource = readProjectFile("src/components/language-card-owner-
 const odataSource = readProjectFile("src/lib/odata.ts");
 const mutationsSource = readProjectFile("src/lib/odata-mutations.ts");
 const actionsSource = readProjectFile("src/app/actions.ts");
+const palettesPageSource = readProjectFile("src/app/(site)/palettes/page.tsx");
+const paletteDetailSource = readProjectFile("src/app/(site)/palettes/[id]/page.tsx");
 const ownerPageSource = readProjectFile("src/app/(site)/owner/page.tsx");
 const sendToReviewSource = readProjectFile("src/components/send-to-review-language-button.tsx");
+const synthesizePaletteSkillSource = readProjectFile(
+  "../katagami-curation/agents/curator/skills/synthesize-palette/SKILL.md",
+);
 const deferredComponentPath = resolve("src/components/deferred-language-cards.tsx");
 
 const violations = [
@@ -204,6 +209,36 @@ if (!/Rejected history/.test(ownerPageSource) || !/rejected\.map\(\(rule\)/.test
 if (!/listTaxonomies[\s\S]*let rows = await collectODataPages<Taxonomy>\([\s\S]*Taxonomies\$\{q \? `\?\$\{q\}` : ""\}[\s\S]*rows = rows\.filter\(\(row\)/.test(odataSource)) {
   violations.push({
     label: "listTaxonomies does not fetch canonical taxonomy rows before local lifecycle filtering",
+  });
+}
+
+if (!/temper\.action\('PaletteSystems',\s*eid,\s*'SetName'/.test(synthesizePaletteSkillSource)) {
+  violations.push({
+    label: "palette synthesis skill does not set PaletteSystem names before publishing",
+  });
+}
+
+if (!/function normalizeLaneFields/.test(odataSource) || !/snakeCaseFieldName/.test(odataSource)) {
+  violations.push({
+    label: "lane OData rows are not normalized across PascalCase and snake_case fields",
+  });
+}
+
+if (!/export function paletteDisplayName/.test(odataSource)) {
+  violations.push({
+    label: "public palette UI lacks a display-name fallback for legacy unnamed rows",
+  });
+}
+
+if (!/paletteDisplayName/.test(palettesPageSource) || !/paletteDisplayName/.test(paletteDetailSource)) {
+  violations.push({
+    label: "palette catalog/detail pages do not use the shared display-name helper",
+  });
+}
+
+if (!/paletteRampStopHex/.test(odataSource) || !/paletteRampStopHex/.test(paletteDetailSource)) {
+  violations.push({
+    label: "palette detail page cannot render object-shaped ramp stops",
   });
 }
 

--- a/ui/scripts/check-gallery-renders-all-cards.mjs
+++ b/ui/scripts/check-gallery-renders-all-cards.mjs
@@ -14,10 +14,16 @@ const mutationsSource = readProjectFile("src/lib/odata-mutations.ts");
 const actionsSource = readProjectFile("src/app/actions.ts");
 const palettesPageSource = readProjectFile("src/app/(site)/palettes/page.tsx");
 const paletteDetailSource = readProjectFile("src/app/(site)/palettes/[id]/page.tsx");
+const artStylesPageSource = readProjectFile("src/app/(site)/art-styles/page.tsx");
+const artStyleDetailSource = readProjectFile("src/app/(site)/art-styles/[id]/page.tsx");
+const remixOptionsSource = readProjectFile("src/lib/remix-options.ts");
 const ownerPageSource = readProjectFile("src/app/(site)/owner/page.tsx");
 const sendToReviewSource = readProjectFile("src/components/send-to-review-language-button.tsx");
 const synthesizePaletteSkillSource = readProjectFile(
   "../katagami-curation/agents/curator/skills/synthesize-palette/SKILL.md",
+);
+const synthesizeArtStyleSkillSource = readProjectFile(
+  "../katagami-curation/agents/curator/skills/synthesize-art-style/SKILL.md",
 );
 const deferredComponentPath = resolve("src/components/deferred-language-cards.tsx");
 
@@ -218,6 +224,12 @@ if (!/temper\.action\('PaletteSystems',\s*eid,\s*'SetName'/.test(synthesizePalet
   });
 }
 
+if (!/temper\.action\('ArtStyles',\s*eid,\s*'SetName'/.test(synthesizeArtStyleSkillSource)) {
+  violations.push({
+    label: "art-style synthesis skill does not set ArtStyle names before publishing",
+  });
+}
+
 if (!/function normalizeLaneFields/.test(odataSource) || !/snakeCaseFieldName/.test(odataSource)) {
   violations.push({
     label: "lane OData rows are not normalized across PascalCase and snake_case fields",
@@ -233,6 +245,24 @@ if (!/export function paletteDisplayName/.test(odataSource)) {
 if (!/paletteDisplayName/.test(palettesPageSource) || !/paletteDisplayName/.test(paletteDetailSource)) {
   violations.push({
     label: "palette catalog/detail pages do not use the shared display-name helper",
+  });
+}
+
+if (!/export function artStyleDisplayName/.test(odataSource)) {
+  violations.push({
+    label: "public art-style UI lacks a display-name fallback for legacy unnamed rows",
+  });
+}
+
+if (!/artStyleDisplayName/.test(artStylesPageSource) || !/artStyleDisplayName/.test(artStyleDetailSource)) {
+  violations.push({
+    label: "art-style catalog/detail pages do not use the shared display-name helper",
+  });
+}
+
+if (!/artStyleDisplayName/.test(remixOptionsSource)) {
+  violations.push({
+    label: "studio remix options do not use the shared art-style display-name helper",
   });
 }
 

--- a/ui/src/app/(site)/art-styles/[id]/page.tsx
+++ b/ui/src/app/(site)/art-styles/[id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import {
+  artStyleDisplayName,
   getArtStyle,
   listDesignLanguages,
   listPaletteSystems,
@@ -33,7 +34,7 @@ export default async function ArtStyleDetailPage({ params }: { params: Promise<{
     notFound();
   }
   const f = art.fields;
-  const name = f.name ?? "Untitled";
+  const name = artStyleDisplayName(f);
   const medium = f.medium ?? "mixed";
   const promptTemplate = f.prompt_template ?? "";
   const negativePrompt = f.negative_prompt ?? "";

--- a/ui/src/app/(site)/art-styles/page.tsx
+++ b/ui/src/app/(site)/art-styles/page.tsx
@@ -1,4 +1,9 @@
-import { listArtStyles, getFileUrl, parseJson } from "@/lib/odata";
+import {
+  artStyleDisplayName,
+  getFileUrl,
+  listArtStyles,
+  parseJson,
+} from "@/lib/odata";
 import { PageHero, Marker } from "@/components/page-hero";
 import { ArtStyleCatalog } from "@/components/lane-catalog";
 import type { ArtStyleItem } from "@/components/art-style-card";
@@ -18,7 +23,7 @@ export default async function ArtStylesPage() {
   const rows = await listArtStyles("Status eq 'Published'").catch(() => []);
   const items: ArtStyleItem[] = rows.map((r) => ({
     id: r.entity_id,
-    name: r.fields.name ?? "Untitled",
+    name: artStyleDisplayName(r.fields),
     slug: r.fields.slug ?? "",
     status: r.status,
     medium: r.fields.medium ?? "",

--- a/ui/src/app/(site)/palettes/[id]/page.tsx
+++ b/ui/src/app/(site)/palettes/[id]/page.tsx
@@ -6,6 +6,8 @@ import {
   listDesignLanguages,
   listArtStyles,
   paletteCore,
+  paletteDisplayName,
+  paletteRampStopHex,
   parseJson,
 } from "@/lib/odata";
 import { toLanguageOpts, toPaletteOpts, toArtOpts } from "@/lib/remix-options";
@@ -23,6 +25,15 @@ export const dynamic = "force-dynamic";
 
 const NEUTRAL_ORDER = ["bg", "surface", "text", "muted", "border"];
 const SEMANTIC_ORDER = ["success", "warning", "error", "info"];
+type PaletteRamp = Record<string, string | { hex?: string }>;
+
+function rampHexes(ramp: PaletteRamp | undefined): string[] {
+  if (!ramp) return [];
+  return Object.entries(ramp)
+    .sort(([a], [b]) => Number(a) - Number(b))
+    .map(([, stop]) => paletteRampStopHex(stop))
+    .filter((hex): hex is string => Boolean(hex));
+}
 
 export default async function PaletteDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -34,10 +45,10 @@ export default async function PaletteDetailPage({ params }: { params: Promise<{ 
   }
   const f = pal.fields;
   const core = paletteCore(f);
-  const ramps = parseJson<Record<string, Record<string, string>>>(f.ramps) ?? {};
+  const ramps = parseJson<Record<string, PaletteRamp>>(f.ramps) ?? {};
   const guidance = parseJson<{ do?: string[]; dont?: string[] }>(f.usage_guidance);
   const tags = parseJson<string[]>(f.tags) ?? [];
-  const name = f.name ?? "Untitled";
+  const name = paletteDisplayName(f, core);
   const slug = f.slug ?? id.slice(0, 8);
 
   const flat: Record<string, string> = {
@@ -128,22 +139,23 @@ export default async function PaletteDetailPage({ params }: { params: Promise<{ 
           </>
         ) : null}
 
-        {ramps.accent || ramps.neutral ? (
+        {rampHexes(ramps.accent).length || rampHexes(ramps.neutral).length ? (
           <>
             <div className="mt-4 mb-2 font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground">Ramps</div>
             <div className="space-y-1.5">
-              {(["accent", "neutral"] as const).map((r) =>
-                ramps[r] ? (
+              {(["accent", "neutral"] as const).map((r) => {
+                const hexes = rampHexes(ramps[r]);
+                return hexes.length ? (
                   <div key={r} className="flex items-center gap-2">
                     <span className="w-14 font-mono text-[9px] uppercase tracking-[0.14em] text-muted-foreground">{r}</span>
                     <div className={`flex h-5 flex-1 overflow-hidden rounded-[2px] ${RING}`}>
-                      {Object.values(ramps[r]).map((c, i) => (
-                        <span key={i} className="h-full flex-1" style={{ background: c }} />
+                      {hexes.map((hex, i) => (
+                        <span key={i} className="h-full flex-1" style={{ background: hex }} />
                       ))}
                     </div>
                   </div>
-                ) : null,
-              )}
+                ) : null;
+              })}
             </div>
           </>
         ) : null}

--- a/ui/src/app/(site)/palettes/page.tsx
+++ b/ui/src/app/(site)/palettes/page.tsx
@@ -1,4 +1,10 @@
-import { listPaletteSystems, parseJson, paletteRoles, paletteCore } from "@/lib/odata";
+import {
+  listPaletteSystems,
+  paletteCore,
+  paletteDisplayName,
+  paletteRoles,
+  parseJson,
+} from "@/lib/odata";
 import { PageHero, Marker } from "@/components/page-hero";
 import { PaletteCatalog } from "@/components/lane-catalog";
 import type { PaletteItem } from "@/components/palette-card";
@@ -11,16 +17,19 @@ export const metadata = {
 
 export default async function PalettesPage() {
   const rows = await listPaletteSystems("Status eq 'Published'").catch(() => []);
-  const items: PaletteItem[] = rows.map((r) => ({
-    id: r.entity_id,
-    name: r.fields.name ?? "Untitled",
-    slug: r.fields.slug ?? "",
-    status: r.status,
-    roles: paletteRoles(r.fields),
-    core: paletteCore(r.fields),
-    ramps: parseJson<Record<string, Record<string, string>>>(r.fields.ramps) ?? {},
-    tags: parseJson<string[]>(r.fields.tags) ?? [],
-  }));
+  const items: PaletteItem[] = rows.map((r) => {
+    const core = paletteCore(r.fields);
+    return {
+      id: r.entity_id,
+      name: paletteDisplayName(r.fields, core),
+      slug: r.fields.slug ?? "",
+      status: r.status,
+      roles: paletteRoles(r.fields),
+      core,
+      ramps: parseJson<Record<string, Record<string, string>>>(r.fields.ramps) ?? {},
+      tags: parseJson<string[]>(r.fields.tags) ?? [],
+    };
+  });
 
   return (
     <div className="mx-auto w-full max-w-7xl px-4 py-6 sm:py-10">

--- a/ui/src/lib/odata.ts
+++ b/ui/src/lib/odata.ts
@@ -623,14 +623,35 @@ export type Remix = LaneEntity;
 
 const LANE_PAGE_SIZE = 200;
 
+function snakeCaseFieldName(key: string): string {
+  return key
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[-\s]+/g, "_")
+    .toLowerCase();
+}
+
+function normalizeLaneFields(
+  raw: Record<string, unknown>,
+): Record<string, string | undefined> {
+  const fields: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (typeof value !== "string") continue;
+    fields[key] = value;
+    const snake = snakeCaseFieldName(key);
+    if (!fields[snake]) fields[snake] = value;
+  }
+  return fields;
+}
+
 function normalizeLaneRow(raw: Record<string, unknown>, set: string): LaneEntity {
   if (raw && typeof raw.fields === "object" && raw.fields !== null) {
     const row = raw as unknown as LaneEntity;
-    const f = row.fields as Record<string, string | undefined>;
-    const status = row.status ?? f.State ?? f.Status ?? "";
-    return { entity_id: row.entity_id, status, fields: f };
+    const f = normalizeLaneFields(row.fields as Record<string, unknown>);
+    const status = row.status ?? f.State ?? f.Status ?? f.state ?? f.status ?? "";
+    return { entity_id: row.entity_id || f.Id || "", status, fields: f };
   }
-  const fields: Record<string, string | undefined> = {};
+  const rawFields: Record<string, unknown> = {};
   let entityId = "";
   let status = "";
   for (const [key, value] of Object.entries(raw)) {
@@ -645,11 +666,12 @@ function normalizeLaneRow(raw: Record<string, unknown>, set: string): LaneEntity
     }
     if ((key === "status" || key === "State" || key === "Status") && typeof value === "string") {
       status = value;
-      fields[key === "status" ? "State" : key] = value;
+      rawFields[key === "status" ? "State" : key] = value;
       continue;
     }
-    if (typeof value === "string") fields[key] = value;
+    if (typeof value === "string") rawFields[key] = value;
   }
+  const fields = normalizeLaneFields(rawFields);
   entityId = (fields.Id as string) ?? entityId;
   return { entity_id: entityId, status, fields };
 }
@@ -718,6 +740,45 @@ export function paletteCore(fields: Record<string, string | undefined>): Palette
     .filter((s) => /^#?[0-9a-f]{3,8}$/i.test(s.hex));
   const mood = parseJson<{ temperature?: string; key_hue?: string; summary?: string }>(fields.mood) ?? {};
   return { signature, neutrals, semantic, mood };
+}
+
+function titleFromSlug(value: string): string {
+  return value
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function paletteDisplayName(
+  fields: Record<string, string | undefined>,
+  core = paletteCore(fields),
+): string {
+  const explicit = [fields.name, fields.Name].find((value) => value?.trim());
+  if (explicit) return explicit.trim();
+
+  const slug = [fields.slug, fields.Slug].find((value) => value?.trim());
+  if (slug) return titleFromSlug(slug.trim());
+
+  const signatureNames = core.signature
+    .map((swatch) => swatch.name?.trim())
+    .filter((name): name is string => Boolean(name));
+  if (signatureNames.length > 0) {
+    return signatureNames.slice(0, 2).join(" + ");
+  }
+
+  if (core.mood.key_hue?.trim()) {
+    return `${titleFromSlug(core.mood.key_hue.trim())} Palette`;
+  }
+
+  return "Untitled palette";
+}
+
+export function paletteRampStopHex(stop: unknown): string | undefined {
+  if (typeof stop === "string") return stop;
+  if (!stop || typeof stop !== "object") return undefined;
+  const hex = (stop as { hex?: unknown }).hex;
+  return typeof hex === "string" ? hex : undefined;
 }
 
 // ── Files (embodiment HTML) ──

--- a/ui/src/lib/odata.ts
+++ b/ui/src/lib/odata.ts
@@ -774,6 +774,27 @@ export function paletteDisplayName(
   return "Untitled palette";
 }
 
+export function artStyleDisplayName(
+  fields: Record<string, string | undefined>,
+): string {
+  const explicit = [fields.name, fields.Name].find((value) => value?.trim());
+  if (explicit) return explicit.trim();
+
+  const slug = [fields.slug, fields.Slug].find((value) => value?.trim());
+  if (slug) return titleFromSlug(slug.trim());
+
+  const prompt = [fields.prompt_template, fields.PromptTemplate].find((value) =>
+    value?.trim(),
+  );
+  const promptLead = prompt?.split(",")[0]?.trim();
+  if (promptLead && !promptLead.includes("{")) return titleFromSlug(promptLead);
+
+  const medium = [fields.medium, fields.Medium].find((value) => value?.trim());
+  if (medium) return `${titleFromSlug(medium.trim())} Art Style`;
+
+  return "Untitled art style";
+}
+
 export function paletteRampStopHex(stop: unknown): string | undefined {
   if (typeof stop === "string") return stop;
   if (!stop || typeof stop !== "object") return undefined;

--- a/ui/src/lib/remix-options.ts
+++ b/ui/src/lib/remix-options.ts
@@ -1,6 +1,7 @@
 // Shared builders that turn OData rows into the option shapes InlineRemix needs,
 // so the studio and every detail-page remix map data identically.
 import {
+  artStyleDisplayName,
   getFileUrl,
   parseJson,
   paletteRoles,
@@ -67,7 +68,7 @@ export function toArtOpts(rows: Row[]): ArtOpt[] {
     const thumb = a.fields.thumbnail_file_id ? getFileUrl(a.fields.thumbnail_file_id) : "";
     return {
       id: a.entity_id,
-      name: a.fields.name ?? "Untitled",
+      name: artStyleDisplayName(a.fields),
       medium: a.fields.medium ?? "",
       hero: refs[0] || thumb || "",
       promptTemplate: a.fields.prompt_template ?? "",

--- a/ui/src/lib/remix-options.ts
+++ b/ui/src/lib/remix-options.ts
@@ -5,6 +5,7 @@ import {
   parseJson,
   paletteRoles,
   paletteCore,
+  paletteDisplayName,
 } from "@/lib/odata";
 import type { LanguageOpt, PaletteOpt, ArtOpt } from "@/components/remix/inline-remix";
 
@@ -49,7 +50,7 @@ export function toPaletteOpts(rows: Row[]): PaletteOpt[] {
     ].filter(Boolean) as string[];
     return {
       id: p.entity_id,
-      name: p.fields.name ?? "Untitled",
+      name: paletteDisplayName(p.fields, core),
       roles,
       swatches,
       mood: core.mood.summary,


### PR DESCRIPTION
## Summary
- call PaletteSystems.SetName in the palette synthesis skill so future generated palettes are not published unnamed
- normalize lane OData fields across PascalCase and snake_case before the public UI reads them
- render legacy unnamed palettes from signature/mood fallback names and support object-shaped ramp stops in palette detail pages
- add regression checks for palette naming, lane field normalization, and ramp rendering

## Live context
- TemperPaw/Railway now produced published PaletteSystems for the fresh run
- https://katagami.ai/palettes currently exposes the generated palette IDs, but the live rows revealed unnamed palette display and object-shaped ramp rendering issues

## Verification
- npm test
- npm run lint (0 errors; existing warnings only)
- npm run build
- local fixture API + Next dev check: /palettes and /palettes/en-019eb9c0-8856-7670-ba43-cbdd19eef104 render Transformative teal + Adaptive violet with no Untitled or [object Object]

## Notes
- Computer Use visual verification was unavailable because macOS Accessibility/Screen Recording permissions remained pending after repeated checks.