### PR TITLE
fix(ui): tolerate non-string engine-hint/slot-recipe values on art-style page

### DIFF
--- a/ui/src/app/(site)/art-styles/[id]/page.tsx
+++ b/ui/src/app/(site)/art-styles/[id]/page.tsx
@@ -24,6 +24,15 @@ function refUrls(raw?: string): string[] {
   return Array.isArray(ids) ? ids.map((id) => getFileUrl(id)) : [];
 }
 
+/** Render a parsed-JSON value as text. These maps are typed as string values,
+ *  but contributor-submitted data can carry nested objects/arrays — handing a
+ *  raw object to JSX throws "Objects are not valid as a React child" and 500s
+ *  the page. Coerce so malformed data degrades to readable text instead. */
+function cellText(v: unknown): string {
+  if (v == null) return "";
+  return typeof v === "string" ? v : JSON.stringify(v);
+}
+
 export default async function ArtStyleDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   let art;
@@ -37,8 +46,8 @@ export default async function ArtStyleDetailPage({ params }: { params: Promise<{
   const medium = f.medium ?? "mixed";
   const promptTemplate = f.prompt_template ?? "";
   const negativePrompt = f.negative_prompt ?? "";
-  const engineHints = parseJson<Record<string, string>>(f.engine_hints) ?? {};
-  const slotRecipes = parseJson<Record<string, string>>(f.slot_recipes) ?? {};
+  const engineHints = parseJson<Record<string, unknown>>(f.engine_hints) ?? {};
+  const slotRecipes = parseJson<Record<string, unknown>>(f.slot_recipes) ?? {};
   const guidance = parseJson<{ do?: string[]; dont?: string[] }>(f.guidance);
   const tags = parseJson<string[]>(f.tags) ?? [];
 
@@ -131,7 +140,7 @@ export default async function ArtStyleDetailPage({ params }: { params: Promise<{
             <div className="grid gap-1.5 sm:grid-cols-2">
               {Object.entries(slotRecipes).map(([k, v]) => (
                 <div key={k} className={`rounded-[3px] px-2.5 py-1.5 text-[12px] text-foreground ${CHIP}`}>
-                  <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">{k}</span> — {v}
+                  <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">{k}</span> — {cellText(v)}
                 </div>
               ))}
             </div>
@@ -143,7 +152,7 @@ export default async function ArtStyleDetailPage({ params }: { params: Promise<{
             <div className="flex flex-wrap gap-1.5">
               {Object.entries(engineHints).map(([k, v]) => (
                 <span key={k} className="rounded-[2px] bg-[color-mix(in_srgb,var(--foreground)_6%,transparent)] px-2.5 py-1 font-mono text-[10px] text-muted-foreground">
-                  <span className="text-foreground">{k}</span> · {v}
+                  <span className="text-foreground">{k}</span> · {cellText(v)}
                 </span>
               ))}
             </div>


### PR DESCRIPTION
## What
The art-style detail page (`ui/src/app/(site)/art-styles/[id]/page.tsx`) rendered parsed-JSON `engine_hints` / `slot_recipes` values straight into JSX. When a value is a nested object (e.g. `engine_hints: {"recraft": {"style": "risograph"}}`), React throws **"Objects are not valid as a React child"** and the route 500s.

## Why it matters
This is the exact failure an agent/contributor hits submitting an art style with structured engine hints — a single malformed value crashed the whole public page. Found by reproducing a live 500 locally and reading the server stack.

## Fix
- Added `cellText(v)` — coerce a value to text (`string` passthrough, else `JSON.stringify`).
- Typed `engineHints` / `slotRecipes` as `Record<string, unknown>` (parsed JSON values aren't guaranteed strings).
- Applied `cellText(v)` at both render sites.

Malformed data now degrades to readable text instead of crashing the route.

## Verification
- `tsc --noEmit`: clean (only a pre-existing, unrelated missing optional module).
- Post-deploy: re-introduce an object-valued engine hint on a draft art style and confirm the page returns 200.

Refs ARN-95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)