### PR TITLE
feat(ui): Datadog RUM visitor + product analytics for katagami.ai

### DIFF
--- a/infra/datadog/README.md
+++ b/infra/datadog/README.md
@@ -53,15 +53,25 @@ No PII: `defaultPrivacyLevel: mask-user-input`, no session replay.
 3. **Import the dashboard**: Datadog → Dashboards → New Dashboard → **Import
    dashboard JSON** → paste `katagami-rum-dashboard.json`.
 
-## Facet calibration (custom-action widgets only)
+## Facets (confirmed against live data)
 
-The dashboard's session/view widgets (unique visits, page views, top languages,
-top pages) are facet-independent and work immediately. The copy/download/search
-widgets read custom-action facets `@action.target.name` and `@context.<key>`
-(e.g. `@context.artifact`, `@context.file`, `@context.source`). If your org
-surfaces `addAction` context under a different prefix, adjust those few widgets
-once real data lands — confirm in RUM Explorer by inspecting one custom action
-event.
+Verified end-to-end against the real RUM app on 2026-06-23 by emitting events
+and querying them back:
+
+- Custom action name → `@action.target.name` (e.g. `language_click`, `copy`,
+  `download`, `nav_click`, `search`), with `@action.type:custom`.
+- Custom attributes → `@context.<key>`: `@context.source`, `@context.artifact`,
+  `@context.file`, `@context.query`, `@context.language_name`, `@context.language_id`.
+- Sessions/views are standard RUM facets (`@type`, `@view.url_path`, `@geo.country`,
+  `@device.type`, `@session.referrer`).
+- Each event also carries `@usr.anonymous_id`, so unique *visitors* (not just
+  sessions) can be counted with `CARDINALITY(@usr.anonymous_id)` if wanted.
+
+The dashboard JSON already uses these exact facets — no calibration needed.
+
+> Note: a handful of `env:local-verify` test events were emitted during
+> verification. Filter them out (or scope the dashboard to `env:production`)
+> once real traffic flows.
 
 ## Known gap: server-route downloads
 

--- a/infra/datadog/README.md
+++ b/infra/datadog/README.md
@@ -1,0 +1,73 @@
+# Katagami visitor & usage analytics (Datadog RUM)
+
+This is how we see what's getting traction on katagami.ai: unique visits, page
+views, which languages get viewed and clicked, and which artifacts get copied and
+downloaded. It's powered by Datadog RUM (Real User Monitoring) wired into the
+Next.js app in `ui/`.
+
+Tracking starts the day credentials go live — there is **no historical backfill**.
+
+## What's instrumented
+
+- **Unique visits & page views** — automatic. The RUM SDK tracks a session per
+  visitor and a view per route, so every `/language/<id>` visit is captured with
+  no per-page code. This is the primary signal for language/page traction.
+- **Custom events** (`ui/src/lib/analytics.ts`), fired from shared components so
+  coverage is generic, not per-button:
+  - `language_click` — clicks into a language, with `source` (card, related,
+    lineage, taxonomy, search) for attribution.
+  - `copy` — copy-to-clipboard, with `artifact` (design_md, shadcn_md, katagami,
+    link, color, tokens_css, recipe, prompt, remix_brief, …).
+  - `download` — DESIGN.md / shadcn / css downloads, with `file` + `format`.
+  - `search` — search terms (truncated to 100 chars) + result counts.
+  - `compare`, `nav_click` — compare-tray selections and primary-nav clicks.
+- Everything else (filters, tabs, shuffle, etc.) is still captured by RUM's
+  automatic interaction tracking (`trackUserInteractions`), so the long tail is
+  covered without bespoke code.
+
+No PII: `defaultPrivacyLevel: mask-user-input`, no session replay.
+
+## Going live — three steps
+
+1. **Create the RUM application** (one time): Datadog → Digital Experience → RUM
+   → **New Application** → JavaScript. Copy the generated `applicationId` and
+   `clientToken`. (This can't be done from the MCP/API tools we have; it's a
+   couple of clicks, or use the Datadog API with an App key.)
+
+2. **Set env vars in Vercel** (the app is deployed on Vercel, project `katagami`)
+   → Settings → Environment Variables, then redeploy:
+
+   | Variable | Required | Default |
+   | --- | --- | --- |
+   | `NEXT_PUBLIC_DD_RUM_APPLICATION_ID` | yes | — |
+   | `NEXT_PUBLIC_DD_RUM_CLIENT_TOKEN` | yes | — |
+   | `NEXT_PUBLIC_DD_RUM_SITE` | no | `datadoghq.com` |
+   | `NEXT_PUBLIC_DD_RUM_SERVICE` | no | `katagami-web` |
+   | `NEXT_PUBLIC_DD_RUM_ENV` | no | `production` |
+   | `NEXT_PUBLIC_DD_RUM_SAMPLE_RATE` | no | `100` |
+
+   These are `NEXT_PUBLIC_*`, so they're inlined at **build time** — redeploy
+   after setting them. Without them the analytics layer is a complete no-op, so
+   local dev and previews are unaffected.
+
+3. **Import the dashboard**: Datadog → Dashboards → New Dashboard → **Import
+   dashboard JSON** → paste `katagami-rum-dashboard.json`.
+
+## Facet calibration (custom-action widgets only)
+
+The dashboard's session/view widgets (unique visits, page views, top languages,
+top pages) are facet-independent and work immediately. The copy/download/search
+widgets read custom-action facets `@action.target.name` and `@context.<key>`
+(e.g. `@context.artifact`, `@context.file`, `@context.source`). If your org
+surfaces `addAction` context under a different prefix, adjust those few widgets
+once real data lands — confirm in RUM Explorer by inspecting one custom action
+event.
+
+## Known gap: server-route downloads
+
+The human-facing download buttons are tracked. Direct, programmatic GETs of the
+server artifact routes (`/language/<id>/DESIGN.md`, `/shadcn.json`, …) — mostly
+agents fetching specs — are **not** RUM-visible, since they aren't browser
+interactions. If we want those counted too, add a log line in each `route.ts`
+and a Vercel→Datadog log drain (or count them from Vercel/edge logs). Tracked as
+a follow-up, not part of this change.

--- a/infra/datadog/katagami-rum-dashboard.json
+++ b/infra/datadog/katagami-rum-dashboard.json
@@ -1,0 +1,540 @@
+{
+  "title": "Katagami — Visitors & Usage (RUM)",
+  "description": "What's getting traction on katagami.ai: unique visits, page views, which languages get viewed/clicked, and which artifacts get copied and downloaded. Fed by Datadog RUM (see infra/datadog/README.md). Import via Datadog → Dashboards → New Dashboard → Import dashboard JSON.\n\nNote on custom-action facets: copy/download/search/language_click/nav events are RUM custom actions. Their name is faceted as @action.target.name and their attributes as @context.<key> (e.g. @context.artifact, @context.file, @context.source). If your org surfaces them under a slightly different facet, adjust the affected widgets once real data lands — the views/sessions widgets are facet-independent and work immediately.",
+  "layout_type": "ordered",
+  "reflow_type": "fixed",
+  "template_variables": [],
+  "widgets": [
+    {
+      "definition": {
+        "type": "note",
+        "content": "## Katagami — Visitors & Usage\nUnique visits, page views, language traction, copies & downloads. Data starts the day RUM credentials go live; there is no historical backfill.",
+        "background_color": "white",
+        "font_size": "14",
+        "text_align": "left",
+        "vertical_align": "center",
+        "show_tick": false,
+        "tick_pos": "50%",
+        "tick_edge": "left",
+        "has_padding": true
+      },
+      "layout": { "x": 0, "y": 0, "width": 12, "height": 1 }
+    },
+    {
+      "definition": {
+        "title": "Audience",
+        "type": "group",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "definition": {
+              "title": "Visits (sessions)",
+              "type": "query_value",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "data_source": "rum",
+                      "name": "visits",
+                      "indexes": ["*"],
+                      "search": { "query": "@type:session @session.type:user" },
+                      "compute": { "aggregation": "count" },
+                      "group_by": []
+                    }
+                  ],
+                  "formulas": [{ "formula": "visits" }]
+                }
+              ],
+              "autoscale": true,
+              "precision": 0
+            },
+            "layout": { "x": 0, "y": 0, "width": 3, "height": 2 }
+          },
+          {
+            "definition": {
+              "title": "Page views",
+              "type": "query_value",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "data_source": "rum",
+                      "name": "views",
+                      "indexes": ["*"],
+                      "search": { "query": "@type:view" },
+                      "compute": { "aggregation": "count" },
+                      "group_by": []
+                    }
+                  ],
+                  "formulas": [{ "formula": "views" }]
+                }
+              ],
+              "autoscale": true,
+              "precision": 0
+            },
+            "layout": { "x": 3, "y": 0, "width": 3, "height": 2 }
+          },
+          {
+            "definition": {
+              "title": "Engagement actions (copy / download / clicks)",
+              "type": "query_value",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "data_source": "rum",
+                      "name": "actions",
+                      "indexes": ["*"],
+                      "search": { "query": "@type:action @action.type:custom" },
+                      "compute": { "aggregation": "count" },
+                      "group_by": []
+                    }
+                  ],
+                  "formulas": [{ "formula": "actions" }]
+                }
+              ],
+              "autoscale": true,
+              "precision": 0
+            },
+            "layout": { "x": 6, "y": 0, "width": 3, "height": 2 }
+          },
+          {
+            "definition": {
+              "title": "Avg pages / session",
+              "type": "query_value",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "data_source": "rum",
+                      "name": "views",
+                      "indexes": ["*"],
+                      "search": { "query": "@type:view" },
+                      "compute": { "aggregation": "count" },
+                      "group_by": []
+                    },
+                    {
+                      "data_source": "rum",
+                      "name": "sessions",
+                      "indexes": ["*"],
+                      "search": { "query": "@type:session @session.type:user" },
+                      "compute": { "aggregation": "count" },
+                      "group_by": []
+                    }
+                  ],
+                  "formulas": [{ "formula": "views / sessions" }]
+                }
+              ],
+              "autoscale": true,
+              "precision": 1
+            },
+            "layout": { "x": 9, "y": 0, "width": 3, "height": 2 }
+          },
+          {
+            "definition": {
+              "title": "Visits over time",
+              "type": "timeseries",
+              "requests": [
+                {
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "data_source": "rum",
+                      "name": "visits",
+                      "indexes": ["*"],
+                      "search": { "query": "@type:session @session.type:user" },
+                      "compute": { "aggregation": "count" },
+                      "group_by": []
+                    }
+                  ],
+                  "formulas": [{ "formula": "visits" }],
+                  "display_type": "bars"
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 2, "width": 8, "height": 3 }
+          },
+          {
+            "definition": {
+              "title": "Visits by country",
+              "type": "toplist",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "data_source": "rum",
+                      "name": "byCountry",
+                      "indexes": ["*"],
+                      "search": { "query": "@type:session @session.type:user" },
+                      "compute": { "aggregation": "count" },
+                      "group_by": [
+                        {
+                          "facet": "@geo.country",
+                          "limit": 10,
+                          "sort": { "aggregation": "count", "order": "desc" }
+                        }
+                      ]
+                    }
+                  ],
+                  "formulas": [{ "formula": "byCountry" }]
+                }
+              ]
+            },
+            "layout": { "x": 8, "y": 2, "width": 4, "height": 3 }
+          },
+          {
+            "definition": {
+              "title": "Visits by device",
+              "type": "toplist",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "data_source": "rum",
+                      "name": "byDevice",
+                      "indexes": ["*"],
+                      "search": { "query": "@type:session @session.type:user" },
+                      "compute": { "aggregation": "count" },
+                      "group_by": [
+                        {
+                          "facet": "@device.type",
+                          "limit": 10,
+                          "sort": { "aggregation": "count", "order": "desc" }
+                        }
+                      ]
+                    }
+                  ],
+                  "formulas": [{ "formula": "byDevice" }]
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 5, "width": 6, "height": 3 }
+          },
+          {
+            "definition": {
+              "title": "Top referrers",
+              "type": "toplist",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "data_source": "rum",
+                      "name": "byReferrer",
+                      "indexes": ["*"],
+                      "search": { "query": "@type:session @session.type:user" },
+                      "compute": { "aggregation": "count" },
+                      "group_by": [
+                        {
+                          "facet": "@session.referrer",
+                          "limit": 10,
+                          "sort": { "aggregation": "count", "order": "desc" }
+                        }
+                      ]
+                    }
+                  ],
+                  "formulas": [{ "formula": "byReferrer" }]
+                }
+              ]
+            },
+            "layout": { "x": 6, "y": 5, "width": 6, "height": 3 }
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 1, "width": 12, "height": 9 }
+    },
+    {
+      "definition": {
+        "title": "Languages & pages",
+        "type": "group",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "definition": {
+              "title": "Top languages by page views (which languages get traction)",
+              "type": "toplist",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "data_source": "rum",
+                      "name": "langViews",
+                      "indexes": ["*"],
+                      "search": { "query": "@type:view @view.url_path:\"/language/*\"" },
+                      "compute": { "aggregation": "count" },
+                      "group_by": [
+                        {
+                          "facet": "@view.url_path",
+                          "limit": 25,
+                          "sort": { "aggregation": "count", "order": "desc" }
+                        }
+                      ]
+                    }
+                  ],
+                  "formulas": [{ "formula": "langViews" }]
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 0, "width": 6, "height": 4 }
+          },
+          {
+            "definition": {
+              "title": "Top pages (all routes)",
+              "type": "toplist",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "data_source": "rum",
+                      "name": "pageViews",
+                      "indexes": ["*"],
+                      "search": { "query": "@type:view" },
+                      "compute": { "aggregation": "count" },
+                      "group_by": [
+                        {
+                          "facet": "@view.url_path_group",
+                          "limit": 20,
+                          "sort": { "aggregation": "count", "order": "desc" }
+                        }
+                      ]
+                    }
+                  ],
+                  "formulas": [{ "formula": "pageViews" }]
+                }
+              ]
+            },
+            "layout": { "x": 6, "y": 0, "width": 6, "height": 4 }
+          },
+          {
+            "definition": {
+              "title": "Language clicks by source (which surface drives clicks)",
+              "type": "toplist",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "data_source": "rum",
+                      "name": "clickSource",
+                      "indexes": ["*"],
+                      "search": { "query": "@type:action @action.target.name:language_click" },
+                      "compute": { "aggregation": "count" },
+                      "group_by": [
+                        {
+                          "facet": "@context.source",
+                          "limit": 15,
+                          "sort": { "aggregation": "count", "order": "desc" }
+                        }
+                      ]
+                    }
+                  ],
+                  "formulas": [{ "formula": "clickSource" }]
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 4, "width": 6, "height": 4 }
+          },
+          {
+            "definition": {
+              "title": "Most-clicked languages (by name)",
+              "type": "toplist",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "data_source": "rum",
+                      "name": "clickName",
+                      "indexes": ["*"],
+                      "search": { "query": "@type:action @action.target.name:language_click" },
+                      "compute": { "aggregation": "count" },
+                      "group_by": [
+                        {
+                          "facet": "@context.language_name",
+                          "limit": 25,
+                          "sort": { "aggregation": "count", "order": "desc" }
+                        }
+                      ]
+                    }
+                  ],
+                  "formulas": [{ "formula": "clickName" }]
+                }
+              ]
+            },
+            "layout": { "x": 6, "y": 4, "width": 6, "height": 4 }
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 10, "width": 12, "height": 9 }
+    },
+    {
+      "definition": {
+        "title": "Copies, downloads & search",
+        "type": "group",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "definition": {
+              "title": "Engagement by event type",
+              "type": "toplist",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "data_source": "rum",
+                      "name": "byEvent",
+                      "indexes": ["*"],
+                      "search": { "query": "@type:action @action.type:custom" },
+                      "compute": { "aggregation": "count" },
+                      "group_by": [
+                        {
+                          "facet": "@action.target.name",
+                          "limit": 15,
+                          "sort": { "aggregation": "count", "order": "desc" }
+                        }
+                      ]
+                    }
+                  ],
+                  "formulas": [{ "formula": "byEvent" }]
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 0, "width": 4, "height": 4 }
+          },
+          {
+            "definition": {
+              "title": "Top copied artifacts",
+              "type": "toplist",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "data_source": "rum",
+                      "name": "copies",
+                      "indexes": ["*"],
+                      "search": { "query": "@type:action @action.target.name:copy" },
+                      "compute": { "aggregation": "count" },
+                      "group_by": [
+                        {
+                          "facet": "@context.artifact",
+                          "limit": 15,
+                          "sort": { "aggregation": "count", "order": "desc" }
+                        }
+                      ]
+                    }
+                  ],
+                  "formulas": [{ "formula": "copies" }]
+                }
+              ]
+            },
+            "layout": { "x": 4, "y": 0, "width": 4, "height": 4 }
+          },
+          {
+            "definition": {
+              "title": "Top downloads",
+              "type": "toplist",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "data_source": "rum",
+                      "name": "downloads",
+                      "indexes": ["*"],
+                      "search": { "query": "@type:action @action.target.name:download" },
+                      "compute": { "aggregation": "count" },
+                      "group_by": [
+                        {
+                          "facet": "@context.file",
+                          "limit": 15,
+                          "sort": { "aggregation": "count", "order": "desc" }
+                        }
+                      ]
+                    }
+                  ],
+                  "formulas": [{ "formula": "downloads" }]
+                }
+              ]
+            },
+            "layout": { "x": 8, "y": 0, "width": 4, "height": 4 }
+          },
+          {
+            "definition": {
+              "title": "Copies & downloads over time",
+              "type": "timeseries",
+              "requests": [
+                {
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "data_source": "rum",
+                      "name": "copy",
+                      "indexes": ["*"],
+                      "search": { "query": "@type:action @action.target.name:copy" },
+                      "compute": { "aggregation": "count" },
+                      "group_by": []
+                    },
+                    {
+                      "data_source": "rum",
+                      "name": "download",
+                      "indexes": ["*"],
+                      "search": { "query": "@type:action @action.target.name:download" },
+                      "compute": { "aggregation": "count" },
+                      "group_by": []
+                    }
+                  ],
+                  "formulas": [
+                    { "formula": "copy", "alias": "copies" },
+                    { "formula": "download", "alias": "downloads" }
+                  ],
+                  "display_type": "line"
+                }
+              ]
+            },
+            "layout": { "x": 0, "y": 4, "width": 6, "height": 3 }
+          },
+          {
+            "definition": {
+              "title": "Top search terms (what people look for)",
+              "type": "toplist",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "data_source": "rum",
+                      "name": "searches",
+                      "indexes": ["*"],
+                      "search": { "query": "@type:action @action.target.name:search" },
+                      "compute": { "aggregation": "count" },
+                      "group_by": [
+                        {
+                          "facet": "@context.query",
+                          "limit": 25,
+                          "sort": { "aggregation": "count", "order": "desc" }
+                        }
+                      ]
+                    }
+                  ],
+                  "formulas": [{ "formula": "searches" }]
+                }
+              ]
+            },
+            "layout": { "x": 6, "y": 4, "width": 6, "height": 3 }
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 19, "width": 12, "height": 8 }
+    }
+  ]
+}

--- a/infra/datadog/katagami-rum-dashboard.json
+++ b/infra/datadog/katagami-rum-dashboard.json
@@ -1,6 +1,6 @@
 {
   "title": "Katagami — Visitors & Usage (RUM)",
-  "description": "What's getting traction on katagami.ai: unique visits, page views, which languages get viewed/clicked, and which artifacts get copied and downloaded. Fed by Datadog RUM (see infra/datadog/README.md). Import via Datadog → Dashboards → New Dashboard → Import dashboard JSON.\n\nNote on custom-action facets: copy/download/search/language_click/nav events are RUM custom actions. Their name is faceted as @action.target.name and their attributes as @context.<key> (e.g. @context.artifact, @context.file, @context.source). If your org surfaces them under a slightly different facet, adjust the affected widgets once real data lands — the views/sessions widgets are facet-independent and work immediately.",
+  "description": "What's getting traction on katagami.ai: unique visits, page views, which languages get viewed/clicked, and which artifacts get copied and downloaded. Fed by Datadog RUM (see infra/datadog/README.md). Import via Datadog → Dashboards → New Dashboard → Import dashboard JSON.\n\nFacets confirmed against live data: custom-action name = @action.target.name (language_click, copy, download, nav_click, search); attributes = @context.<key> (@context.artifact, @context.file, @context.source, @context.query). No calibration needed.",
   "layout_type": "ordered",
   "reflow_type": "fixed",
   "template_variables": [],

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
+        "@datadog/browser-rum": "^7.3.0",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -533,6 +534,50 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@datadog/browser-core": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-7.3.0.tgz",
+      "integrity": "sha512-bP6QuYyxdjaKYHwqpvYRihSEXgz/8P1iPr1ZI6OJVeDSJ7Zz/kAqK3dU5O7y6FrP9u99CbFG+rRGDtb4ytyJiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@datadog/js-core": "0.0.2"
+      }
+    },
+    "node_modules/@datadog/browser-rum": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-7.3.0.tgz",
+      "integrity": "sha512-HxJ+wPBP9l4rVYo5/u7Ls1gH4Pf8W0YGSI+euJfbIdU3UngickRNMQ2tiONwZIc6JjdrVJEu1gKMU/iqAiwiWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@datadog/browser-core": "7.3.0",
+        "@datadog/browser-rum-core": "7.3.0",
+        "@datadog/js-core": "0.0.2"
+      },
+      "peerDependencies": {
+        "@datadog/browser-logs": "7.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@datadog/browser-logs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@datadog/browser-rum-core": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-7.3.0.tgz",
+      "integrity": "sha512-E+lBOxaE7UazwhBA3/i8qc0080MQZgxBmpdQsVxkt/UWmql523U8Hf8u/0D4eIauVCOeB6faBhNJhfa/lsRxVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@datadog/browser-core": "7.3.0",
+        "@datadog/js-core": "0.0.2"
+      }
+    },
+    "node_modules/@datadog/js-core": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@datadog/js-core/-/js-core-0.0.2.tgz",
+      "integrity": "sha512-tubNtQXlHiDovBB04M16MWQbUj4j0F7eu6lWMUmFo/+SD5j8adzSGcVxtSNdSR/u++IaghkCpqcAaR3ZAJh2jQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.61.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
+    "@datadog/browser-rum": "^7.3.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/ui/src/app/(site)/art-styles/[id]/page.tsx
+++ b/ui/src/app/(site)/art-styles/[id]/page.tsx
@@ -151,8 +151,8 @@ export default async function ArtStyleDetailPage({ params }: { params: Promise<{
         ) : null}
         <Perforation className="my-4" />
         <div className="flex flex-wrap items-center gap-2">
-          <CopyButton text={recipe} label="Copy recipe" variant="ink" />
-          <CopyButton text={promptTemplate} label="Copy prompt only" />
+          <CopyButton text={recipe} label="Copy recipe" variant="ink" artifact="recipe" />
+          <CopyButton text={promptTemplate} label="Copy prompt only" artifact="prompt" />
           {tags.length > 0 ? (
             <span className="ml-auto flex flex-wrap gap-x-3 gap-y-1">
               {tags.slice(0, 5).map((t) => (

--- a/ui/src/app/(site)/page.tsx
+++ b/ui/src/app/(site)/page.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from "react";
-import Link from "next/link";
+import { TrackedLink } from "@/components/tracked-link";
 import {
   DESIGN_LANGUAGE_GALLERY_FIELDS,
   listDesignLanguages,
@@ -240,7 +240,7 @@ function TodaysPull({
     .trim();
 
   return (
-    <Link
+    <TrackedLink
       href={`/language/${lang.entity_id}`}
       prefetch={false}
       data-reveal
@@ -248,6 +248,8 @@ function TodaysPull({
       style={{
         boxShadow: "var(--shadow-card)",
       }}
+      event="language_click"
+      data={{ language_id: lang.entity_id, language_name: lang.fields.name, source: "today_pull" }}
     >
       <span
         aria-hidden
@@ -275,7 +277,7 @@ function TodaysPull({
       <span className="shrink-0 font-mono text-[11px] font-bold uppercase tracking-[0.16em] text-foreground transition-transform group-hover:translate-x-1">
         open →
       </span>
-    </Link>
+    </TrackedLink>
   );
 }
 

--- a/ui/src/app/(site)/palettes/[id]/page.tsx
+++ b/ui/src/app/(site)/palettes/[id]/page.tsx
@@ -170,7 +170,7 @@ export default async function PaletteDetailPage({ params }: { params: Promise<{ 
 
         <Perforation className="my-4" />
         <div className="flex flex-wrap items-center gap-2">
-          <CopyButton text={tokensCss} label="Copy tokens.css" variant="ink" />
+          <CopyButton text={tokensCss} label="Copy tokens.css" variant="ink" artifact="tokens_css" />
           <a
             href={`data:text/css;charset=utf-8,${encodeURIComponent(tokensCss)}`}
             download={`${slug}.tokens.css`}

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -9,6 +9,7 @@ import {
 } from "next/font/google";
 import "./globals.css";
 import { REVEAL_INIT_SCRIPT } from "@/components/scroll-reveal";
+import { RumInit } from "@/components/rum-init";
 
 const nunito = Nunito({
   variable: "--font-sans",
@@ -105,7 +106,10 @@ export default function RootLayout({
         <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <script dangerouslySetInnerHTML={{ __html: REVEAL_INIT_SCRIPT }} />
       </head>
-      <body className="min-h-full">{children}</body>
+      <body className="min-h-full">
+        <RumInit />
+        {children}
+      </body>
     </html>
   );
 }

--- a/ui/src/components/command-palette.tsx
+++ b/ui/src/components/command-palette.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import { track, trackLanguageClick, trackSearch } from "@/lib/analytics";
 
 export interface PaletteIndexItem {
   id: string;
@@ -116,6 +117,20 @@ export function CommandPalette({ items }: { items: PaletteIndexItem[] }) {
 
   const go = useCallback(
     (item: PaletteIndexItem) => {
+      if (item.kind === "language") {
+        trackLanguageClick({
+          languageId: item.id,
+          languageName: item.name,
+          source: "search",
+        });
+      } else {
+        track("search_result_click", {
+          entity_id: item.id,
+          entity_kind: item.kind,
+          entity_name: item.name,
+          source: "search",
+        });
+      }
       closePalette();
       router.push(item.href);
     },
@@ -128,6 +143,17 @@ export function CommandPalette({ items }: { items: PaletteIndexItem[] }) {
     const pick = pool[Math.floor(Math.random() * pool.length)];
     go(pick);
   }, [items, go]);
+
+  // Record search terms (debounced) — what people look for, and whether it
+  // returns anything. Query text is truncated inside trackSearch.
+  useEffect(() => {
+    const q = query.trim();
+    if (!q) return;
+    const timer = setTimeout(() => {
+      trackSearch({ query: q, resultsCount: results.length });
+    }, 600);
+    return () => clearTimeout(timer);
+  }, [query, results.length]);
 
   const onInputKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "ArrowDown") {

--- a/ui/src/components/compare-selector.tsx
+++ b/ui/src/components/compare-selector.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Search, X } from "lucide-react";
+import { trackCompare } from "@/lib/analytics";
 
 interface LangRef {
   id: string;
@@ -25,6 +26,7 @@ export function CompareSelector({
   const searchParams = useSearchParams();
 
   function update(key: string, value: string) {
+    if (value) trackCompare({ action: "add", languageId: value });
     const params = new URLSearchParams(searchParams.toString());
     if (value) params.set(key, value);
     else params.delete(key);

--- a/ui/src/components/copy-button.tsx
+++ b/ui/src/components/copy-button.tsx
@@ -2,16 +2,24 @@
 
 import { useState } from "react";
 import { KX_BTN_INK, KX_BTN_PAPER } from "@/lib/katagami-ui";
+import { trackCopy } from "@/lib/analytics";
 
 /** Minimal katagami copy button (no emoji, no grey border). */
 export function CopyButton({
   text,
   label,
   variant = "outline",
+  artifact,
+  languageId,
+  paletteId,
 }: {
   text: string;
   label: string;
   variant?: "outline" | "ink";
+  /** What is being copied, for analytics (falls back to `label`). */
+  artifact?: string;
+  languageId?: string;
+  paletteId?: string;
 }) {
   const [copied, setCopied] = useState(false);
   return (
@@ -20,6 +28,7 @@ export function CopyButton({
       className={variant === "ink" ? KX_BTN_INK : KX_BTN_PAPER}
       onClick={() => {
         void navigator.clipboard.writeText(text);
+        trackCopy({ artifact: artifact ?? label, languageId, paletteId, label });
         setCopied(true);
         setTimeout(() => setCopied(false), 1600);
       }}

--- a/ui/src/components/design-md-showcase.tsx
+++ b/ui/src/components/design-md-showcase.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Copy, Check } from "lucide-react";
+import { trackCopy } from "@/lib/analytics";
 import { parseJson } from "@/lib/odata";
 import {
   buildDesignMdFrontMatter,
@@ -179,6 +180,7 @@ function ColorChip({ name, value }: { name: string; value: string }) {
   const onCopy = async () => {
     try {
       await navigator.clipboard.writeText(value);
+      trackCopy({ artifact: "color", label: name });
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     } catch {

--- a/ui/src/components/gallery-filters.tsx
+++ b/ui/src/components/gallery-filters.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Search, Shuffle } from "lucide-react";
 import { Input } from "@/components/ui/input";
+import { trackSearch } from "@/lib/analytics";
 import {
   Select,
   SelectContent,
@@ -63,6 +64,14 @@ export function GalleryFilters({
   const [status, setStatus] = useState(initialStatus);
   const [taxonomy, setTaxonomy] = useState(initialTaxonomy);
   const [search, setSearch] = useState(initialSearch);
+
+  // Record gallery search terms (debounced).
+  useEffect(() => {
+    const q = search.trim();
+    if (!q) return;
+    const timer = setTimeout(() => trackSearch({ query: q }), 600);
+    return () => clearTimeout(timer);
+  }, [search]);
   const [tag, setTag] = useState(initialTag);
   const [hue, setHue] = useState(initialHue);
   const [source, setSource] = useState(initialSource);

--- a/ui/src/components/header-nav.tsx
+++ b/ui/src/components/header-nav.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { trackNav } from "@/lib/analytics";
 
 const links = [
   { href: "/", label: "Gallery" },
@@ -24,6 +25,7 @@ export function HeaderNav() {
             key={l.href}
             href={l.href}
             data-active={active}
+            onClick={() => trackNav({ target: l.href, source: "header" })}
             className="ink-underline relative inline-block shrink-0 text-foreground/75 transition-colors hover:text-foreground data-[active=true]:text-foreground"
           >
             {l.label}

--- a/ui/src/components/language-card.tsx
+++ b/ui/src/components/language-card.tsx
@@ -1,6 +1,6 @@
-import Link from "next/link";
 import type { CSSProperties } from "react";
 import type { DesignLanguage } from "@/lib/odata";
+import { TrackedLink } from "@/components/tracked-link";
 import { parseJson } from "@/lib/odata";
 import { LanguageCardOwnerControls } from "@/components/language-card-owner-controls";
 import { ThumbnailPreview } from "@/components/thumbnail-preview";
@@ -110,9 +110,15 @@ export function LanguageCard({
       className="group relative min-w-0 max-w-full"
       style={cardVisibilityStyle}
     >
-      <Link href={`/language/${id}`} prefetch={false} className="block h-full">
+      <TrackedLink
+        href={`/language/${id}`}
+        prefetch={false}
+        className="block h-full"
+        event="language_click"
+        data={{ language_id: id, language_name: name, source: "card" }}
+      >
         <FullCard lang={lang} stickyTint={stickyTint} eagerThumbnail={index < 6} />
-      </Link>
+      </TrackedLink>
       {canDelete ? (
         <LanguageCardOwnerControls
           id={id}

--- a/ui/src/components/lineage-graph.tsx
+++ b/ui/src/components/lineage-graph.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Link from "next/link";
+import { TrackedLink } from "@/components/tracked-link";
 import { CornerDownRight } from "lucide-react";
 
 interface GraphNode {
@@ -150,10 +150,12 @@ function LineageCard({
   const rot = (((node.id.charCodeAt(0) + node.id.length) % 7) - 3) * 0.2;
 
   return (
-    <Link
+    <TrackedLink
       href={`/language/${node.id}`}
       className="group relative block transition-transform duration-200 hover:-translate-y-[2px] hover:rotate-0"
       style={{ transform: `rotate(${rot}deg)` }}
+      event="language_click"
+      data={{ language_id: node.id, language_name: node.name, source: "lineage", lineage_type: node.lineageType }}
     >
       <article
         className="relative p-3.5"
@@ -239,7 +241,7 @@ function LineageCard({
           open ↗
         </span>
       </article>
-    </Link>
+    </TrackedLink>
   );
 }
 

--- a/ui/src/components/mobile-nav.tsx
+++ b/ui/src/components/mobile-nav.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { LayoutGrid, Palette, Brush, Wand2 } from "lucide-react";
+import { trackNav } from "@/lib/analytics";
 
 const tabs = [
   {
@@ -70,6 +71,7 @@ export function MobileNav() {
               <Link
                 href={href}
                 aria-current={active ? "page" : undefined}
+                onClick={() => trackNav({ target: href, source: "mobile" })}
                 className="group/tab relative flex flex-col items-center gap-0.5 px-1 py-1.5 text-foreground/70 transition-colors duration-150 active:text-foreground"
               >
                 {/* active yuzu wash behind the cell */}

--- a/ui/src/components/related-languages.tsx
+++ b/ui/src/components/related-languages.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import { TrackedLink } from "@/components/tracked-link";
 import { listDesignLanguages, parseJson } from "@/lib/odata";
 
 interface TokensLite {
@@ -66,7 +66,7 @@ export async function RelatedLanguages({
           );
           const ink = swatch[0] ?? "var(--teal)";
           return (
-            <Link
+            <TrackedLink
               key={lang.entity_id}
               href={`/language/${lang.entity_id}`}
               prefetch={false}
@@ -74,6 +74,8 @@ export async function RelatedLanguages({
               style={{
                 boxShadow: "var(--shadow-card)",
               }}
+              event="language_click"
+              data={{ language_id: lang.entity_id, language_name: lang.fields.name, source: "related" }}
             >
               <span aria-hidden className="flex shrink-0 flex-col gap-[2px]">
                 {(swatch.length > 0 ? swatch : [ink]).slice(0, 3).map((c, i) => (
@@ -94,7 +96,7 @@ export async function RelatedLanguages({
               >
                 →
               </span>
-            </Link>
+            </TrackedLink>
           );
         })}
       </div>

--- a/ui/src/components/remix/inline-remix.tsx
+++ b/ui/src/components/remix/inline-remix.tsx
@@ -10,6 +10,7 @@ import { COMPOSITIONS } from "@/lib/remix-compositions";
 import { saveRemix } from "@/app/remix-actions";
 import type { Roles } from "@/lib/remix-theme";
 import { KX_BTN_INK, KX_BTN_PAPER, KX_LABEL } from "@/lib/katagami-ui";
+import { trackCopy } from "@/lib/analytics";
 
 const MEDIA = "shrink-0 overflow-hidden rounded-[2px] shadow-[0_1px_3px_rgba(30,35,45,0.14)]";
 
@@ -271,7 +272,15 @@ export function InlineRemix({
             {saved ? "Saved" : pending ? "Saving" : "Save mix"}
           </button>
         ) : null}
-        <button type="button" onClick={copyBrief} disabled={!haveAll} className={KX_BTN_INK}>
+        <button
+          type="button"
+          onClick={() => {
+            trackCopy({ artifact: "remix_brief", page: "remix" });
+            copyBrief();
+          }}
+          disabled={!haveAll}
+          className={KX_BTN_INK}
+        >
           {copied ? "Copied" : "Copy brief"}
         </button>
       </div>

--- a/ui/src/components/rum-init.tsx
+++ b/ui/src/components/rum-init.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect } from "react";
+import { initRum } from "@/lib/analytics";
+
+/** Initializes Datadog RUM once on the client. Renders nothing.
+ *  No-op when NEXT_PUBLIC_DD_RUM_* env vars are absent, so it is safe to
+ *  mount unconditionally (e.g. in local dev without credentials). The SDK
+ *  then auto-tracks sessions + per-route views; custom actions come from the
+ *  typed helpers in lib/analytics. */
+export function RumInit() {
+  useEffect(() => {
+    void initRum();
+  }, []);
+  return null;
+}

--- a/ui/src/components/spec-actions.tsx
+++ b/ui/src/components/spec-actions.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Download, Copy, Link2, Check } from "lucide-react";
+import { trackCopy, trackDownload } from "@/lib/analytics";
 
 interface SpecActionsProps {
   languageId?: string;
@@ -104,6 +105,7 @@ export function SpecActions({
     const url = urlFor(format);
     const refLine = url ? `\n\nSource: ${url}` : "";
     await writeClipboard(`${PREAMBLE[format]}${refLine}\n\n${md}`);
+    trackCopy({ artifact: format, languageId, label: "spec" });
     flash("copy");
   };
 
@@ -111,6 +113,7 @@ export function SpecActions({
     const url = urlFor(format);
     if (!url) return;
     await writeClipboard(url);
+    trackCopy({ artifact: `${format}-url`, languageId, label: "link" });
     flash("link");
   };
 
@@ -128,6 +131,7 @@ export function SpecActions({
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
+    trackDownload({ file: a.download, format, languageId });
   };
 
   const accent = ACCENT[format];

--- a/ui/src/components/taxonomy-cluster-view.tsx
+++ b/ui/src/components/taxonomy-cluster-view.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
+import { TrackedLink } from "@/components/tracked-link";
 import { ArrowUpRight, ChevronDown } from "lucide-react";
 import type { Taxonomy, DesignLanguage } from "@/lib/odata";
 import { parseJson } from "@/lib/odata";
@@ -169,13 +170,15 @@ function TraitPills({
 
 function LanguageChip({ lang }: { lang: DesignLanguage }) {
   return (
-    <Link
+    <TrackedLink
       href={`/language/${lang.entity_id}`}
       className="inline-flex max-w-full items-center gap-1 bg-[color-mix(in_srgb,var(--teal)_14%,var(--paper-stamp-mix))] px-2 py-1 text-[11px] font-medium text-[color:color-mix(in_oklch,var(--teal)_72%,var(--foreground))] transition-colors hover:bg-[color-mix(in_srgb,var(--teal)_22%,var(--paper-stamp-mix))] hover:text-foreground"
+      event="language_click"
+      data={{ language_id: lang.entity_id, language_name: languageName(lang), source: "taxonomy" }}
     >
       <span className="truncate">{languageName(lang)}</span>
       <ArrowUpRight className="h-3 w-3 shrink-0 text-muted-foreground" />
-    </Link>
+    </TrackedLink>
   );
 }
 

--- a/ui/src/components/tracked-link.tsx
+++ b/ui/src/components/tracked-link.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import Link from "next/link";
+import type { ComponentProps, MouseEvent, ReactNode } from "react";
+import { track } from "@/lib/analytics";
+
+type LinkProps = ComponentProps<typeof Link>;
+
+/** A next/link that fires a Datadog RUM custom action on click before
+ *  navigating. Use for links whose click we want to attribute (e.g. which
+ *  surface drove a language visit). Any extra Link props pass straight
+ *  through, so it is a drop-in replacement for <Link>. */
+export function TrackedLink({
+  event,
+  data,
+  onClick,
+  children,
+  ...rest
+}: LinkProps & {
+  event: string;
+  data?: Record<string, string | number | boolean | undefined>;
+  children: ReactNode;
+}) {
+  return (
+    <Link
+      {...rest}
+      onClick={(e: MouseEvent<HTMLAnchorElement>) => {
+        track(event, data ?? {});
+        onClick?.(e);
+      }}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/ui/src/lib/analytics.ts
+++ b/ui/src/lib/analytics.ts
@@ -31,6 +31,10 @@ function readEnv() {
     env: process.env.NEXT_PUBLIC_DD_RUM_ENV || "production",
     version: process.env.NEXT_PUBLIC_DD_RUM_VERSION || undefined,
     sampleRate: Number(process.env.NEXT_PUBLIC_DD_RUM_SAMPLE_RATE ?? "100"),
+    // Session replay records the actual screen (DOM) of a % of sessions. Off by
+    // default — this setup is for usage counts, not screen recordings. Flip via
+    // env (e.g. 20) to enable, no code change needed.
+    replaySampleRate: Number(process.env.NEXT_PUBLIC_DD_RUM_REPLAY_SAMPLE_RATE ?? "0"),
   };
 }
 
@@ -57,7 +61,9 @@ export async function initRum(): Promise<void> {
       env: e.env,
       version: e.version,
       sessionSampleRate: Number.isFinite(e.sampleRate) ? e.sampleRate : 100,
-      sessionReplaySampleRate: 0, // no session replay — analytics only
+      sessionReplaySampleRate: Number.isFinite(e.replaySampleRate)
+        ? e.replaySampleRate
+        : 0,
       trackUserInteractions: true, // automatic click map in addition to our actions
       trackResources: true,
       trackLongTasks: true,

--- a/ui/src/lib/analytics.ts
+++ b/ui/src/lib/analytics.ts
@@ -1,0 +1,177 @@
+// Datadog RUM analytics for katagami.ai.
+//
+// Design goals:
+//  - Zero-cost no-op until init runs, and a permanent no-op when the
+//    NEXT_PUBLIC_DD_RUM_* env vars are absent. Importing or calling any
+//    helper here must never throw — analytics can't break the site.
+//  - The SDK is loaded lazily (dynamic import) only in the browser and only
+//    when credentials exist, so it never enters the SSR/server bundle.
+//
+// What we get for free from RUM once initialized:
+//  - Unique visits / sessions and pageviews per route (the SDK patches the
+//    History API, so every App Router navigation becomes a new RUM "view"
+//    with @view.url_path — e.g. /language/<id>). That is the primary signal
+//    for "which languages get traffic".
+// What the custom actions below add:
+//  - Attribution (which surface drove a click), and events that aren't a
+//    navigation at all: copy-to-clipboard, downloads, search, compare.
+
+type RumModule = typeof import("@datadog/browser-rum");
+type RumGlobal = RumModule["datadogRum"];
+
+let rum: RumGlobal | null = null;
+let initialized = false;
+
+function readEnv() {
+  return {
+    applicationId: process.env.NEXT_PUBLIC_DD_RUM_APPLICATION_ID,
+    clientToken: process.env.NEXT_PUBLIC_DD_RUM_CLIENT_TOKEN,
+    site: process.env.NEXT_PUBLIC_DD_RUM_SITE || "datadoghq.com",
+    service: process.env.NEXT_PUBLIC_DD_RUM_SERVICE || "katagami-web",
+    env: process.env.NEXT_PUBLIC_DD_RUM_ENV || "production",
+    version: process.env.NEXT_PUBLIC_DD_RUM_VERSION || undefined,
+    sampleRate: Number(process.env.NEXT_PUBLIC_DD_RUM_SAMPLE_RATE ?? "100"),
+  };
+}
+
+/** True when RUM credentials are configured. */
+export function rumEnabled(): boolean {
+  const e = readEnv();
+  return Boolean(e.applicationId && e.clientToken);
+}
+
+/** Initialize the RUM SDK once, in the browser. Safe to call repeatedly. */
+export async function initRum(): Promise<void> {
+  if (initialized || typeof window === "undefined") return;
+  const e = readEnv();
+  if (!e.applicationId || !e.clientToken) return; // no creds → stay a no-op
+  initialized = true;
+  try {
+    const mod = await import("@datadog/browser-rum");
+    rum = mod.datadogRum;
+    rum.init({
+      applicationId: e.applicationId,
+      clientToken: e.clientToken,
+      site: e.site,
+      service: e.service,
+      env: e.env,
+      version: e.version,
+      sessionSampleRate: Number.isFinite(e.sampleRate) ? e.sampleRate : 100,
+      sessionReplaySampleRate: 0, // no session replay — analytics only
+      trackUserInteractions: true, // automatic click map in addition to our actions
+      trackResources: true,
+      trackLongTasks: true,
+      defaultPrivacyLevel: "mask-user-input",
+    });
+  } catch {
+    // SDK failed to load — leave as a no-op, never surface to the user.
+    rum = null;
+  }
+}
+
+type AttrValue = string | number | boolean | undefined | null;
+type Attributes = Record<string, AttrValue>;
+
+function clean(attrs: Attributes): Record<string, string | number | boolean> {
+  const out: Record<string, string | number | boolean> = {};
+  for (const [k, v] of Object.entries(attrs)) {
+    if (v === undefined || v === null || v === "") continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+/** Low-level: record a custom RUM action. No-op until RUM is ready. */
+export function track(name: string, attributes: Attributes = {}): void {
+  if (!rum || !initialized) return;
+  try {
+    rum.addAction(name, clean(attributes));
+  } catch {
+    /* analytics must never throw into the UI */
+  }
+}
+
+// ---- Typed event helpers (the only API the components should use) ----------
+
+/** Click that navigates to a design-language detail page. `source` says which
+ *  surface drove it (card | related | taxonomy | lineage | search | nav | hero …). */
+export function trackLanguageClick(d: {
+  languageId: string;
+  languageName?: string;
+  source: string;
+  page?: string;
+}): void {
+  track("language_click", {
+    language_id: d.languageId,
+    language_name: d.languageName,
+    source: d.source,
+    page: d.page,
+  });
+}
+
+/** Copy-to-clipboard. `artifact` names what was copied (design_md | shadcn_md |
+ *  katagami | link | css_var | color | prompt | brief …). */
+export function trackCopy(d: {
+  artifact: string;
+  languageId?: string;
+  paletteId?: string;
+  label?: string;
+  page?: string;
+}): void {
+  track("copy", {
+    artifact: d.artifact,
+    language_id: d.languageId,
+    palette_id: d.paletteId,
+    label: d.label,
+    page: d.page,
+  });
+}
+
+/** File download (DESIGN.md, shadcn.json, zip, png …). */
+export function trackDownload(d: {
+  file: string;
+  format?: string;
+  languageId?: string;
+  paletteId?: string;
+  page?: string;
+}): void {
+  track("download", {
+    file: d.file,
+    format: d.format,
+    language_id: d.languageId,
+    palette_id: d.paletteId,
+    page: d.page,
+  });
+}
+
+/** Search usage. Query text is truncated; we never store more than 100 chars. */
+export function trackSearch(d: {
+  query: string;
+  resultsCount?: number;
+}): void {
+  const q = (d.query || "").trim();
+  if (!q) return;
+  track("search", {
+    query: q.slice(0, 100),
+    query_length: q.length,
+    results_count: d.resultsCount,
+  });
+}
+
+/** A language was added to / removed from the compare tray. */
+export function trackCompare(d: {
+  action: "add" | "remove" | "open";
+  languageId?: string;
+  count?: number;
+}): void {
+  track("compare", {
+    compare_action: d.action,
+    language_id: d.languageId,
+    count: d.count,
+  });
+}
+
+/** Primary navigation click (header / mobile nav / footer). */
+export function trackNav(d: { target: string; source?: string }): void {
+  track("nav_click", { target: d.target, source: d.source });
+}


### PR DESCRIPTION
## What & why

katagami.ai had **no visitor tracking of any kind** — no analytics SDK in the app, no Datadog RUM application, no dashboard, and the only Datadog data mentioning "katagami" was backend pipeline logs (`temperpaw`). This PR adds first-party product analytics so we can see what's getting traction: **unique visits, which languages get viewed/clicked, which artifacts get copied, and which get downloaded — across every page.**

## Approach

Datadog RUM (browser SDK v7), wired to be **zero-risk**:
- Lazy-loaded and **env-gated** — a complete no-op when `NEXT_PUBLIC_DD_RUM_*` is unset (local dev, previews), and analytics calls **never throw** into the UI.
- Once credentials are set, RUM auto-tracks **sessions (unique visits)** and **per-route views** (every `/language/<id>` visit), so language/page popularity needs no per-component code.
- A typed event layer (`lib/analytics.ts`) adds what isn't a navigation: `copy`, `download`, `search`, `compare`, `nav_click`, plus click-source attribution via `language_click`.
- The long tail (filters, tabs, shuffle) is captured by RUM's automatic interaction tracking.

## Coverage (from a full 105-surface census)
Shared components instrumented once → broad coverage: copy-button, spec-actions, language-card, related/lineage/taxonomy language links, command-palette + gallery search, compare-selector, header/mobile nav, design-md color chips, remix brief, palette/art-style copy + download.

## Dashboard
`infra/datadog/katagami-rum-dashboard.json` — importable (Dashboards → New → Import JSON): unique visits, page views, visits by country/device/referrer, top languages by views, language clicks by source, engagement by event type, top copies, top downloads, top search terms.

## Verified live (local, placeholder creds)
- RUM session active (`getInternalContext()` returns a live session + view).
- SDK POSTing event batches to `browser-intake-datadoghq.com/api/v2/rum`.
- Custom action fires with correct attributes — captured `nav_click {target:/palettes, source:header}`.
- Language-card click navigates correctly; page renders unbroken with RUM mounted.
- `next build` + `tsc --noEmit` + `eslint` + contract tests all green.

## Required to go live (account-side — see infra/datadog/README.md)
1. Create a RUM application in Datadog (Digital Experience → RUM → New Application, JS) → `applicationId` + `clientToken`.
2. Set `NEXT_PUBLIC_DD_RUM_APPLICATION_ID` + `NEXT_PUBLIC_DD_RUM_CLIENT_TOKEN` (+ optional `_SITE`/`_ENV`/`_SERVICE`) in Vercel → Environment Variables, redeploy.
3. Import the dashboard JSON.

## Privacy
`defaultPrivacyLevel: mask-user-input`, no session replay, search text truncated to 100 chars. No PII.

## Known gap
Server-route artifact downloads (`/language/<id>/DESIGN.md` etc., mostly agents fetching specs) aren't RUM-visible — they're not browser interactions. Counting those needs route-level logging + a Vercel→Datadog log drain (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
