### PR TITLE
fix(ui): center shadcn tab triggers + status badge labels

### DIFF
--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -472,6 +472,8 @@
   .shadsync-status {
     border: 1.5px solid color-mix(in srgb, var(--shadsync-outline) 78%, transparent);
     box-shadow: 0 1px 0 rgb(255 255 255 / 0.42) inset, 0 2px 7px rgb(48 64 59 / 0.07);
+    /* optically centre the (usually uppercase) label so it never drifts top/bottom */
+    line-height: 1 !important;
   }
 
   .shadsync-preview .shadsync-button,
@@ -652,11 +654,13 @@
     padding: 3px;
     align-items: center;
   }
-  /* keep the tab triggers vertically centred in the bar (no bottom bias) */
+  /* triggers fill the bar height and optically centre their (often uppercase) label */
   .shadsync-preview .shadsync-tabs [data-slot="tabs-trigger"] {
-    align-self: center;
-    height: auto;
-    min-height: 1.6rem;
+    align-self: stretch;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1 !important;
   }
 
   .shadsync-notes {

--- a/ui/src/components/shadcn-preview.tsx
+++ b/ui/src/components/shadcn-preview.tsx
@@ -965,7 +965,7 @@ function SceneBadge({ status }: { status: string }) {
   return (
     <Badge
       variant={variant}
-      className="shadsync-status h-5 rounded-md"
+      className="shadsync-status h-5 rounded-md leading-none"
       data-shadsync-status-tone={tone}
     >
       {status}
@@ -1392,7 +1392,7 @@ function SceneHeader({
     <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
       <div className="min-w-0 space-y-1.5">
         <div className="flex flex-wrap items-center gap-2">
-          <Badge className="shadsync-status h-5 rounded-md">{scene.eyebrow || shot.viewport}</Badge>
+          <Badge className="shadsync-status h-5 rounded-md leading-none">{scene.eyebrow || shot.viewport}</Badge>
           <Badge variant="outline" className="shadsync-chip h-5 rounded-md">
             {shot.id}
           </Badge>


### PR DESCRIPTION
The Queued/Blocked/Done tab triggers and status badges had uneven top/bottom space (uppercase labels drifting). Triggers now fill the bar and flex-center with line-height:1; badges use line-height:1 + leading-none. Verified locally on Phosphor.