### PR TITLE
Palette & art-style lanes: owner archiving + shelves

### DIFF
--- a/ui/src/app/(site)/art-styles/page.tsx
+++ b/ui/src/app/(site)/art-styles/page.tsx
@@ -7,6 +7,7 @@ import {
 import { PageHero, Marker } from "@/components/page-hero";
 import { ArtStyleCatalog } from "@/components/lane-catalog";
 import type { ArtStyleItem } from "@/components/art-style-card";
+import { isOwner } from "@/lib/owner";
 
 export const dynamic = "force-dynamic";
 export const metadata = {
@@ -20,19 +21,28 @@ function refUrls(raw?: string): string[] {
 }
 
 export default async function ArtStylesPage() {
-  const rows = await listArtStyles("Status eq 'Published'").catch(() => []);
-  const items: ArtStyleItem[] = rows.map((r) => ({
-    id: r.entity_id,
-    name: artStyleDisplayName(r.fields),
-    slug: r.fields.slug ?? "",
-    status: r.status,
-    medium: r.fields.medium ?? "",
-    promptTemplate: r.fields.prompt_template ?? "",
-    refs: refUrls(r.fields.reference_image_file_ids),
-    proofs: refUrls(r.fields.proof_shots_file_ids),
-    thumb: r.fields.thumbnail_file_id ? getFileUrl(r.fields.thumbnail_file_id) : "",
-    tags: parseJson<string[]>(r.fields.tags) ?? [],
-  }));
+  // Owners also see archived art styles (so they can spot what's hidden); the
+  // public catalog stays Published-only.
+  const owner = await isOwner();
+  const filter = owner
+    ? "Status eq 'Published' or Status eq 'Archived'"
+    : "Status eq 'Published'";
+  const rows = await listArtStyles(filter).catch(() => []);
+  const items: ArtStyleItem[] = rows
+    .map((r) => ({
+      id: r.entity_id,
+      name: artStyleDisplayName(r.fields),
+      slug: r.fields.slug ?? "",
+      status: r.status,
+      medium: r.fields.medium ?? "",
+      promptTemplate: r.fields.prompt_template ?? "",
+      refs: refUrls(r.fields.reference_image_file_ids),
+      proofs: refUrls(r.fields.proof_shots_file_ids),
+      thumb: r.fields.thumbnail_file_id ? getFileUrl(r.fields.thumbnail_file_id) : "",
+      tags: parseJson<string[]>(r.fields.tags) ?? [],
+    }))
+    // Keep archived items last so they never crowd the live catalog.
+    .sort((a, b) => Number(a.status === "Archived") - Number(b.status === "Archived"));
 
   return (
     <div className="mx-auto w-full max-w-7xl px-4 py-6 sm:py-10">

--- a/ui/src/app/(site)/art-styles/page.tsx
+++ b/ui/src/app/(site)/art-styles/page.tsx
@@ -53,7 +53,7 @@ export default async function ArtStylesPage() {
         description="Engine-agnostic style recipes — reference images plus a portable subject/palette prompt. Remix them onto any UI language and palette in the Studio."
       />
       <div className="mt-10">
-        <ArtStyleCatalog items={items} />
+        <ArtStyleCatalog items={items} canArchive={owner} />
       </div>
     </div>
   );

--- a/ui/src/app/(site)/palettes/page.tsx
+++ b/ui/src/app/(site)/palettes/page.tsx
@@ -8,6 +8,7 @@ import {
 import { PageHero, Marker } from "@/components/page-hero";
 import { PaletteCatalog } from "@/components/lane-catalog";
 import type { PaletteItem } from "@/components/palette-card";
+import { isOwner } from "@/lib/owner";
 
 export const dynamic = "force-dynamic";
 export const metadata = {
@@ -16,20 +17,29 @@ export const metadata = {
 };
 
 export default async function PalettesPage() {
-  const rows = await listPaletteSystems("Status eq 'Published'").catch(() => []);
-  const items: PaletteItem[] = rows.map((r) => {
-    const core = paletteCore(r.fields);
-    return {
-      id: r.entity_id,
-      name: paletteDisplayName(r.fields, core),
-      slug: r.fields.slug ?? "",
-      status: r.status,
-      roles: paletteRoles(r.fields),
-      core,
-      ramps: parseJson<Record<string, Record<string, string>>>(r.fields.ramps) ?? {},
-      tags: parseJson<string[]>(r.fields.tags) ?? [],
-    };
-  });
+  // Owners also see archived palettes (so they can spot what's hidden); the
+  // public catalog stays Published-only.
+  const owner = await isOwner();
+  const filter = owner
+    ? "Status eq 'Published' or Status eq 'Archived'"
+    : "Status eq 'Published'";
+  const rows = await listPaletteSystems(filter).catch(() => []);
+  const items: PaletteItem[] = rows
+    .map((r) => {
+      const core = paletteCore(r.fields);
+      return {
+        id: r.entity_id,
+        name: paletteDisplayName(r.fields, core),
+        slug: r.fields.slug ?? "",
+        status: r.status,
+        roles: paletteRoles(r.fields),
+        core,
+        ramps: parseJson<Record<string, Record<string, string>>>(r.fields.ramps) ?? {},
+        tags: parseJson<string[]>(r.fields.tags) ?? [],
+      };
+    })
+    // Keep archived items last so they never crowd the live catalog.
+    .sort((a, b) => Number(a.status === "Archived") - Number(b.status === "Archived"));
 
   return (
     <div className="mx-auto w-full max-w-7xl px-4 py-6 sm:py-10">
@@ -40,7 +50,7 @@ export default async function PalettesPage() {
         description="Curated color systems — semantic roles, tonal ramps, and contrast guidance. Pair any of these with a UI language and an art style in the Studio."
       />
       <div className="mt-10">
-        <PaletteCatalog items={items} />
+        <PaletteCatalog items={items} canArchive={owner} />
       </div>
     </div>
   );

--- a/ui/src/app/(site)/palettes/page.tsx
+++ b/ui/src/app/(site)/palettes/page.tsx
@@ -36,6 +36,7 @@ export default async function PalettesPage() {
         core,
         ramps: parseJson<Record<string, Record<string, string>>>(r.fields.ramps) ?? {},
         tags: parseJson<string[]>(r.fields.tags) ?? [],
+        featured: /^(true|1)$/i.test(String(r.fields.featured ?? "")),
       };
     })
     // Keep archived items last so they never crowd the live catalog.

--- a/ui/src/app/actions.ts
+++ b/ui/src/app/actions.ts
@@ -29,6 +29,33 @@ export async function deleteLanguage(id: string): Promise<void> {
   revalidatePath(`/language/${id}`);
 }
 
+/**
+ * Catalog lanes whose cards can be archived from owner-mode controls, mapped
+ * to the paths to revalidate after the status changes. Design languages keep
+ * their own `deleteLanguage` action; this covers the other lanes the same way.
+ */
+const CATALOG_ARCHIVE_TARGETS: Record<string, (id: string) => string[]> = {
+  PaletteSystems: (id) => ["/palettes", `/palettes/${id}`],
+  ArtStyles: (id) => ["/art-styles", `/art-styles/${id}`],
+};
+
+export async function archiveCatalogItem(
+  entitySet: string,
+  id: string,
+): Promise<void> {
+  await assertOwner();
+  const revalidate = CATALOG_ARCHIVE_TARGETS[entitySet];
+  if (!revalidate) {
+    throw new Error(`Archiving ${entitySet} is not supported.`);
+  }
+  await dispatchAction(entitySet, id, "Archive", {
+    curator_notes: OWNER_ARCHIVE_NOTE,
+  });
+  for (const path of revalidate(id)) {
+    revalidatePath(path);
+  }
+}
+
 export async function sendLanguageToReview(id: string): Promise<void> {
   await assertOwner();
   const lang = await getDesignLanguage(id);

--- a/ui/src/components/archive-entity-button.tsx
+++ b/ui/src/components/archive-entity-button.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { createPortal } from "react-dom";
+import { useRouter } from "next/navigation";
+import { AlertTriangle, Archive, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { archiveCatalogItem } from "@/app/actions";
+
+/**
+ * Generic owner archive control for a catalog lane entity (palette, art
+ * style — design languages keep their own DeleteLanguageButton). It mirrors
+ * that button's risograph dialog exactly, parameterized by the OData entity
+ * set and a human noun, so every lane archives "the same way". The server
+ * action re-checks owner mode before it changes anything.
+ */
+export interface ArchiveEntityTarget {
+  id: string;
+  name: string;
+}
+
+export function ArchiveEntityButton({
+  entitySet,
+  id,
+  name,
+  noun,
+  redirectTo,
+  variant = "button",
+}: {
+  entitySet: string;
+  id: string;
+  name: string;
+  noun: string;
+  redirectTo?: string;
+  variant?: "button" | "icon";
+}) {
+  const [confirming, setConfirming] = useState(false);
+
+  if (variant === "icon") {
+    return (
+      <>
+        <button
+          type="button"
+          className="group/archive relative flex h-7 w-7 items-center justify-center rounded-[3px] bg-[color-mix(in_srgb,var(--beni)_14%,var(--paper-stamp-mix))] text-[color-mix(in_oklch,var(--beni)_72%,var(--foreground))] shadow-[0_1px_0_rgba(30,35,45,0.08)] transition-all hover:-translate-y-0.5 hover:rotate-[2deg] hover:bg-[var(--beni)] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/30 disabled:pointer-events-none disabled:opacity-60"
+          aria-label={`Archive ${name}`}
+          title={`Archive ${name}`}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setConfirming(true);
+          }}
+        >
+          <span
+            aria-hidden
+            className="absolute -right-1 -top-1 h-2 w-2 rounded-full bg-[var(--sakura)] opacity-0 transition-opacity group-hover/archive:opacity-100"
+          />
+          <Archive className="h-3.5 w-3.5" />
+        </button>
+        <ArchiveEntityDialog
+          key={confirming ? id : "closed"}
+          entitySet={entitySet}
+          target={{ id, name }}
+          noun={noun}
+          open={confirming}
+          onOpenChange={setConfirming}
+          redirectTo={redirectTo}
+        />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Button variant="destructive" size="sm" onClick={() => setConfirming(true)}>
+        <Archive className="h-4 w-4 mr-1" />
+        Archive
+      </Button>
+      <ArchiveEntityDialog
+        key={confirming ? id : "closed"}
+        entitySet={entitySet}
+        target={{ id, name }}
+        noun={noun}
+        open={confirming}
+        onOpenChange={setConfirming}
+        redirectTo={redirectTo}
+      />
+    </>
+  );
+}
+
+export function ArchiveEntityDialog({
+  entitySet,
+  target,
+  noun,
+  open,
+  onOpenChange,
+  redirectTo,
+}: {
+  entitySet: string;
+  target: ArchiveEntityTarget | null;
+  noun: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  redirectTo?: string;
+}) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape" && !isPending) {
+        onOpenChange(false);
+      }
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isPending, onOpenChange, open]);
+
+  if (!open || !target || typeof document === "undefined") return null;
+
+  function handleArchive() {
+    if (!target) return;
+    setError(null);
+    startTransition(async () => {
+      try {
+        await archiveCatalogItem(entitySet, target.id);
+        onOpenChange(false);
+        if (redirectTo) {
+          router.push(redirectTo);
+        } else {
+          router.refresh();
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Could not archive.");
+      }
+    });
+  }
+
+  const dialog = (
+    <>
+      <div
+        className="fixed inset-0 z-[80] bg-[rgba(36,24,28,0.42)] backdrop-blur-[4px]"
+        onClick={() => {
+          if (!isPending) onOpenChange(false);
+        }}
+      />
+      <div className="fixed inset-0 z-[81] flex items-center justify-center p-4">
+        <div
+          role="alertdialog"
+          aria-modal="true"
+          aria-labelledby={`archive-${target.id}-title`}
+          aria-describedby={`archive-${target.id}-description`}
+          className="relative w-full max-w-[420px] overflow-hidden bg-[var(--paper-sticker)] p-5 text-foreground dark:bg-popover"
+          style={{
+            boxShadow: "var(--shadow-card)",
+          }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <span
+            aria-hidden
+            className="pointer-events-none absolute -left-5 top-3 h-[18px] w-28 rounded-[1px]"
+            style={{
+              background: "var(--sakura)",
+              opacity: 0.75,
+              mixBlendMode: "var(--ink-blend)" as never,
+              transform: "rotate(-8deg)",
+            }}
+          />
+          <span
+            aria-hidden
+            className="pointer-events-none absolute -right-3 top-5 h-[16px] w-20 rounded-[1px]"
+            style={{
+              background: "var(--yuzu)",
+              opacity: 0.75,
+              mixBlendMode: "var(--ink-blend)" as never,
+              transform: "rotate(8deg)",
+            }}
+          />
+          <button
+            type="button"
+            aria-label="Cancel archive"
+            disabled={isPending}
+            onClick={() => onOpenChange(false)}
+            className="absolute right-3 top-3 flex h-7 w-7 items-center justify-center rounded-[3px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+          >
+            <X className="h-4 w-4" />
+          </button>
+
+          <div className="relative space-y-4 pt-5">
+            <div className="flex items-start gap-3">
+              <span className="relative flex h-11 w-11 shrink-0 items-center justify-center rounded-[2px] bg-[color-mix(in_srgb,var(--beni)_14%,var(--paper-stamp-mix))] text-destructive shadow-[0_1px_0_rgba(30,35,45,0.08)]">
+                <Archive className="h-5 w-5 rotate-[-8deg]" />
+              </span>
+              <div className="min-w-0 space-y-1">
+                <div className="stamp inline-flex text-[var(--beni)]">
+                  catalog archive
+                </div>
+                <h3
+                  id={`archive-${target.id}-title`}
+                  className="font-display text-[23px] font-bold leading-tight tracking-[-0.02em]"
+                >
+                  Archive &ldquo;{target.name}&rdquo;?
+                </h3>
+              </div>
+            </div>
+
+            <p
+              id={`archive-${target.id}-description`}
+              className="text-sm leading-relaxed text-muted-foreground"
+            >
+              This hides the {noun} from the public catalog without deleting its
+              record. The server checks owner mode again before it changes
+              anything.
+            </p>
+
+            {error ? (
+              <div
+                className="relative bg-destructive/10 px-3 py-2 text-sm font-medium text-destructive"
+                style={{
+                  boxShadow: "var(--shadow-card)",
+                }}
+              >
+                <AlertTriangle className="mr-2 inline h-4 w-4 align-[-3px]" />
+                {error}
+              </div>
+            ) : null}
+
+            <div className="sticker-perforation" />
+
+            <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                onClick={() => onOpenChange(false)}
+                disabled={isPending}
+                className="h-8 rounded-[3px] bg-[color-mix(in_srgb,var(--foreground)_8%,var(--paper-stamp-mix))] px-3 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-muted-foreground transition-all hover:-translate-y-0.5 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+              >
+                keep it
+              </button>
+              <button
+                type="button"
+                onClick={handleArchive}
+                disabled={isPending}
+                className="h-8 rounded-[3px] bg-[color-mix(in_srgb,var(--beni)_14%,var(--paper-stamp-mix))] px-3 font-mono text-[10px] font-black uppercase tracking-[0.16em] text-[color-mix(in_oklch,var(--beni)_72%,var(--foreground))] shadow-[0_2px_0_rgba(30,35,45,0.08)] transition-all hover:-translate-y-0.5 hover:rotate-[0.6deg] hover:bg-[var(--beni)] hover:text-white disabled:pointer-events-none disabled:opacity-60"
+              >
+                {isPending ? "archiving..." : "archive"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+
+  return createPortal(dialog, document.body);
+}

--- a/ui/src/components/archived-stamp.tsx
+++ b/ui/src/components/archived-stamp.tsx
@@ -1,0 +1,15 @@
+/**
+ * Corner marker shown on a catalog card that has been archived. Archived
+ * items are only fetched for owners, so this is an owner-facing cue that the
+ * item is hidden from the public catalog — a quiet beni stamp, no border.
+ */
+export function ArchivedStamp() {
+  return (
+    <span
+      className="pointer-events-none absolute left-2 top-2 z-20 rounded-[2px] bg-[color-mix(in_srgb,var(--beni)_16%,var(--paper-sticker))] px-1.5 py-0.5 font-mono text-[9px] font-black uppercase tracking-[0.16em] text-[color-mix(in_oklch,var(--beni)_72%,var(--foreground))] shadow-[0_1px_0_rgba(30,35,45,0.08)]"
+      style={{ transform: "rotate(-2deg)" }}
+    >
+      archived
+    </span>
+  );
+}

--- a/ui/src/components/art-style-card.tsx
+++ b/ui/src/components/art-style-card.tsx
@@ -1,3 +1,6 @@
+import { CatalogCardOwnerControls } from "@/components/catalog-card-owner-controls";
+import { ArchivedStamp } from "@/components/archived-stamp";
+
 export interface ArtStyleItem {
   id: string;
   name: string;
@@ -26,8 +29,15 @@ function hashInt(s: string) {
   return Math.abs(h);
 }
 
-export function ArtStyleCard({ art }: { art: ArtStyleItem }) {
+export function ArtStyleCard({
+  art,
+  owner = false,
+}: {
+  art: ArtStyleItem;
+  owner?: boolean;
+}) {
   const tint = accentColors[hashInt(art.id) % accentColors.length];
+  const archived = art.status === "Archived";
 
   // A wide hero (the establishing shot) leads; the proof shots read as a tidy
   // contact strip of fixed-size squares (never a stretched orphan). Falls back
@@ -42,7 +52,7 @@ export function ArtStyleCard({ art }: { art: ArtStyleItem }) {
 
   return (
     <article
-      className="sticker-card group/card relative flex h-full w-full flex-col overflow-hidden"
+      className={`sticker-card group/card relative flex h-full w-full flex-col overflow-hidden${archived ? " opacity-60 saturate-[0.85]" : ""}`}
       style={
         {
           background: `color-mix(in srgb, ${tint} 5%, var(--paper-tint-base))`,
@@ -50,6 +60,16 @@ export function ArtStyleCard({ art }: { art: ArtStyleItem }) {
         } as React.CSSProperties
       }
     >
+      {archived ? <ArchivedStamp /> : null}
+      {owner ? (
+        <CatalogCardOwnerControls
+          entitySet="ArtStyles"
+          id={art.id}
+          name={art.name}
+          noun="art style"
+          status={art.status}
+        />
+      ) : null}
       {/* hero reference — edge to edge; proofs ride as a small strip in the corner */}
       <div className="relative w-full overflow-hidden bg-muted" style={{ aspectRatio: "16 / 10" }}>
         {hero ? (

--- a/ui/src/components/catalog-card-owner-controls.tsx
+++ b/ui/src/components/catalog-card-owner-controls.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { ArchiveEntityButton } from "@/components/archive-entity-button";
+
+/**
+ * Owner-mode controls for a catalog lane card (palette, art style). Mirrors
+ * LanguageCardOwnerControls — same risograph sticker chrome, same corner
+ * placement, same click-swallow so the control never triggers the card's
+ * link — but generic over the entity. Archive is only offered while the item
+ * is still live; an already-archived item shows nothing to act on (matching
+ * the one-way design-language flow).
+ */
+export function CatalogCardOwnerControls({
+  entitySet,
+  id,
+  name,
+  noun,
+  status,
+}: {
+  entitySet: string;
+  id: string;
+  name: string;
+  noun: string;
+  status: string;
+}) {
+  if (status === "Archived") return null;
+
+  return (
+    <div
+      className="absolute right-2 top-2 z-30 flex items-center gap-1 rounded-[2px] bg-[color-mix(in_oklch,var(--paper-sticker)_92%,transparent)] p-1 backdrop-blur-[2px]"
+      style={{
+        transform: "rotate(-1deg)",
+        boxShadow: "var(--shadow-card)",
+      }}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      }}
+    >
+      <span
+        aria-hidden
+        className="pointer-events-none absolute -left-2 -top-1.5 h-[9px] w-11 rounded-[1px]"
+        style={{
+          background: "var(--yuzu)",
+          opacity: 0.75,
+          mixBlendMode: "var(--ink-blend)" as never,
+          transform: "rotate(-5deg)",
+        }}
+      />
+      <ArchiveEntityButton
+        entitySet={entitySet}
+        id={id}
+        name={name}
+        noun={noun}
+        variant="icon"
+      />
+    </div>
+  );
+}

--- a/ui/src/components/lane-catalog.tsx
+++ b/ui/src/components/lane-catalog.tsx
@@ -50,7 +50,13 @@ function SearchBar({
   );
 }
 
-export function PaletteCatalog({ items }: { items: PaletteItem[] }) {
+export function PaletteCatalog({
+  items,
+  canArchive = false,
+}: {
+  items: PaletteItem[];
+  canArchive?: boolean;
+}) {
   const [q, setQ] = useState("");
   const filtered = useMemo(() => {
     const query = q.trim().toLowerCase();
@@ -67,7 +73,7 @@ export function PaletteCatalog({ items }: { items: PaletteItem[] }) {
         <div data-reveal-children className="grid grid-cols-2 items-start gap-3 sm:gap-4 md:grid-cols-3 lg:grid-cols-4">
           {filtered.map((p) => (
             <Link key={p.id} href={`/palettes/${p.id}`} prefetch={false} className="group block min-w-0">
-              <PaletteCard palette={p} />
+              <PaletteCard palette={p} owner={canArchive} />
             </Link>
           ))}
         </div>
@@ -78,7 +84,13 @@ export function PaletteCatalog({ items }: { items: PaletteItem[] }) {
   );
 }
 
-export function ArtStyleCatalog({ items }: { items: ArtStyleItem[] }) {
+export function ArtStyleCatalog({
+  items,
+  canArchive = false,
+}: {
+  items: ArtStyleItem[];
+  canArchive?: boolean;
+}) {
   const [q, setQ] = useState("");
   const filtered = useMemo(() => {
     const query = q.trim().toLowerCase();
@@ -95,7 +107,7 @@ export function ArtStyleCatalog({ items }: { items: ArtStyleItem[] }) {
         <div data-reveal-children className="grid grid-cols-2 items-start gap-3 sm:gap-4 md:grid-cols-3 lg:grid-cols-4">
           {filtered.map((a) => (
             <Link key={a.id} href={`/art-styles/${a.id}`} prefetch={false} className="group block min-w-0">
-              <ArtStyleCard art={a} />
+              <ArtStyleCard art={a} owner={canArchive} />
             </Link>
           ))}
         </div>

--- a/ui/src/components/lane-catalog.tsx
+++ b/ui/src/components/lane-catalog.tsx
@@ -1,11 +1,83 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import Link from "next/link";
 import { Search } from "lucide-react";
 import { PaletteCard, type PaletteItem } from "@/components/palette-card";
 import { ArtStyleCard, type ArtStyleItem } from "@/components/art-style-card";
 import { KX_FIELD } from "@/lib/katagami-ui";
+import {
+  COLOR_MOOD_SHELVES,
+  colorMoodShelfKey,
+  groupIntoShelves,
+  type ShelfBucket,
+  type ShelfDef,
+} from "@/lib/color-shelves";
+
+const GRID =
+  "grid grid-cols-2 items-start gap-3 sm:gap-4 md:grid-cols-3 lg:grid-cols-4";
+
+/** A lane shelves itself once it outgrows a flat wall; below this it's a
+ *  single grid. Lower than the language gallery's threshold because the
+ *  palette/art catalogs are smaller. */
+const LANE_SHELF_THRESHOLD = 8;
+
+/** Archived items collect in a trailing shelf (owners only ever see these). */
+const ARCHIVED_SHELF: ShelfDef = {
+  key: "archived",
+  label: "archived",
+  blurb: "hidden from the public catalog",
+  ink: "var(--beni)",
+};
+
+/** Palette shelves reuse the language color-mood cabinet, plus archived. */
+const PALETTE_SHELVES: ShelfDef[] = [...COLOR_MOOD_SHELVES, ARCHIVED_SHELF];
+
+const MEDIUM_INKS = [
+  "var(--sakura)", "var(--yuzu)", "var(--salad)",
+  "var(--teal)", "var(--ramune)", "var(--sumire)",
+];
+
+function paletteShelfKey(p: PaletteItem): string {
+  if (p.status === "Archived") return "archived";
+  return colorMoodShelfKey({
+    primary: p.core.signature?.[0]?.hex,
+    background: p.core.neutrals?.bg,
+    featured: p.featured,
+  });
+}
+
+/** Art styles have no token palette, so they shelve by medium (largest medium
+ *  first), with archived collected last. */
+function mediumShelves(items: ArtStyleItem[]): ShelfBucket<ArtStyleItem>[] {
+  const buckets = new Map<string, ArtStyleItem[]>();
+  const archived: ArtStyleItem[] = [];
+  for (const a of items) {
+    if (a.status === "Archived") {
+      archived.push(a);
+      continue;
+    }
+    const key = (a.medium || "mixed").trim().toLowerCase() || "mixed";
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push(a);
+    else buckets.set(key, [a]);
+  }
+  const shelves: ShelfBucket<ArtStyleItem>[] = [...buckets.entries()]
+    .sort((a, b) => b[1].length - a[1].length || a[0].localeCompare(b[0]))
+    .map(([key, arr], i) => ({
+      key,
+      label: key,
+      blurb: "",
+      ink: MEDIUM_INKS[i % MEDIUM_INKS.length],
+      items: arr,
+    }));
+  if (archived.length) shelves.push({ ...ARCHIVED_SHELF, items: archived });
+  return shelves;
+}
+
+function activeCount(items: { status: string }[]): number {
+  return items.reduce((n, i) => n + (i.status === "Archived" ? 0 : 1), 0);
+}
 
 function SearchBar({
   value,
@@ -50,6 +122,66 @@ function SearchBar({
   );
 }
 
+function LaneGrid<T extends { id: string }>({
+  items,
+  hrefBase,
+  renderCard,
+}: {
+  items: T[];
+  hrefBase: string;
+  renderCard: (item: T) => ReactNode;
+}) {
+  return (
+    <div data-reveal-children className={GRID}>
+      {items.map((item) => (
+        <Link
+          key={item.id}
+          href={`${hrefBase}/${item.id}`}
+          prefetch={false}
+          className="group block min-w-0"
+        >
+          {renderCard(item)}
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+/** Labeled color-mood / medium shelves — a stamp label + count over a grid,
+ *  matching the home gallery's cabinet. */
+function ShelfSections<T extends { id: string }>({
+  shelves,
+  hrefBase,
+  renderCard,
+}: {
+  shelves: ShelfBucket<T>[];
+  hrefBase: string;
+  renderCard: (item: T) => ReactNode;
+}) {
+  return (
+    <div className="space-y-7">
+      {shelves.map((shelf) => (
+        <section key={shelf.key} data-shelf-section={shelf.key} className="min-w-0">
+          <div className="mb-2 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2">
+            <span
+              className="ink-stamp shrink-0"
+              style={{ ["--ink" as string]: shelf.ink }}
+            >
+              {shelf.label}
+            </span>
+            <span className="min-w-0 truncate font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+              {shelf.blurb ? `${shelf.blurb} · ` : ""}
+              {shelf.items.length}
+            </span>
+            <span className="sticker-perforation hidden min-w-0 flex-1 sm:block" />
+          </div>
+          <LaneGrid items={shelf.items} hrefBase={hrefBase} renderCard={renderCard} />
+        </section>
+      ))}
+    </div>
+  );
+}
+
 export function PaletteCatalog({
   items,
   canArchive = false,
@@ -62,23 +194,36 @@ export function PaletteCatalog({
     const query = q.trim().toLowerCase();
     if (!query) return items;
     return items.filter((p) =>
-      `${p.name} ${p.tags.join(" ")} ${Object.values(p.roles).join(" ")}`.toLowerCase().includes(query),
+      `${p.name} ${p.tags.join(" ")} ${Object.values(p.roles).join(" ")}`
+        .toLowerCase()
+        .includes(query),
     );
   }, [q, items]);
+  const shelves = useMemo(() => {
+    if (q.trim() || activeCount(items) <= LANE_SHELF_THRESHOLD) return null;
+    return groupIntoShelves(items, paletteShelfKey, PALETTE_SHELVES);
+  }, [q, items]);
+
+  const renderCard = (p: PaletteItem) => (
+    <PaletteCard palette={p} owner={canArchive} />
+  );
 
   return (
     <>
-      <SearchBar value={q} onChange={setQ} placeholder="Search palettes by name, tag, or hex…" count={filtered.length} total={items.length} noun="palettes" />
-      {filtered.length ? (
-        <div data-reveal-children className="grid grid-cols-2 items-start gap-3 sm:gap-4 md:grid-cols-3 lg:grid-cols-4">
-          {filtered.map((p) => (
-            <Link key={p.id} href={`/palettes/${p.id}`} prefetch={false} className="group block min-w-0">
-              <PaletteCard palette={p} owner={canArchive} />
-            </Link>
-          ))}
-        </div>
-      ) : (
+      <SearchBar
+        value={q}
+        onChange={setQ}
+        placeholder="Search palettes by name, tag, or hex…"
+        count={filtered.length}
+        total={items.length}
+        noun="palettes"
+      />
+      {filtered.length === 0 ? (
         <EmptyState noun="palettes" />
+      ) : shelves ? (
+        <ShelfSections shelves={shelves} hrefBase="/palettes" renderCard={renderCard} />
+      ) : (
+        <LaneGrid items={filtered} hrefBase="/palettes" renderCard={renderCard} />
       )}
     </>
   );
@@ -96,23 +241,36 @@ export function ArtStyleCatalog({
     const query = q.trim().toLowerCase();
     if (!query) return items;
     return items.filter((a) =>
-      `${a.name} ${a.medium} ${a.tags.join(" ")} ${a.promptTemplate}`.toLowerCase().includes(query),
+      `${a.name} ${a.medium} ${a.tags.join(" ")} ${a.promptTemplate}`
+        .toLowerCase()
+        .includes(query),
     );
   }, [q, items]);
+  const shelves = useMemo(() => {
+    if (q.trim() || activeCount(items) <= LANE_SHELF_THRESHOLD) return null;
+    return mediumShelves(items);
+  }, [q, items]);
+
+  const renderCard = (a: ArtStyleItem) => (
+    <ArtStyleCard art={a} owner={canArchive} />
+  );
 
   return (
     <>
-      <SearchBar value={q} onChange={setQ} placeholder="Search art styles by name, medium, or prompt…" count={filtered.length} total={items.length} noun="art styles" />
-      {filtered.length ? (
-        <div data-reveal-children className="grid grid-cols-2 items-start gap-3 sm:gap-4 md:grid-cols-3 lg:grid-cols-4">
-          {filtered.map((a) => (
-            <Link key={a.id} href={`/art-styles/${a.id}`} prefetch={false} className="group block min-w-0">
-              <ArtStyleCard art={a} owner={canArchive} />
-            </Link>
-          ))}
-        </div>
-      ) : (
+      <SearchBar
+        value={q}
+        onChange={setQ}
+        placeholder="Search art styles by name, medium, or prompt…"
+        count={filtered.length}
+        total={items.length}
+        noun="art styles"
+      />
+      {filtered.length === 0 ? (
         <EmptyState noun="art styles" />
+      ) : shelves ? (
+        <ShelfSections shelves={shelves} hrefBase="/art-styles" renderCard={renderCard} />
+      ) : (
+        <LaneGrid items={filtered} hrefBase="/art-styles" renderCard={renderCard} />
       )}
     </>
   );

--- a/ui/src/components/language-gallery.tsx
+++ b/ui/src/components/language-gallery.tsx
@@ -2,6 +2,7 @@ import type { DesignLanguage } from "@/lib/odata";
 import { LanguageCard } from "@/components/language-card";
 import { GalleryFilters } from "@/components/gallery-filters";
 import { ShelfSpread } from "@/components/shelf-spread";
+import { COLOR_MOOD_SHELVES, colorMoodShelfKey } from "@/lib/color-shelves";
 
 /** Shelves only make sense once the catalog outgrows a single wall. */
 const SHELF_THRESHOLD = 24;
@@ -152,40 +153,6 @@ interface Shelf {
   languages: DesignLanguage[];
 }
 
-/** Shelf definitions, in display order. Membership is computed from each
- *  language's OWN token colors — the cabinet organizes itself by what the
- *  designs actually look like, not by tag bookkeeping. */
-const SHELF_DEFS = [
-  { key: "picks", label: "curator's picks", blurb: "pinned to the corkboard", ink: "var(--sakura)" },
-  { key: "night", label: "night stock", blurb: "printed on dark paper", ink: "var(--ramune)" },
-  { key: "loud", label: "loud inks", blurb: "full coverage, no apologies", ink: "var(--sakura)" },
-  { key: "quiet", label: "quiet paper", blurb: "restraint and whitespace", ink: "var(--ramune)" },
-  { key: "warm", label: "warm press", blurb: "earth, amber, ember", ink: "var(--yuzu)" },
-  { key: "cold", label: "cold press", blurb: "sea, slate, shade", ink: "var(--ramune)" },
-  { key: "misc", label: "miscellany", blurb: "everything else", ink: "var(--graphite)" },
-] as const;
-
-function hexParts(hex?: string): { h: number; s: number; l: number } | null {
-  if (!hex || !/^#[0-9a-f]{3,8}$/i.test(hex)) return null;
-  const m = hex.replace("#", "");
-  const v =
-    m.length === 3
-      ? m.split("").map((c) => parseInt(c + c, 16) / 255)
-      : [0, 2, 4].map((i) => parseInt(m.slice(i, i + 2), 16) / 255);
-  const [r, g, b] = v;
-  const max = Math.max(r, g, b);
-  const min = Math.min(r, g, b);
-  const l = (max + min) / 2;
-  if (max === min) return { h: 0, s: 0, l };
-  const d = max - min;
-  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-  let h: number;
-  if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) * 60;
-  else if (max === g) h = ((b - r) / d + 2) * 60;
-  else h = ((r - g) / d + 4) * 60;
-  return { h, s, l };
-}
-
 function isFeaturedLanguage(lang: DesignLanguage): boolean {
   const bag = lang as unknown as Record<string, unknown>;
   for (const c of [bag.booleans, bag.fields, bag.counters, bag]) {
@@ -198,19 +165,15 @@ function isFeaturedLanguage(lang: DesignLanguage): boolean {
 }
 
 function shelfKeyFor(lang: DesignLanguage): string {
-  if (isFeaturedLanguage(lang)) return "picks";
   const tokens = parseMaybeJson(lang.fields.tokens) as
     | { colors?: Record<string, string> }
     | undefined;
   const colors = tokens?.colors ?? {};
-  const bg = hexParts(colors.background);
-  const prim = hexParts(colors.primary ?? colors.accent);
-  if (bg && bg.l < 0.38) return "night";
-  if (!prim) return "misc";
-  if (prim.s < 0.24) return "quiet";
-  if (prim.s > 0.6 && prim.l > 0.28 && prim.l < 0.82) return "loud";
-  const warm = prim.h < 90 || prim.h >= 330;
-  return warm ? "warm" : "cold";
+  return colorMoodShelfKey({
+    primary: colors.primary ?? colors.accent,
+    background: colors.background,
+    featured: isFeaturedLanguage(lang),
+  });
 }
 
 function buildShelves(languages: DesignLanguage[]): Shelf[] {
@@ -226,9 +189,9 @@ function buildShelves(languages: DesignLanguage[]): Shelf[] {
     bucket.push(lang);
     buckets.set(key, bucket);
   }
-  return SHELF_DEFS.filter((def) => (buckets.get(def.key)?.length ?? 0) > 0).map(
-    (def) => ({ ...def, languages: buckets.get(def.key)! }),
-  );
+  return COLOR_MOOD_SHELVES.filter(
+    (def) => (buckets.get(def.key)?.length ?? 0) > 0,
+  ).map((def) => ({ ...def, languages: buckets.get(def.key)! }));
 }
 
 function assignGlobalIndices(shelves: Shelf[]): Map<string, number> {

--- a/ui/src/components/palette-card.tsx
+++ b/ui/src/components/palette-card.tsx
@@ -14,6 +14,8 @@ export interface PaletteItem {
   core: PaletteCore;
   ramps: Record<string, Record<string, string>>;
   tags: string[];
+  /** Owner-pinned — floats to the "curator's picks" shelf. */
+  featured?: boolean;
 }
 
 const NEUTRAL_ORDER = ["bg", "surface", "text", "muted", "border"];

--- a/ui/src/components/palette-card.tsx
+++ b/ui/src/components/palette-card.tsx
@@ -1,4 +1,6 @@
 import { readableTextColor } from "@/lib/shadcn-export";
+import { CatalogCardOwnerControls } from "@/components/catalog-card-owner-controls";
+import { ArchivedStamp } from "@/components/archived-stamp";
 import type { PaletteCore } from "@/lib/odata";
 
 export interface PaletteItem {
@@ -21,16 +23,33 @@ const NEUTRAL_ORDER = ["bg", "surface", "text", "muted", "border"];
  * card. A tall signature band (the star) sits over a thin neutrals strip;
  * a quiet footer carries the name + mood. No frame, no chrome.
  */
-export function PaletteCard({ palette }: { palette: PaletteItem }) {
+export function PaletteCard({
+  palette,
+  owner = false,
+}: {
+  palette: PaletteItem;
+  owner?: boolean;
+}) {
   const { signature, neutrals, mood } = palette.core;
   const sig = signature.length ? signature : [{ hex: "#888888", name: "—" }];
   const tint = sig[0].hex || "var(--teal)";
+  const archived = palette.status === "Archived";
 
   return (
     <article
-      className="sticker-card group/card relative flex h-full w-full flex-col overflow-hidden"
+      className={`sticker-card group/card relative flex h-full w-full flex-col overflow-hidden${archived ? " opacity-60 saturate-[0.85]" : ""}`}
       style={{ ["--card-ink" as string]: tint }}
     >
+      {archived ? <ArchivedStamp /> : null}
+      {owner ? (
+        <CatalogCardOwnerControls
+          entitySet="PaletteSystems"
+          id={palette.id}
+          name={palette.name}
+          noun="palette"
+          status={palette.status}
+        />
+      ) : null}
       {/* SIGNATURE — the star, full-bleed colour band */}
       <div className="flex h-32 w-full sm:h-36">
         {sig.slice(0, 5).map((s, i) => {

--- a/ui/src/lib/color-shelves.ts
+++ b/ui/src/lib/color-shelves.ts
@@ -1,0 +1,86 @@
+/**
+ * Color-mood shelves — the self-organizing "cabinet" the home gallery and the
+ * palette lane both use. An item's shelf is computed from its OWN colors (a
+ * dark ground → night stock, a vivid primary → loud inks, etc.), so the
+ * catalog organizes itself by what the designs actually look like rather than
+ * by tag bookkeeping. Shared so languages and palettes speak the same
+ * vocabulary.
+ */
+export interface ShelfDef {
+  key: string;
+  label: string;
+  blurb: string;
+  ink: string;
+}
+
+/** Shelf definitions, in display order. */
+export const COLOR_MOOD_SHELVES: ShelfDef[] = [
+  { key: "picks", label: "curator's picks", blurb: "pinned to the corkboard", ink: "var(--sakura)" },
+  { key: "night", label: "night stock", blurb: "printed on dark paper", ink: "var(--ramune)" },
+  { key: "loud", label: "loud inks", blurb: "full coverage, no apologies", ink: "var(--sakura)" },
+  { key: "quiet", label: "quiet paper", blurb: "restraint and whitespace", ink: "var(--ramune)" },
+  { key: "warm", label: "warm press", blurb: "earth, amber, ember", ink: "var(--yuzu)" },
+  { key: "cold", label: "cold press", blurb: "sea, slate, shade", ink: "var(--ramune)" },
+  { key: "misc", label: "miscellany", blurb: "everything else", ink: "var(--graphite)" },
+];
+
+/** Parse a hex color to HSL parts (h 0–360, s/l 0–1), or null if unparseable. */
+export function hexParts(hex?: string): { h: number; s: number; l: number } | null {
+  if (!hex || !/^#[0-9a-f]{3,8}$/i.test(hex)) return null;
+  const m = hex.replace("#", "");
+  const v =
+    m.length === 3
+      ? m.split("").map((c) => parseInt(c + c, 16) / 255)
+      : [0, 2, 4].map((i) => parseInt(m.slice(i, i + 2), 16) / 255);
+  const [r, g, b] = v;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  if (max === min) return { h: 0, s: 0, l };
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  let h: number;
+  if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) * 60;
+  else if (max === g) h = ((b - r) / d + 2) * 60;
+  else h = ((r - g) / d + 4) * 60;
+  return { h, s, l };
+}
+
+/** The color-mood cascade — first match wins, in shelf display order. */
+export function colorMoodShelfKey(opts: {
+  primary?: string;
+  background?: string;
+  featured?: boolean;
+}): string {
+  if (opts.featured) return "picks";
+  const bg = hexParts(opts.background);
+  const prim = hexParts(opts.primary);
+  if (bg && bg.l < 0.38) return "night";
+  if (!prim) return "misc";
+  if (prim.s < 0.24) return "quiet";
+  if (prim.s > 0.6 && prim.l > 0.28 && prim.l < 0.82) return "loud";
+  const warm = prim.h < 90 || prim.h >= 330;
+  return warm ? "warm" : "cold";
+}
+
+export interface ShelfBucket<T> extends ShelfDef {
+  items: T[];
+}
+
+/** Bucket items into the given shelf defs, in def order, dropping empties. */
+export function groupIntoShelves<T>(
+  items: T[],
+  keyFn: (item: T) => string,
+  defs: ShelfDef[],
+): ShelfBucket<T>[] {
+  const buckets = new Map<string, T[]>();
+  for (const item of items) {
+    const key = keyFn(item);
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push(item);
+    else buckets.set(key, [item]);
+  }
+  return defs
+    .filter((def) => (buckets.get(def.key)?.length ?? 0) > 0)
+    .map((def) => ({ ...def, items: buckets.get(def.key)! }));
+}


### PR DESCRIPTION
Two enhancements to the **palette** and **art-style** catalog lanes, mirroring patterns already used for design languages.

## 1. Owner archiving
Owners can archive palettes and art styles the same way they archive design languages. **UI-only** — the backend specs already define identical `Archive`/`Restore` actions and an `Archived` state.

- `archive-entity-button.tsx` — generic risograph archive button + confirm dialog (entity set + noun). Design languages keep their existing `DeleteLanguageButton`.
- `catalog-card-owner-controls.tsx` + `archived-stamp.tsx` — owner card chrome + "archived" marker.
- `archiveCatalogItem` server action — allowlisted to `PaletteSystems`/`ArtStyles`, re-checks owner mode, dispatches `Archive`, revalidates.
- Cards render owner controls behind an optional `owner` prop (public view unchanged); lane pages fetch archived items for owners only.

## 2. Shelves
The home gallery groups design languages into self-organizing **color-mood shelves**. The palette and art-style lanes now get the same browse-by-feel treatment.

- Extracted the color-mood cabinet into `lib/color-shelves.ts` (defs, hex→HSL, the first-match cascade, generic grouping) and refactored `language-gallery` to use it — one source of truth.
- **Palettes** shelve by color mood (from each palette's signature color + neutral ground; featured → "curator's picks") — mirrors languages.
- **Art styles** shelve by **medium** (largest first) — they have no token palette.
- Archived items collect in a trailing "archived" shelf (owners only).
- Shelves engage only when a lane outgrows a flat wall (>8 live items); below that, or while searching, it stays a single grid.

## Verification
- Live (local stack): public view shows no owner controls; owner sees archive buttons on all palettes + art styles, dialog copy correct. Palette lane groups into night/loud/quiet/cold; art lane into painting/photography/print; home language gallery unchanged (103 cards, same 5 shelves). Lint + production build green.
- One gap: backend **persistence** of an archive couldn't be exercised — the local Temper stack's SQLite is missing its `events` table, so every event-sourced write 409s (blocks the existing design-language archive identically). The action routed correctly (`KatagamiCommons.Archive` invoked → 409 from execution, not 404) and surfaced the error. No production palette was archived to force a green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)