### PR TITLE
feat(ui): family-grouped gallery, published-only counts, lineage fix, palette discipline

### DIFF
--- a/ui/src/app/(site)/art-styles/page.tsx
+++ b/ui/src/app/(site)/art-styles/page.tsx
@@ -4,7 +4,7 @@ import {
   listArtStyles,
   parseJson,
 } from "@/lib/odata";
-import { PageHero, Marker } from "@/components/page-hero";
+import { PageHero, Marker, HeroStat } from "@/components/page-hero";
 import { ArtStyleCatalog } from "@/components/lane-catalog";
 import type { ArtStyleItem } from "@/components/art-style-card";
 import { isOwner } from "@/lib/owner";
@@ -21,13 +21,10 @@ function refUrls(raw?: string): string[] {
 }
 
 export default async function ArtStylesPage() {
-  // Owners also see archived art styles (so they can spot what's hidden); the
-  // public catalog stays Published-only.
+  // Published-only everywhere — draft/archived art styles never appear in the
+  // catalog or counts. Owners can still archive published art styles.
   const owner = await isOwner();
-  const filter = owner
-    ? "Status eq 'Published' or Status eq 'Archived'"
-    : "Status eq 'Published'";
-  const rows = await listArtStyles(filter).catch(() => []);
+  const rows = await listArtStyles("Status eq 'Published'").catch(() => []);
   const items: ArtStyleItem[] = rows
     .map((r) => ({
       id: r.entity_id,
@@ -51,6 +48,7 @@ export default async function ArtStylesPage() {
         eyebrowAccent="sakura"
         title={<>The <Marker color="sakura">art style</Marker> catalog</>}
         description="Engine-agnostic style recipes — reference images plus a portable subject/palette prompt. Remix them onto any UI language and palette in the Studio."
+        rightSlot={<HeroStat value={items.length} label="art styles" accent="sakura" />}
       />
       <div className="mt-10">
         <ArtStyleCatalog items={items} canArchive={owner} />

--- a/ui/src/app/(site)/compare/page.tsx
+++ b/ui/src/app/(site)/compare/page.tsx
@@ -267,7 +267,8 @@ export default async function ComparePage({
 
   let languages: { entity_id: string; fields: { name?: string } }[] = [];
   try {
-    languages = await listDesignLanguages();
+    // Published-only: draft/archived languages are never offered for compare.
+    languages = await listDesignLanguages("Status eq 'Published'");
   } catch {
     // keep empty
   }

--- a/ui/src/app/(site)/layout.tsx
+++ b/ui/src/app/(site)/layout.tsx
@@ -116,14 +116,6 @@ export default async function SiteLayout({
 
   return (
     <div className="flex min-h-full w-full max-w-full flex-col overflow-x-hidden pb-[calc(4rem+env(safe-area-inset-bottom))] md:pb-0">
-      {/* Registration bar — the printer's color check, run across the top
-          of every sheet. Doubles as the site's signature. */}
-      <div aria-hidden className="flex h-[5px] w-full">
-        {REGISTRATION_INKS.map((ink) => (
-          <span key={ink} className="h-full flex-1" style={{ background: ink }} />
-        ))}
-      </div>
-
       <header className="relative max-w-full overflow-x-clip bg-background/80 backdrop-blur-sm">
         <nav className="mx-auto flex h-14 max-w-7xl items-center gap-3 px-4 sm:h-16 sm:gap-6 md:gap-8">
           <Link

--- a/ui/src/app/(site)/lineage/page.tsx
+++ b/ui/src/app/(site)/lineage/page.tsx
@@ -16,7 +16,8 @@ export default async function LineagePage({
 
   let languages;
   try {
-    languages = await listDesignLanguages();
+    // Published-only: draft/archived languages never appear in lineage.
+    languages = await listDesignLanguages("Status eq 'Published'");
   } catch {
     return (
       <div className="mx-auto max-w-7xl space-y-8 px-4 py-10">
@@ -33,13 +34,46 @@ export default async function LineagePage({
     );
   }
 
-  const nodes = languages.map((l) => ({
+  // Lineage kind and generation are DERIVED from the parent graph — the single
+  // source of truth — not from the stored `lineage_type` / `generation_number`
+  // fields, which are noisy (blank, "curated_from_query", …) and disagree with
+  // `parent_ids`. Deriving guarantees the legend always sums to the total and
+  // that "originals" means exactly one thing: a language with no parents.
+  const parsed = languages.map((l) => ({
     id: l.entity_id,
     name: l.fields.name ?? l.entity_id.slice(0, 12),
     status: l.status,
-    lineageType: l.fields.lineage_type ?? "original",
-    generation: parseInt(l.fields.generation_number ?? "0", 10),
-    parentIds: parseJson<string[]>(l.fields.parent_ids) ?? [],
+    parentIds: (parseJson<string[]>(l.fields.parent_ids) ?? []).filter(Boolean),
+  }));
+  const byId = new Map(parsed.map((n) => [n.id, n]));
+
+  const genCache = new Map<string, number>();
+  const generationOf = (id: string, depth = 0): number => {
+    const cached = genCache.get(id);
+    if (cached !== undefined) return cached;
+    const node = byId.get(id);
+    let gen: number;
+    if (!node || node.parentIds.length === 0) {
+      gen = 0; // a root within the published set → an original
+    } else if (depth > 64) {
+      gen = 1; // cycle guard
+    } else {
+      const inSet = node.parentIds.filter((p) => byId.has(p));
+      gen =
+        inSet.length === 0
+          ? 1 // derived from an ancestor outside the published set
+          : 1 + Math.max(...inSet.map((p) => generationOf(p, depth + 1)));
+    }
+    genCache.set(id, gen);
+    return gen;
+  };
+  const kindOf = (count: number) =>
+    count === 0 ? "original" : count === 1 ? "evolution" : "remix";
+
+  const nodes = parsed.map((n) => ({
+    ...n,
+    lineageType: kindOf(n.parentIds.length),
+    generation: generationOf(n.id),
   }));
 
   return (

--- a/ui/src/app/(site)/page.tsx
+++ b/ui/src/app/(site)/page.tsx
@@ -2,16 +2,111 @@ import { Suspense } from "react";
 import Link from "next/link";
 import {
   DESIGN_LANGUAGE_GALLERY_FIELDS,
+  countDesignLanguages,
+  languageTaxonomyMap,
   listDesignLanguages,
   listTaxonomies,
   parseJson,
+  taxonomyFamilyIndex,
 } from "@/lib/odata";
 import { LanguageGallery, dominantHueBucket } from "@/components/language-gallery";
 import { RisoHeroPress } from "@/components/riso-hero";
 import { RisoInkField } from "@/components/riso-ink-field";
-import { SurpriseChip } from "@/components/hero-actions";
 import { TasteDeck, type DeckEntry } from "@/components/taste-deck";
 import { isOwner } from "@/lib/owner";
+
+const HOW_STEPS = [
+  {
+    n: "01",
+    ink: "sakura",
+    title: "Browse",
+    body: "Filter by ink, vibe, or movement — or let the shuffle pick a language you didn't know you wanted.",
+  },
+  {
+    n: "02",
+    ink: "ramune",
+    title: "Open a language",
+    body: "Every language ships its philosophy, tokens, rules, and working landing + dashboard embodiments.",
+  },
+  {
+    n: "03",
+    ink: "yuzu",
+    title: "Hand it to your agent",
+    body: "Copy DESIGN.md (or the shadcn/ui kit) and your agent stays on-style, session after session.",
+  },
+] as const;
+
+/** The three-step explainer, folded into one quiet index tab that unfolds
+ *  to the full passes. Native <details> — works without JS, calm by default. */
+function HowItWorksFold() {
+  return (
+    <details className="group/how">
+      {/* gentle katagami dashes — the hero's underline */}
+      <span aria-hidden className="sticker-perforation block" />
+      <summary className="flex cursor-pointer list-none flex-wrap items-center gap-x-3 gap-y-1.5 py-3.5 [&::-webkit-details-marker]:hidden">
+        <span className="font-mono text-[11px] font-bold uppercase tracking-[0.18em] text-foreground">
+          how it works
+        </span>
+        <span className="hidden min-w-0 flex-wrap items-center gap-x-2.5 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground sm:flex">
+          {HOW_STEPS.map((s, i) => (
+            <span key={s.n} className="inline-flex items-center gap-1.5">
+              <span
+                className="font-bold"
+                style={{
+                  color: `color-mix(in oklch, var(--${s.ink}) 72%, var(--foreground))`,
+                }}
+              >
+                {s.n}
+              </span>
+              {s.title}
+              {i < HOW_STEPS.length - 1 ? (
+                <span aria-hidden className="text-muted-foreground/35">
+                  ·
+                </span>
+              ) : null}
+            </span>
+          ))}
+        </span>
+        <span
+          aria-hidden
+          className="ml-auto text-muted-foreground transition-transform duration-200 group-open/how:rotate-180"
+        >
+          <svg
+            viewBox="0 0 10 6"
+            className="h-[6px] w-2.5"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+          >
+            <path d="M1 1l4 4 4-4" />
+          </svg>
+        </span>
+      </summary>
+      <div className="mt-2 grid gap-6 pb-5 sm:grid-cols-3">
+        {HOW_STEPS.map((step) => (
+          <div key={step.n} className="relative pl-12">
+            <span
+              aria-hidden
+              className="absolute left-0 top-0 font-display text-[34px] font-bold leading-none"
+              style={{
+                color: `color-mix(in oklch, var(--${step.ink}) 70%, var(--foreground))`,
+              }}
+            >
+              {step.n}
+            </span>
+            <h3 className="font-display text-[17px] font-bold leading-tight tracking-[-0.015em]">
+              {step.title}
+            </h3>
+            <p className="mt-1.5 text-[13.5px] leading-relaxed text-muted-foreground">
+              {step.body}
+            </p>
+          </div>
+        ))}
+      </div>
+    </details>
+  );
+}
 
 async function GalleryGrid({
   status,
@@ -35,12 +130,26 @@ async function GalleryGrid({
   const canDelete = demo ? false : await isOwner();
 
   let languages: Awaited<ReturnType<typeof listDesignLanguages>>;
+  // The taxonomy hierarchy + each language's leaf taxonomies drive the gallery's
+  // family shelves; both load in parallel and are non-fatal — empty maps just
+  // fall back to color-mood grouping.
+  let taxonomyParents: Map<string, { name: string; parentId: string }> =
+    new Map();
+  let taxonomyByLang: Map<string, string[]> = new Map();
   try {
-    languages = await listDesignLanguages(
-      undefined,
-      undefined,
-      DESIGN_LANGUAGE_GALLERY_FIELDS,
-    );
+    // Published-only — draft/archived languages never appear in the gallery,
+    // counts, lineage, taxonomy, or anywhere public.
+    [languages, taxonomyParents, taxonomyByLang] = await Promise.all([
+      listDesignLanguages(
+        "Status eq 'Published'",
+        undefined,
+        DESIGN_LANGUAGE_GALLERY_FIELDS,
+      ),
+      taxonomyFamilyIndex().catch(
+        () => new Map<string, { name: string; parentId: string }>(),
+      ),
+      languageTaxonomyMap().catch(() => new Map<string, string[]>()),
+    ]);
   } catch {
     return (
       <div className="sticker-card mx-auto max-w-md p-8 text-center text-sm text-muted-foreground">
@@ -194,12 +303,20 @@ async function GalleryGrid({
 
   return (
     <>
-      {pull ? <TodaysPull lang={pull} /> : null}
-      {deckEntries.length > 2 ? <TasteDeck entries={deckEntries} /> : null}
+      {/* Today's pull + Taste finder are hidden for now — the functionality is
+          unfinished. Re-enable by setting NEXT_PUBLIC_SHOW_TASTE=1. */}
+      {process.env.NEXT_PUBLIC_SHOW_TASTE === "1" && pull ? (
+        <TodaysPull lang={pull} />
+      ) : null}
+      {process.env.NEXT_PUBLIC_SHOW_TASTE === "1" && deckEntries.length > 2 ? (
+        <TasteDeck entries={deckEntries} />
+      ) : null}
       <LanguageGallery
         languages={languages}
         canDelete={canDelete}
         taxonomies={taxonomies}
+        taxonomyParents={taxonomyParents}
+        taxonomyByLang={taxonomyByLang}
         initialFilters={{
           status: status ?? "Published",
           taxonomy: taxonomy ?? "all",
@@ -294,12 +411,15 @@ export default async function GalleryPage({
 }) {
   const sp = await searchParams;
   const demo = sp.demo !== undefined && sp.demo !== "0" && sp.demo !== "false";
-  let taxonomies: { entity_id: string; fields: { name?: string } }[] = [];
-  try {
-    taxonomies = await listTaxonomies("Status eq 'Published'");
-  } catch {
-    // Taxonomy listing may fail if no data yet
-  }
+  // Taxonomies + the published-language count run in parallel; the count uses
+  // OData $count (no rows), so the Gallery header's figure renders immediately
+  // without waiting on the streamed gallery payload.
+  const [taxonomies, languageCount] = await Promise.all([
+    listTaxonomies("Status eq 'Published'").catch(
+      () => [] as { entity_id: string; fields: { name?: string } }[],
+    ),
+    countDesignLanguages("Status eq 'Published'"),
+  ]);
 
   return (
     <div className="w-full overflow-x-hidden">
@@ -394,76 +514,31 @@ export default async function GalleryPage({
               Browse gallery
               <span aria-hidden className="transition-transform group-hover:translate-x-0.5">→</span>
             </a>
-            <SurpriseChip />
-            <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
-              or press <kbd className="font-bold text-foreground">⌘K</kbd> to search
-            </span>
           </div>
           </div>
         </div>
       </section>
 
-      {/* ── Everything below the hero stays in the content column ── */}
-      <div className="mx-auto w-full max-w-7xl space-y-12 px-4 pb-16 pt-10 sm:space-y-16">
-      {/* ── How it works — one quiet strip, three passes ─────────── */}
-      <section
-        aria-label="How katagami works"
-        data-reveal-children
-        className="relative grid gap-6 sm:grid-cols-3"
-      >
-        {(
-          [
-            {
-              n: "01",
-              ink: "sakura",
-              title: "Browse",
-              body: "Filter by ink, vibe, or movement — or let the shuffle pick a language you didn't know you wanted.",
-            },
-            {
-              n: "02",
-              ink: "ramune",
-              title: "Open a language",
-              body: "Every language ships its philosophy, tokens, rules, and working landing + dashboard embodiments.",
-            },
-            {
-              n: "03",
-              ink: "yuzu",
-              title: "Hand it to your agent",
-              body: "Copy DESIGN.md (or the shadcn/ui kit) and your agent stays on-style, session after session.",
-            },
-          ] as const
-        ).map((step) => (
-          <div key={step.n} className="relative pl-12">
-            <span
-              aria-hidden
-              className="absolute left-0 top-0 font-display text-[34px] font-bold leading-none"
-              style={{
-                color: `color-mix(in oklch, var(--${step.ink}) 70%, var(--foreground))`,
-              }}
-            >
-              {step.n}
-            </span>
-            <h3 className="font-display text-[17px] font-bold leading-tight tracking-[-0.015em]">
-              {step.title}
-            </h3>
-            <p className="mt-1.5 text-[13.5px] leading-relaxed text-muted-foreground">
-              {step.body}
-            </p>
-          </div>
-        ))}
-      </section>
+      {/* ── How it works — folded as a clever dashed underline beneath the hero ── */}
+      <div className="mx-auto w-full max-w-7xl px-4">
+        <HowItWorksFold />
+      </div>
 
+      {/* ── Everything below the hero stays in the content column ── */}
+      <div className="mx-auto w-full max-w-7xl space-y-12 px-4 pb-16 pt-8 sm:space-y-16">
       {/* ── Gallery ──────────────────────────────────────────────── */}
       <section id="gallery" className="scroll-mt-20 space-y-4">
         <div data-reveal className="flex flex-wrap items-end justify-between gap-3">
-          <div>
-            <div className="mb-2 flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
-              <span className="inline-block h-[3px] w-9 rounded-[2px] bg-[var(--ramune)]" />
-              choose a language
-            </div>
+          <div className="flex items-baseline gap-3">
             <h2 className="font-display text-[26px] font-bold leading-none tracking-[-0.02em]">
               Gallery
             </h2>
+            <span className="font-mono text-[12px] uppercase tracking-[0.16em] text-muted-foreground">
+              <span className="font-bold tabular-nums text-foreground">
+                {languageCount}
+              </span>{" "}
+              languages
+            </span>
           </div>
           <span className="stamp text-[var(--ramune)]">details inside</span>
         </div>

--- a/ui/src/app/(site)/palettes/page.tsx
+++ b/ui/src/app/(site)/palettes/page.tsx
@@ -5,7 +5,7 @@ import {
   paletteRoles,
   parseJson,
 } from "@/lib/odata";
-import { PageHero, Marker } from "@/components/page-hero";
+import { PageHero, Marker, HeroStat } from "@/components/page-hero";
 import { PaletteCatalog } from "@/components/lane-catalog";
 import type { PaletteItem } from "@/components/palette-card";
 import { isOwner } from "@/lib/owner";
@@ -17,13 +17,10 @@ export const metadata = {
 };
 
 export default async function PalettesPage() {
-  // Owners also see archived palettes (so they can spot what's hidden); the
-  // public catalog stays Published-only.
+  // Published-only everywhere — draft/archived palettes never appear in the
+  // catalog or counts. Owners can still archive published palettes.
   const owner = await isOwner();
-  const filter = owner
-    ? "Status eq 'Published' or Status eq 'Archived'"
-    : "Status eq 'Published'";
-  const rows = await listPaletteSystems(filter).catch(() => []);
+  const rows = await listPaletteSystems("Status eq 'Published'").catch(() => []);
   const items: PaletteItem[] = rows
     .map((r) => {
       const core = paletteCore(r.fields);
@@ -49,6 +46,7 @@ export default async function PalettesPage() {
         eyebrowAccent="ramune"
         title={<>The <Marker color="ramune">palette</Marker> catalog</>}
         description="Curated color systems — semantic roles, tonal ramps, and contrast guidance. Pair any of these with a UI language and an art style in the Studio."
+        rightSlot={<HeroStat value={items.length} label="palettes" accent="ramune" />}
       />
       <div className="mt-10">
         <PaletteCatalog items={items} canArchive={owner} />

--- a/ui/src/app/(site)/taxonomy/page.tsx
+++ b/ui/src/app/(site)/taxonomy/page.tsx
@@ -25,7 +25,8 @@ export default async function TaxonomyPage() {
 
   let languages: Awaited<ReturnType<typeof listDesignLanguages>> = [];
   try {
-    languages = await listDesignLanguages();
+    // Published-only: draft/archived languages never count toward taxonomy.
+    languages = await listDesignLanguages("Status eq 'Published'");
   } catch {
     // keep empty
   }

--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -1216,20 +1216,22 @@
     mask-image: linear-gradient(90deg, black calc(100% - 56px), transparent);
   }
   .shelf-row > [data-gallery-card] {
-    flex: 0 0 220px;
+    flex: 0 0 236px;
     min-width: 0;
     scroll-snap-align: start;
   }
   @media (min-width: 640px) {
     .shelf-row > [data-gallery-card] {
-      flex-basis: 240px;
+      flex-basis: 268px;
     }
   }
   [data-spread="true"] .shelf-row {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+    /* one fewer, larger column than the old 210px so the wall reads calmer;
+       the content column is capped at max-w-7xl, so ultrawide stays ~5 wide. */
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
     align-items: start;
-    gap: 1rem 0.9rem;
+    gap: 1.5rem 1.1rem;
     overflow: visible;
     -webkit-mask-image: none;
     mask-image: none;

--- a/ui/src/components/gallery-filters.tsx
+++ b/ui/src/components/gallery-filters.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Search, Shuffle } from "lucide-react";
+import { Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/select";
 
 const fieldBase =
-  "rounded-none border-0 border-b-2 border-foreground/15 bg-transparent px-1 font-mono text-sm text-foreground shadow-none transition-colors focus-visible:border-[var(--ramune)] focus-visible:ring-0 focus-visible:ring-offset-0";
+  "rounded-none border-0 border-b border-dashed border-foreground/30 bg-transparent px-1 font-mono text-sm text-foreground shadow-none transition-colors focus-visible:border-[var(--ramune)] focus-visible:ring-0 focus-visible:ring-offset-0";
 
 /** Hue buckets for the ink explorer — order matters for display. */
 export const HUE_BUCKETS = [
@@ -60,7 +60,9 @@ export function GalleryFilters({
   initialHue?: string;
   initialSource?: string;
 }) {
-  const [status, setStatus] = useState(initialStatus);
+  // Catalog is Published-only, so status never varies — kept for the
+  // shared filter shape, but there's no status control any more.
+  const [status] = useState(initialStatus);
   const [taxonomy, setTaxonomy] = useState(initialTaxonomy);
   const [search, setSearch] = useState(initialSearch);
   const [tag, setTag] = useState(initialTag);
@@ -122,8 +124,12 @@ export function GalleryFilters({
 
     const empty = document.querySelector<HTMLElement>("[data-gallery-empty]");
     if (empty) empty.hidden = count > 0;
-    if (countRef.current) countRef.current.textContent = String(count);
-  }, [status, taxonomy, search, tag, hue, source]);
+    if (countRef.current)
+      countRef.current.textContent =
+        count === totalCount
+          ? `${count} languages`
+          : `${count} of ${totalCount} languages`;
+  }, [status, taxonomy, search, tag, hue, source, totalCount]);
 
   useEffect(() => {
     applyFilters();
@@ -205,25 +211,11 @@ export function GalleryFilters({
         </div>
 
         <span
-          className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground"
+          className="ml-auto font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground"
           aria-live="polite"
         >
-          <span ref={countRef}>{totalCount}</span> / {totalCount} languages
+          <span ref={countRef}>{totalCount} languages</span>
         </span>
-
-        <button
-          type="button"
-          onClick={shuffle}
-          className="ml-auto inline-flex items-center gap-1.5 px-2.5 py-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.14em] text-foreground transition-all hover:-translate-y-[1px] hover:rotate-[-1.5deg]"
-          style={{
-            background:
-              "color-mix(in srgb, var(--sakura) 18%, var(--paper-stamp-mix))",
-          }}
-          title="Deal a random sheet"
-        >
-          <Shuffle className="h-3 w-3" />
-          surprise me
-        </button>
       </div>
 
       {/* Row 2 — ink explorer + vibe chips */}
@@ -301,22 +293,8 @@ export function GalleryFilters({
         )}
       </div>
 
-      {/* Row 3 — status / taxonomy / source */}
+      {/* Row 3 — taxonomy / source */}
       <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
-        <FieldLabel>status</FieldLabel>
-        <Select value={status} onValueChange={(v) => setStatus(v ?? "all")}>
-          <SelectTrigger className={`${fieldBase} h-8 w-32 gap-2 sm:w-36`}>
-            <SelectValue placeholder="any" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">all</SelectItem>
-            <SelectItem value="Draft">Draft</SelectItem>
-            <SelectItem value="UnderReview">Under Review</SelectItem>
-            <SelectItem value="Published">Published</SelectItem>
-            <SelectItem value="Archived">Archived</SelectItem>
-          </SelectContent>
-        </Select>
-
         {taxonomies.length > 0 && (
           <>
             <FieldLabel>taxonomy</FieldLabel>

--- a/ui/src/components/lane-catalog.tsx
+++ b/ui/src/components/lane-catalog.tsx
@@ -34,8 +34,7 @@ const ARCHIVED_SHELF: ShelfDef = {
 const PALETTE_SHELVES: ShelfDef[] = [...COLOR_MOOD_SHELVES, ARCHIVED_SHELF];
 
 const MEDIUM_INKS = [
-  "var(--sakura)", "var(--yuzu)", "var(--salad)",
-  "var(--teal)", "var(--ramune)", "var(--sumire)",
+  "var(--sakura)", "var(--yuzu)", "var(--ramune)", "var(--sumire)",
 ];
 
 function paletteShelfKey(p: PaletteItem): string {
@@ -100,7 +99,7 @@ function SearchBar({
         aria-hidden
         className="pointer-events-none absolute -left-3 -top-2 h-[14px] w-16 rounded-[1px] opacity-75"
         style={{
-          background: "var(--salad)",
+          background: "var(--yuzu)",
           mixBlendMode: "var(--ink-blend)" as never,
           transform: "rotate(-6deg)",
         }}

--- a/ui/src/components/language-card.tsx
+++ b/ui/src/components/language-card.tsx
@@ -21,8 +21,6 @@ const statusLabel: Record<string, string> = {
 const accentColors = [
   "var(--sakura)",
   "var(--yuzu)",
-  "var(--salad)",
-  "var(--teal)",
   "var(--ramune)",
   "var(--sumire)",
 ];

--- a/ui/src/components/language-gallery.tsx
+++ b/ui/src/components/language-gallery.tsx
@@ -11,11 +11,19 @@ export function LanguageGallery({
   languages,
   canDelete,
   taxonomies = [],
+  taxonomyParents,
+  taxonomyByLang,
   initialFilters,
 }: {
   languages: DesignLanguage[];
   canDelete: boolean;
   taxonomies?: { entity_id: string; fields: { name?: string } }[];
+  /** Full taxonomy tree (id → name + parentId) for grouping shelves by the
+   *  root design family. Absent → the gallery falls back to color-mood. */
+  taxonomyParents?: Map<string, { name: string; parentId: string }>;
+  /** languageId → its leaf taxonomy ids (read canonically; the projected
+   *  field is unreliable). Pairs with taxonomyParents to place each shelf. */
+  taxonomyByLang?: Map<string, string[]>;
   initialFilters?: {
     status?: string;
     taxonomy?: string;
@@ -35,7 +43,10 @@ export function LanguageGallery({
   };
 
   const attrsById = new Map(
-    languages.map((lang) => [lang.entity_id, galleryCardAttributes(lang)]),
+    languages.map((lang) => [
+      lang.entity_id,
+      galleryCardAttributes(lang, taxonomyByLang),
+    ]),
   );
   const topTags = collectTopTags(attrsById.values());
   const hasSpecimens = Array.from(attrsById.values()).some((a) => a.specimen);
@@ -45,7 +56,7 @@ export function LanguageGallery({
   // inks, quiet paper, warm/cold press) — a browser who doesn't know what
   // they want slides along shelves instead of scanning one huge grid.
   // Below the threshold everything lives on a single unlabeled wall.
-  const shelves = buildShelves(languages);
+  const shelves = buildShelves(languages, taxonomyParents, taxonomyByLang);
   // Global card position across shelves — drives eager thumbnail loading.
   const indexById = assignGlobalIndices(shelves);
 
@@ -64,7 +75,7 @@ export function LanguageGallery({
         initialSource={filters.source}
       />
 
-      <div className="space-y-5">
+      <div className="mt-10 space-y-12 sm:space-y-16">
         {shelves.map((shelf) => {
           const { key, label, blurb, ink, languages } = shelf;
           const anyVisible = languages.some((lang) =>
@@ -78,7 +89,7 @@ export function LanguageGallery({
               className="min-w-0"
             >
               {label !== null && (
-                <div className="mb-2 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2">
+                <div className="mb-4 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2">
                   <span
                     className="ink-stamp shrink-0"
                     style={{ ["--ink" as string]: ink }}
@@ -86,7 +97,8 @@ export function LanguageGallery({
                     {label}
                   </span>
                   <span className="min-w-0 truncate font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
-                    {blurb} · {languages.length}
+                    {blurb ? `${blurb} · ` : ""}
+                    {languages.length}
                   </span>
                   <span className="sticker-perforation hidden min-w-0 flex-1 sm:block" />
                   <ShelfSpread />
@@ -176,11 +188,21 @@ function shelfKeyFor(lang: DesignLanguage): string {
   });
 }
 
-function buildShelves(languages: DesignLanguage[]): Shelf[] {
+function buildShelves(
+  languages: DesignLanguage[],
+  taxonomyParents?: Map<string, { name: string; parentId: string }>,
+  taxonomyByLang?: Map<string, string[]>,
+): Shelf[] {
   if (languages.length <= SHELF_THRESHOLD) {
     return [
       { key: "all", label: null, blurb: "", ink: "var(--ramune)", languages },
     ];
+  }
+  // Group by the root design family (meaningful) when the taxonomy tree is
+  // available; otherwise fall back to the self-organizing color-mood cabinet.
+  if (taxonomyParents && taxonomyParents.size > 0 && taxonomyByLang) {
+    const families = buildFamilyShelves(languages, taxonomyParents, taxonomyByLang);
+    if (families && families.length > 0) return families;
   }
   const buckets = new Map<string, DesignLanguage[]>();
   for (const lang of languages) {
@@ -192,6 +214,137 @@ function buildShelves(languages: DesignLanguage[]): Shelf[] {
   return COLOR_MOOD_SHELVES.filter(
     (def) => (buckets.get(def.key)?.length ?? 0) > 0,
   ).map((def) => ({ ...def, languages: buckets.get(def.key)! }));
+}
+
+/** Walk a leaf taxonomy up to its root family id (cycle-guarded). */
+function rootFamilyOf(
+  leafId: string,
+  parents: Map<string, { name: string; parentId: string }>,
+): string {
+  let cur = leafId;
+  const seen = new Set<string>();
+  while (!seen.has(cur)) {
+    const info = parents.get(cur);
+    if (!info || !info.parentId || !parents.has(info.parentId)) break;
+    seen.add(cur);
+    cur = info.parentId;
+  }
+  return cur;
+}
+
+/** Trim a long family name down to a calm shelf stamp. */
+function familyLabel(name: string): string {
+  const trimmed = name
+    .replace(/\b(systems?|interfaces?|design|lineages?)\b/gi, " ")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+  return (trimmed || name).toLowerCase();
+}
+
+// Spot-ink trio (sakura / yuzu / ramune) plus violet as a tasteful fourth —
+// no muddy greens in the chrome.
+const FAMILY_INKS = [
+  "var(--sakura)",
+  "var(--ramune)",
+  "var(--yuzu)",
+  "var(--sumire)",
+];
+
+/** A family needs this many languages to earn its own shelf; the long tail of
+ *  smaller families plus untagged languages collects in a trailing shelf. */
+const FAMILY_SHELF_MIN = 5;
+
+/**
+ * Group the wall by the ROOT taxonomy family each language belongs to —
+ * "Japanese & East Asian", "Editorial & Publication", etc. — instead of by
+ * color. Featured languages float to a leading curator's-picks shelf; the long
+ * tail of tiny families collects in "mixed & more". Returns null when no
+ * language carries usable taxonomy data, so the caller can fall back.
+ */
+function buildFamilyShelves(
+  languages: DesignLanguage[],
+  parents: Map<string, { name: string; parentId: string }>,
+  taxonomyByLang: Map<string, string[]>,
+): Shelf[] | null {
+  const taxesOf = (lang: DesignLanguage) =>
+    taxonomyByLang.get(lang.entity_id) ?? [];
+
+  // Popularity of each root family across the catalog — a language tagged with
+  // several families lands on its biggest one, so shelves consolidate.
+  const pop = new Map<string, number>();
+  for (const lang of languages) {
+    const roots = new Set(
+      taxesOf(lang)
+        .map((t) => rootFamilyOf(t, parents))
+        .filter((r) => parents.has(r)),
+    );
+    for (const r of roots) pop.set(r, (pop.get(r) ?? 0) + 1);
+  }
+  if (pop.size === 0) return null;
+
+  const primaryFamily = (lang: DesignLanguage): string | null => {
+    const roots = taxesOf(lang)
+      .map((t) => rootFamilyOf(t, parents))
+      .filter((r) => parents.has(r));
+    if (roots.length === 0) return null;
+    return roots.reduce((a, b) => ((pop.get(b) ?? 0) > (pop.get(a) ?? 0) ? b : a));
+  };
+
+  const featured: DesignLanguage[] = [];
+  const byFamily = new Map<string, DesignLanguage[]>();
+  const orphans: DesignLanguage[] = [];
+  for (const lang of languages) {
+    if (isFeaturedLanguage(lang)) {
+      featured.push(lang);
+      continue;
+    }
+    const fam = primaryFamily(lang);
+    if (!fam) {
+      orphans.push(lang);
+      continue;
+    }
+    const bucket = byFamily.get(fam) ?? [];
+    bucket.push(lang);
+    byFamily.set(fam, bucket);
+  }
+
+  const big = [...byFamily.entries()]
+    .filter(([, v]) => v.length >= FAMILY_SHELF_MIN)
+    .sort((a, b) => b[1].length - a[1].length);
+  const mixed = [...orphans];
+  for (const [, v] of byFamily) {
+    if (v.length < FAMILY_SHELF_MIN) mixed.push(...v);
+  }
+
+  const shelves: Shelf[] = [];
+  if (featured.length > 0) {
+    shelves.push({
+      key: "picks",
+      label: "curator's picks",
+      blurb: "pinned to the corkboard",
+      ink: "var(--sakura)",
+      languages: featured,
+    });
+  }
+  big.forEach(([fam, v], i) => {
+    shelves.push({
+      key: fam,
+      label: familyLabel(parents.get(fam)?.name ?? fam),
+      blurb: "",
+      ink: FAMILY_INKS[i % FAMILY_INKS.length],
+      languages: v,
+    });
+  });
+  if (mixed.length > 0) {
+    shelves.push({
+      key: "mixed",
+      label: "mixed & more",
+      blurb: "every other family",
+      ink: "var(--graphite)",
+      languages: mixed,
+    });
+  }
+  return shelves;
 }
 
 function assignGlobalIndices(shelves: Shelf[]): Map<string, number> {
@@ -206,9 +359,16 @@ function assignGlobalIndices(shelves: Shelf[]): Map<string, number> {
   return indexById;
 }
 
-function galleryCardAttributes(lang: DesignLanguage) {
+function galleryCardAttributes(
+  lang: DesignLanguage,
+  taxonomyByLang?: Map<string, string[]>,
+) {
   const fields = lang.fields as Record<string, unknown>;
-  const taxonomyIds = listFieldValues(fields.taxonomy_ids).join("\t");
+  // Prefer the canonical leaf ids (the projected field is unreliable — ARN-97),
+  // so the taxonomy filter actually matches.
+  const taxonomyIds = (
+    taxonomyByLang?.get(lang.entity_id) ?? listFieldValues(fields.taxonomy_ids)
+  ).join("\t");
   const tags = listFieldValues(fields.tags).map((t) => t.toLowerCase());
   const searchText = [fields.name, fields.tags]
     .map(searchTextFromValue)

--- a/ui/src/components/page-hero.tsx
+++ b/ui/src/components/page-hero.tsx
@@ -60,7 +60,39 @@ export function PageHero({
           </div>
         )}
       </div>
+      {/* close the hero with the same gentle dashes that open it under the header */}
+      <span aria-hidden className="sticker-perforation mt-7 block sm:mt-8" />
     </section>
+  );
+}
+
+/** A clean published-count figure — the big number is the point, anchored by
+ *  one small accent tick (matching the eyebrow). Sits in a PageHero rightSlot. */
+export function HeroStat({
+  value,
+  label,
+  accent = "graphite",
+}: {
+  value: number | string;
+  label: string;
+  accent?: AccentColor;
+}) {
+  return (
+    <div className="text-right">
+      <div className="font-display text-[44px] font-bold leading-none tracking-[-0.04em] tabular-nums text-foreground sm:text-[56px]">
+        {value}
+      </div>
+      <div className="mt-2 flex items-center justify-end gap-2">
+        <span
+          aria-hidden
+          className="inline-block h-[3px] w-6 rounded-[2px]"
+          style={{ background: `var(--${accent})` }}
+        />
+        <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+          {label}
+        </span>
+      </div>
+    </div>
   );
 }
 

--- a/ui/src/lib/odata.ts
+++ b/ui/src/lib/odata.ts
@@ -384,6 +384,29 @@ export async function listDesignLanguages(
   return demo.length > 0 ? [...rows, ...demo] : rows;
 }
 
+/** Cheap published count via OData `$count` — fetches no rows, so it can run
+ *  at the page level without blocking on the full gallery payload. Matches the
+ *  gallery's own count in production (the demo catalog is off there). */
+export async function countDesignLanguages(
+  filter = "Status eq 'Published'",
+): Promise<number> {
+  try {
+    const params = new URLSearchParams();
+    params.set("$filter", filter);
+    params.set("$count", "true");
+    params.set("$top", "0");
+    const resp = await odata<ODataResponse<unknown>>(
+      `DesignLanguages?${params.toString()}`,
+    );
+    const demoCount = demoDesignLanguages().filter(
+      (d) => d.status === "Published",
+    ).length;
+    return (resp["@odata.count"] ?? 0) + demoCount;
+  } catch {
+    return 0;
+  }
+}
+
 async function collectDesignLanguageRows(
   filter: string,
   orderby?: string,
@@ -452,6 +475,77 @@ export async function listTaxonomies(
     }
   }
   return rows.filter((row) => row.fields.name?.trim());
+}
+
+export interface TaxonomyParent {
+  name: string;
+  parentId: string;
+}
+
+let taxonomyIndexCache: { at: number; map: Map<string, TaxonomyParent> } | null =
+  null;
+
+/**
+ * Taxonomy id → { name, parentId } for the WHOLE tree, so a leaf taxonomy can
+ * be walked up to its root "family". The home gallery groups languages by root
+ * family, which needs the full hierarchy (including unpublished interior nodes),
+ * so this fetches every taxonomy once and memoizes for a few minutes — the tree
+ * is effectively static between curation runs.
+ */
+export async function taxonomyFamilyIndex(): Promise<Map<string, TaxonomyParent>> {
+  if (taxonomyIndexCache && Date.now() - taxonomyIndexCache.at < 5 * 60 * 1000) {
+    return taxonomyIndexCache.map;
+  }
+  // The backend caps a page at 500 rows WITHOUT emitting an @odata.nextLink and
+  // doesn't honor $skip (ARN-97), so a small $top silently truncates the tree
+  // and breaks parent chains. A generous single-page $top pulls the whole tree.
+  const rows = await collectODataPages<Record<string, unknown>>(
+    "Taxonomies?$top=5000",
+  );
+  const map = new Map<string, TaxonomyParent>();
+  for (const row of rows) {
+    const id = typeof row.entity_id === "string" ? row.entity_id : "";
+    if (!id) continue;
+    let fields = (row.fields ?? {}) as Record<string, unknown>;
+    // a handful of rows nest a second `fields` object
+    if (fields.fields && typeof fields.fields === "object") {
+      fields = fields.fields as Record<string, unknown>;
+    }
+    const name = String(
+      fields.name ?? fields.Name ?? fields.display_name ?? "",
+    ).trim();
+    const parentId = String(fields.parent_id ?? fields.ParentId ?? "").trim();
+    map.set(id, { name, parentId });
+  }
+  taxonomyIndexCache = { at: Date.now(), map };
+  return map;
+}
+
+let languageTaxonomyCache: { at: number; map: Map<string, string[]> } | null =
+  null;
+
+/**
+ * Published language id → its taxonomy leaf ids, read CANONICALLY. The gallery's
+ * `$select` projection (DESIGN_LANGUAGE_GALLERY_FIELDS) silently drops list
+ * fields like `taxonomy_ids` in the current kernel (ARN-97), so family grouping
+ * can't rely on it — this reads the canonical rows and is memoized for a few
+ * minutes so the lean card fetch stays the home's hot path.
+ */
+export async function languageTaxonomyMap(): Promise<Map<string, string[]>> {
+  if (languageTaxonomyCache && Date.now() - languageTaxonomyCache.at < 5 * 60 * 1000) {
+    return languageTaxonomyCache.map;
+  }
+  const rows = await collectDesignLanguageRows("Status eq 'Published'");
+  const map = new Map<string, string[]>();
+  for (const row of rows) {
+    const id = typeof row.entity_id === "string" ? row.entity_id : "";
+    if (!id) continue;
+    const fields = (row.fields ?? {}) as Record<string, unknown>;
+    const ids = parseJson<string[]>(fields.taxonomy_ids as string) ?? [];
+    map.set(id, Array.isArray(ids) ? ids.filter(Boolean) : []);
+  }
+  languageTaxonomyCache = { at: Date.now(), map };
+  return map;
 }
 
 // ── Taste Rules ──


### PR DESCRIPTION
UI refinement pass (verified live against the production backend).

## Gallery
- Shelves now group by **root design family** (taxonomy hierarchy) instead of color-mood — Japanese & East Asian, Editorial & Publication, Minimal Application, etc. Falls back to color-mood when taxonomy data is unavailable.
- Much more spacing between sections; wider, calmer cards; ultrawide handled.
- Clean published counts: Gallery header figure + per-lane hero stat. Removed the now-pointless status dropdown.

## Published-only
- Home, lineage, taxonomy, compare, palettes, art styles are all `Status eq 'Published'`. Draft/archived never appear in any listing or count.

## Lineage
- "Originals" discrepancy fixed — kind + generation derived from `parent_ids`, so the legend sums to the total (no more "generation NaN").

## Kernel workarounds (ARN-97)
- Read `taxonomy_ids` canonically (the `$select` projection drops list fields).
- Fetch the full taxonomy tree with a generous `$top` (the backend caps a page at 500 with no `nextLink`, and `$skip` is unsupported).
- Taxonomy filter restored (cards now carry taxonomy ids again).

## Polish
- Hero closed with matching top/bottom dashes.
- Dropped the decorative dirty-green from the chrome — spot-ink trio + violet only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)