### PR TITLE
fix(ui): read canonical fields for search/related/taste (not the $select projection)

### DIFF
--- a/ui/src/app/(site)/layout.tsx
+++ b/ui/src/app/(site)/layout.tsx
@@ -33,14 +33,9 @@ async function buildSearchIndex(): Promise<PaletteIndexItem[]> {
   try {
     // Search only surfaces the public catalog — Published only (palettes and
     // art styles are already Published-only via their default filter).
-    const languages = await listDesignLanguages("Status eq 'Published'", undefined, [
-      "Id",
-      "Status",
-      "name",
-      "slug",
-      "tags",
-      "tokens",
-    ]);
+    // Full canonical read (no $select): Temper's projected $select read path
+    // silently omits some published languages, which would hide them from search.
+    const languages = await listDesignLanguages("Status eq 'Published'");
     for (const lang of languages) {
       if (!lang.fields.name) continue;
       const colors = parseJson<TokensLite>(lang.fields.tokens)?.colors ?? {};

--- a/ui/src/app/api/taste/vectors/route.ts
+++ b/ui/src/app/api/taste/vectors/route.ts
@@ -72,11 +72,9 @@ export async function GET() {
   let anyLaneLoaded = false;
 
   try {
-    const languages = await listDesignLanguages(
-      "Status eq 'Published'",
-      undefined,
-      ["Id", "Status", "name", "slug", "tags", "tokens", "philosophy", "taste_vector", "taste_vector_model"],
-    );
+    // Full canonical read (no $select). The projected $select read omits some
+    // published languages, which would drop them from the taste/embedding space.
+    const languages = await listDesignLanguages("Status eq 'Published'");
     anyLaneLoaded = true;
     for (const lang of languages) {
       if (!lang.fields.name) continue;

--- a/ui/src/components/related-languages.tsx
+++ b/ui/src/components/related-languages.tsx
@@ -18,14 +18,9 @@ export async function RelatedLanguages({
 
   let candidates: Awaited<ReturnType<typeof listDesignLanguages>>;
   try {
-    candidates = await listDesignLanguages("Status eq 'Published'", undefined, [
-      "Id",
-      "Status",
-      "name",
-      "slug",
-      "tags",
-      "tokens",
-    ]);
+    // Full canonical read (no $select) — the projected $select read omits some
+    // published languages, which would silently drop them from "related".
+    candidates = await listDesignLanguages("Status eq 'Published'");
   } catch {
     return null;
   }


### PR DESCRIPTION
## Problem
A published design language (Civic Press) showed in the gallery but **not in search**, "related languages", or the taste/embedding space. Root cause: those three readers load `DesignLanguages` with a small **`$select` projection**, and Temper's projected `$select` read path **silently omits some published entities**. Confirmed live: the entity was absent from `$select` reads (with or without the `Status eq 'Published'` filter) but present + `Published` in a full canonical read.

## Fix
Drop the `$select` in the three readers so they read **full canonical** rows (what the studio already does):
- `layout.tsx` `buildSearchIndex()` (⌘K command palette / main-page search)
- `components/related-languages.tsx`
- `app/api/taste/vectors/route.ts`

Palettes and art styles already used full reads (which is why they were searchable). No behavior change other than including the missing languages.

## Verify
- `tsc --noEmit`: clean.
- Post-deploy: searching the catalog returns Civic Press.

The underlying Temper `$select` projection inconsistency is filed separately as a kernel bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)