### PR TITLE
fix(ui): purge the dirty salad-green from chrome — trio + violet only

### DIFF
--- a/ui/src/app/(site)/compare/page.tsx
+++ b/ui/src/app/(site)/compare/page.tsx
@@ -47,7 +47,7 @@ async function ComparisonView({ idA, idB }: { idA: string; idB: string }) {
               <Stamp color="sumire" rotate={-1}>
                 {lang.fields.lineage_type ?? "original"}
               </Stamp>
-              <Stamp color="salad" rotate={2}>
+              <Stamp color="sumire" rotate={2}>
                 v{lang.counters.version ?? 0}
               </Stamp>
             </div>
@@ -112,7 +112,7 @@ async function ComparisonView({ idA, idB }: { idA: string; idB: string }) {
       {/* Embodiment comparison */}
       <section>
         <SectionHeading eyebrow="in the wild" eyebrowColor="sakura">
-          <Marker color="salad">embodiments</Marker>
+          <Marker color="sumire">embodiments</Marker>
         </SectionHeading>
         <div className="grid gap-6 md:grid-cols-2">
           {sides.map(({ lang, tape }, i) => (

--- a/ui/src/app/(site)/owner/page.tsx
+++ b/ui/src/app/(site)/owner/page.tsx
@@ -325,7 +325,7 @@ export default async function OwnerPage({
           </>
         }
         eyebrowAccent="sumire"
-        title={<Marker color={owner ? "salad" : "sumire"}>Owner mode</Marker>}
+        title={<Marker color={owner ? "sakura" : "sumire"}>Owner mode</Marker>}
         description={
           <>
             Unlock this browser to reveal curator controls in the gallery and
@@ -336,7 +336,7 @@ export default async function OwnerPage({
         rightSlot={
           <span
             className={`stamp ${
-              owner ? "text-[var(--salad)]" : "text-[var(--sumire)]"
+              owner ? "text-[var(--sakura)]" : "text-[var(--sumire)]"
             }`}
           >
             {owner ? "unlocked" : "locked"}
@@ -346,7 +346,7 @@ export default async function OwnerPage({
 
       <section className="relative">
         <WashiTape
-          color={owner ? "salad" : "sumire"}
+          color={owner ? "sakura" : "sumire"}
           rotate={-4}
           className="-left-3 -top-3"
           width={86}
@@ -354,9 +354,9 @@ export default async function OwnerPage({
         <StickyNote className="p-5 sm:p-6">
           <SectionHeading
             eyebrow={owner ? "session active" : "unlock"}
-            eyebrowColor={owner ? "salad" : "sumire"}
+            eyebrowColor={owner ? "sakura" : "sumire"}
           >
-            <Marker color={owner ? "salad" : "sumire"}>
+            <Marker color={owner ? "sakura" : "sumire"}>
               {owner ? "archive controls are visible" : "enter passphrase"}
             </Marker>
           </SectionHeading>
@@ -827,7 +827,7 @@ function TasteRuleSourceTag({ rule }: { rule: TasteRule }) {
 function TasteRulePolarityTag({ polarity }: { polarity: string }) {
   const polarityClass =
     polarity === "positive"
-      ? "bg-[color-mix(in_srgb,var(--salad)_14%,var(--paper-stamp-mix))] text-[color-mix(in_oklch,var(--salad)_72%,var(--foreground))]"
+      ? "bg-[color-mix(in_srgb,var(--sakura)_14%,var(--paper-stamp-mix))] text-[color-mix(in_oklch,var(--sakura)_72%,var(--foreground))]"
       : "bg-[color-mix(in_srgb,var(--sakura)_14%,var(--paper-stamp-mix))] text-[color-mix(in_oklch,var(--sakura)_72%,var(--foreground))]";
 
   return (
@@ -842,7 +842,7 @@ function TasteRulePolarityTag({ polarity }: { polarity: string }) {
 function TasteRuleStatusTag({ status }: { status: string }) {
   const statusClass =
     status === "Accepted"
-      ? "bg-[color-mix(in_srgb,var(--salad)_14%,var(--paper-stamp-mix))] text-[color-mix(in_oklch,var(--salad)_72%,var(--foreground))]"
+      ? "bg-[color-mix(in_srgb,var(--sakura)_14%,var(--paper-stamp-mix))] text-[color-mix(in_oklch,var(--sakura)_72%,var(--foreground))]"
       : status === "Rejected"
         ? "bg-[color-mix(in_srgb,var(--sakura)_14%,var(--paper-stamp-mix))] text-[color-mix(in_oklch,var(--sakura)_72%,var(--foreground))]"
         : "bg-[color-mix(in_srgb,var(--ramune)_14%,var(--paper-stamp-mix))] text-[color-mix(in_oklch,var(--ramune)_72%,var(--foreground))]";
@@ -879,7 +879,7 @@ function TasteRuleRejectButton({
 function TasteRuleAcceptButton({ id }: { id: string }) {
   return (
     <form action={acceptTasteRule.bind(null, id)}>
-      <button className="inline-flex h-8 items-center gap-1.5 bg-[color-mix(in_srgb,var(--salad)_14%,var(--paper-stamp-mix))] px-2.5 font-mono text-[10px] uppercase tracking-[0.15em] text-[color-mix(in_oklch,var(--salad)_72%,var(--foreground))] transition-all hover:-translate-y-[1px]">
+      <button className="inline-flex h-8 items-center gap-1.5 bg-[color-mix(in_srgb,var(--sakura)_14%,var(--paper-stamp-mix))] px-2.5 font-mono text-[10px] uppercase tracking-[0.15em] text-[color-mix(in_oklch,var(--sakura)_72%,var(--foreground))] transition-all hover:-translate-y-[1px]">
         <Check className="h-3.5 w-3.5" />
         accept
       </button>

--- a/ui/src/app/(site)/studio/page.tsx
+++ b/ui/src/app/(site)/studio/page.tsx
@@ -44,8 +44,8 @@ export default async function StudioPage() {
     <div className="mx-auto w-full max-w-6xl px-4 py-6 sm:py-10">
       <PageHero
         eyebrow="Remix lane"
-        eyebrowAccent="salad"
-        title={<>The <Marker color="salad">remix</Marker> studio</>}
+        eyebrowAccent="sumire"
+        title={<>The <Marker color="sumire">remix</Marker> studio</>}
         description="Pick a UI language, a palette, and an art style. The preview is that language's own landing & dashboard — recolored by the palette, given the art style's hero. Live, no generation."
       />
 

--- a/ui/src/app/(site)/taxonomy/page.tsx
+++ b/ui/src/app/(site)/taxonomy/page.tsx
@@ -11,9 +11,9 @@ export default async function TaxonomyPage() {
     return (
       <div className="mx-auto max-w-7xl space-y-8 px-4 py-10">
         <PageHero
-          eyebrowAccent="salad"
+          eyebrowAccent="sumire"
           eyebrow="categorization"
-          title={<Marker color="salad">taxonomy</Marker>}
+          title={<Marker color="sumire">taxonomy</Marker>}
           description="Could not reach the server."
         />
         <StickyNote className="p-6 text-center font-mono text-sm text-muted-foreground">
@@ -34,17 +34,17 @@ export default async function TaxonomyPage() {
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-4 py-6 sm:space-y-10 sm:py-10">
       <PageHero
-        eyebrowAccent="salad"
+        eyebrowAccent="sumire"
         eyebrow="categorization"
         title={
           <>
-            <Marker color="salad">taxonomy</Marker> browser
+            <Marker color="sumire">taxonomy</Marker> browser
           </>
         }
         description="A cleaner map of the design-language library, grouped by browsing family and tuned for finding usable styles quickly."
         rightSlot={
           <>
-            <Stamp color="salad">{taxonomies.length} categories</Stamp>
+            <Stamp color="sumire">{taxonomies.length} categories</Stamp>
             <Stamp color="teal" rotate={3}>
               curated
             </Stamp>

--- a/ui/src/components/art-style-card.tsx
+++ b/ui/src/components/art-style-card.tsx
@@ -17,8 +17,7 @@ export interface ArtStyleItem {
 }
 
 const accentColors = [
-  "var(--sakura)", "var(--yuzu)", "var(--salad)",
-  "var(--teal)", "var(--ramune)", "var(--sumire)",
+  "var(--sakura)", "var(--yuzu)", "var(--ramune)", "var(--sumire)",
 ];
 
 const STRIP_MAX = 4;

--- a/ui/src/components/design-md-showcase.tsx
+++ b/ui/src/components/design-md-showcase.tsx
@@ -70,12 +70,12 @@ export function DesignMdShowcase(
           </ShowcaseCard>
         )}
         {hasSpacing && (
-          <ShowcaseCard tape="teal" title="Spacing">
+          <ShowcaseCard tape="ramune" title="Spacing">
             <SpacingScale spacing={spacing} />
           </ShowcaseCard>
         )}
         {hasRounded && (
-          <ShowcaseCard tape="salad" title="Shape">
+          <ShowcaseCard tape="sakura" title="Shape">
             <RoundedSamples rounded={rounded} />
           </ShowcaseCard>
         )}
@@ -203,7 +203,7 @@ function ColorChip({ name, value }: { name: string; value: string }) {
           {name}
         </span>
         {copied ? (
-          <Check className="h-3 w-3 shrink-0 text-[var(--salad)]" />
+          <Check className="h-3 w-3 shrink-0 text-[var(--foreground)]" />
         ) : (
           <Copy className="h-3 w-3 shrink-0 text-muted-foreground/40 transition-colors group-hover:text-foreground" />
         )}

--- a/ui/src/components/lineage-graph.tsx
+++ b/ui/src/components/lineage-graph.tsx
@@ -15,13 +15,13 @@ interface GraphNode {
 type AccentColor = "teal" | "salad" | "sumire" | "sakura" | "yuzu" | "ramune";
 
 const lineageTint: Record<string, AccentColor> = {
-  original: "teal",
-  evolution: "salad",
+  original: "ramune",
+  evolution: "yuzu",
   remix: "sumire",
 };
 
 const statusTint: Record<string, AccentColor> = {
-  Published: "salad",
+  Published: "sumire",
   UnderReview: "yuzu",
   Draft: "ramune",
   Archived: "sakura",
@@ -64,8 +64,8 @@ export function LineageGraph({
         <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
           key
         </span>
-        <LegendChip label={`${counts.original} original`} color="teal" />
-        <LegendChip label={`${counts.evolution} evolution`} color="salad" />
+        <LegendChip label={`${counts.original} original`} color="ramune" />
+        <LegendChip label={`${counts.evolution} evolution`} color="yuzu" />
         <LegendChip label={`${counts.remix} remix`} color="sumire" />
         <span className="ml-1 font-mono text-[10px] text-muted-foreground/60">
           · {nodes.length} total

--- a/ui/src/components/remix/inline-remix.tsx
+++ b/ui/src/components/remix/inline-remix.tsx
@@ -279,7 +279,7 @@ export function InlineRemix({
       {/* preview */}
       <div className="relative">
         <WashiTape color="sakura" rotate={-4} className="-left-4 -top-3" width={104} />
-        <WashiTape color="salad" rotate={5} className="-right-4 -top-3" width={84} />
+        <WashiTape color="yuzu" rotate={5} className="-right-4 -top-3" width={84} />
         <div className="sticker-card relative overflow-hidden p-3 pb-9">
           <div className="mb-2.5 flex items-center justify-between gap-3">
             <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground">{comp?.name ?? "Preview"}</span>

--- a/ui/src/components/spec-actions.tsx
+++ b/ui/src/components/spec-actions.tsx
@@ -47,7 +47,7 @@ const DISPLAY_FILENAME: Record<Format, string> = {
 
 const ACCENT: Record<Format, string> = {
   katagami: "sumire",
-  "design-md": "salad",
+  "design-md": "sakura",
   "shadcn-md": "ramune",
 };
 
@@ -154,7 +154,7 @@ export function SpecActions({
                   <FormatTab
                     active={format === "design-md"}
                     onClick={() => setFormat("design-md")}
-                    accent="salad"
+                    accent="sakura"
                   >
                     DESIGN.md
                   </FormatTab>
@@ -203,7 +203,7 @@ export function SpecActions({
                 rotate={0.5}
                 icon={
                   justCopied === "copy" ? (
-                    <Check className="h-3 w-3 text-[var(--salad)]" />
+                    <Check className="h-3 w-3 text-[var(--foreground)]" />
                   ) : (
                     <Copy className="h-3 w-3" />
                   )
@@ -217,7 +217,7 @@ export function SpecActions({
                 rotate={-0.5}
                 icon={
                   justCopied === "link" ? (
-                    <Check className="h-3 w-3 text-[var(--salad)]" />
+                    <Check className="h-3 w-3 text-[var(--foreground)]" />
                   ) : (
                     <Link2 className="h-3 w-3" />
                   )
@@ -240,7 +240,7 @@ export function SpecActions({
           <FormatTab
             active={format === "design-md"}
             onClick={() => setFormat("design-md")}
-            accent="salad"
+            accent="sakura"
           >
             DESIGN.md
           </FormatTab>
@@ -276,7 +276,7 @@ export function SpecActions({
               rotate={-1.5}
               icon={
                 justCopied === "copy" ? (
-                  <Check className="h-3 w-3 text-[var(--salad)]" />
+                  <Check className="h-3 w-3 text-[var(--foreground)]" />
                 ) : (
                   <Copy className="h-3 w-3" />
                 )
@@ -290,7 +290,7 @@ export function SpecActions({
               rotate={0.5}
               icon={
                 justCopied === "link" ? (
-                  <Check className="h-3 w-3 text-[var(--salad)]" />
+                  <Check className="h-3 w-3 text-[var(--foreground)]" />
                 ) : (
                   <Link2 className="h-3 w-3" />
                 )

--- a/ui/src/components/spec-panel.tsx
+++ b/ui/src/components/spec-panel.tsx
@@ -43,7 +43,7 @@ export interface SpecPanelProps {
 type AccentColor =
   | "sakura"
   | "yuzu"
-  | "salad"
+  | "ramune"
   | "matcha"
   | "teal"
   | "ramune"
@@ -52,8 +52,6 @@ type AccentColor =
 const accentCycle: AccentColor[] = [
   "sakura",
   "yuzu",
-  "salad",
-  "teal",
   "ramune",
   "sumire",
 ];
@@ -172,10 +170,10 @@ function PhilosophyView({ raw }: { raw?: string }) {
       )}
       {values.length > 0 && (
         <section>
-          <SectionRule label="values" color="salad" />
+          <SectionRule label="values" color="ramune" />
           <div className="flex flex-wrap gap-1.5">
             {values.map((v, i) => (
-              <PeeledLabel key={toLabel(v)} index={i} color="salad">
+              <PeeledLabel key={toLabel(v)} index={i} color="ramune">
                 {toLabel(v)}
               </PeeledLabel>
             ))}
@@ -226,8 +224,8 @@ function TokensView({ raw }: { raw?: string }) {
     colors: "sakura",
     typography: "sumire",
     spacing: "teal",
-    radii: "salad",
-    borders: "matcha",
+    radii: "ramune",
+    borders: "ramune",
     shadows: "yuzu",
     elevation: "ramune",
     motion: "teal",
@@ -377,14 +375,14 @@ function RulesView({ raw }: { raw?: string }) {
     return (
       <div className="grid gap-5 md:grid-cols-2">
         {dos.length > 0 && (
-          <RuleNote label="do" color="salad">
+          <RuleNote label="do" color="ramune">
             <ul className="space-y-1.5">
               {dos.map((d) => (
                 <li
                   key={d}
                   className="flex gap-2 text-[13px] leading-relaxed text-foreground/86"
                 >
-                  <span className="mt-[0.55em] h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--salad)]" />
+                  <span className="mt-[0.55em] h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--ramune)]" />
                   <span>{d}</span>
                 </li>
               ))}
@@ -419,7 +417,7 @@ function RuleNote({
   children,
 }: {
   label: string;
-  color: "salad" | "sakura";
+  color: "ramune" | "sakura";
   children: React.ReactNode;
 }) {
   return (
@@ -434,8 +432,8 @@ function RuleNote({
         className="absolute left-4 top-3 inline-flex h-[18px] items-center rounded-[2px] px-2 font-sans text-[9px] font-bold uppercase leading-none tracking-[0.14em]"
         style={{
           color:
-            color === "salad"
-              ? "color-mix(in oklch, var(--salad), black 30%)"
+            color === "ramune"
+              ? "color-mix(in oklch, var(--ramune), black 30%)"
               : "var(--beni)",
           background: `color-mix(in oklch, var(--${color}) 8%, var(--paper-stamp-mix))`,
         }}
@@ -1257,7 +1255,7 @@ export function SpecPanel(props: SpecPanelProps) {
         <Section label="tokens" color="sakura">
           <TokensView raw={tokens} />
         </Section>
-        <Section label="rules" color="salad" defaultOpen>
+        <Section label="rules" color="ramune" defaultOpen>
           <RulesView raw={rules} />
         </Section>
         <Section label="layout" color="sumire">
@@ -1272,7 +1270,7 @@ export function SpecPanel(props: SpecPanelProps) {
           </Section>
         )}
         {generativeCanvas && (
-          <Section label="generative" color="matcha">
+          <Section label="generative" color="ramune">
             <RichKeyValueView raw={generativeCanvas} />
           </Section>
         )}
@@ -1282,7 +1280,7 @@ export function SpecPanel(props: SpecPanelProps) {
         <Section label="DESIGN.md" color="sumire">
           <SpecMarkdownView markdown={designMd} />
         </Section>
-        <Section label="shadcn/ui theme" color="salad">
+        <Section label="shadcn/ui theme" color="ramune">
           <SpecMarkdownView markdown={`\`\`\`json\n${shadcnJson}\`\`\``} />
         </Section>
       </div>

--- a/ui/src/components/taxonomy-cluster-view.tsx
+++ b/ui/src/components/taxonomy-cluster-view.tsx
@@ -26,9 +26,6 @@ interface TaxonomyFamily {
 const accentCycle: AccentColor[] = [
   "sakura",
   "yuzu",
-  "salad",
-  "matcha",
-  "teal",
   "ramune",
   "sumire",
 ];


### PR DESCRIPTION
Follow-up to #62. The muddy yellow-green (`--salad`) was decorating chrome across the app — most visibly the **"Download DESIGN.md" box** on the language detail page (green top bar + marker). Removed it everywhere it was used as decoration:

- DESIGN.md download box → **sakura** top bar + marker
- Spec/token panel section accents, design-md showcase cards
- Lineage Published stamps + "evolution" legend
- Art-style card accents
- Studio / taxonomy / compare page accents, remix tape, owner badges
- Taxonomy cluster color cycle
- "Copied" check icons → neutral

All replaced with the spot-ink trio (sakura / yuzu / ramune) + sumire (violet).

**Kept intentionally:** the INK hue-filter green dot (it filters languages *by* their green dominant color, so it must be green) and the `--matcha` "Do" labels on palette/art-style detail pages.

Verified live on the detail page; lint + type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)