### PR TITLE
feat(commons): record AI model provenance on art styles, languages & palettes

### DIFF
--- a/katagami-commons/specs/art_style.ioa.toml
+++ b/katagami-commons/specs/art_style.ioa.toml
@@ -217,6 +217,14 @@ params = ["credits"]
 hint = "Credit the artists, movements, studios, or traditions this style is attributable to. JSON list of {name, kind (artist|movement|studio|tradition), note}. Credit ALL influences — an LLM-produced style is an aggregate of many hands; never pass a recognizable style off as original. Editable on Published without re-publishing."
 
 [[action]]
+name = "SetModelProvenance"
+kind = "input"
+from = ["Draft", "UnderReview", "Published"]
+effect = [{ type = "set_bool", var = "has_model_provenance", value = "true" }]
+params = ["model_provenance"]
+hint = "Record which AI models produced this art style. JSON {style:{model}, source:{model}, images:{model, provider, tool}}: the model that authored the recipe, the model that sourced/identified the tradition, and the model that generated the sample images. Editable on Published without re-publishing."
+
+[[action]]
 name = "SetFeatured"
 kind = "input"
 from = ["Draft", "UnderReview", "Published"]

--- a/katagami-commons/specs/design_language.ioa.toml
+++ b/katagami-commons/specs/design_language.ioa.toml
@@ -332,6 +332,14 @@ params = ["credits"]
 hint = "Credit the artists, movements, studios, or traditions this language is attributable to. JSON list of {name, kind (artist|movement|studio|tradition), note}. Credit ALL influences — never pass a recognizable style off as original. Editable on Published without re-publishing."
 
 [[action]]
+name = "SetModelProvenance"
+kind = "input"
+from = ["Draft", "UnderReview", "Published"]
+effect = [{ type = "set_bool", var = "has_model_provenance", value = "true" }]
+params = ["model_provenance"]
+hint = "Record which AI models produced this design language. JSON {style:{model}, source:{model}, images:{model, provider, tool}}: the model that authored the spec, the model that sourced/researched it, and the model that generated its imagery. Editable on Published without re-publishing."
+
+[[action]]
 name = "SetFeatured"
 kind = "input"
 from = ["Draft", "UnderReview", "Published"]

--- a/katagami-commons/specs/model.csdl.xml
+++ b/katagami-commons/specs/model.csdl.xml
@@ -70,6 +70,8 @@
         <Property Name="SourceIds" Type="Edm.String" Nullable="false" DefaultValue="[]" />
         <Property Name="Credits" Type="Edm.String" Nullable="false" DefaultValue="[]" />
         <Property Name="HasCredits" Type="Edm.Boolean" Nullable="false" DefaultValue="false" />
+        <Property Name="ModelProvenance" Type="Edm.String" Nullable="false" DefaultValue="{}" />
+        <Property Name="HasModelProvenance" Type="Edm.Boolean" Nullable="false" DefaultValue="false" />
         <!-- Taste embedding: semantic vector for discovery (taste deck,
              related languages). JSON float array + the model that made it. -->
         <Property Name="TasteVector" Type="Edm.String" Nullable="false" DefaultValue="" />
@@ -200,6 +202,8 @@
         <Property Name="SourceIds" Type="Edm.String" Nullable="false" DefaultValue="[]" />
         <Property Name="Credits" Type="Edm.String" Nullable="false" DefaultValue="[]" />
         <Property Name="HasCredits" Type="Edm.Boolean" Nullable="false" DefaultValue="false" />
+        <Property Name="ModelProvenance" Type="Edm.String" Nullable="false" DefaultValue="{}" />
+        <Property Name="HasModelProvenance" Type="Edm.Boolean" Nullable="false" DefaultValue="false" />
         <!-- Taste embedding: semantic vector for discovery. JSON float array + model id. -->
         <Property Name="TasteVector" Type="Edm.String" Nullable="false" DefaultValue="" />
         <Property Name="TasteVectorModel" Type="Edm.String" Nullable="false" DefaultValue="" />
@@ -262,6 +266,8 @@
         <Property Name="SourceIds" Type="Edm.String" Nullable="false" DefaultValue="[]" />
         <Property Name="Credits" Type="Edm.String" Nullable="false" DefaultValue="[]" />
         <Property Name="HasCredits" Type="Edm.Boolean" Nullable="false" DefaultValue="false" />
+        <Property Name="ModelProvenance" Type="Edm.String" Nullable="false" DefaultValue="{}" />
+        <Property Name="HasModelProvenance" Type="Edm.Boolean" Nullable="false" DefaultValue="false" />
         <!-- Taste embedding: semantic vector for discovery. JSON float array + model id. -->
         <Property Name="TasteVector" Type="Edm.String" Nullable="false" DefaultValue="" />
         <Property Name="TasteVectorModel" Type="Edm.String" Nullable="false" DefaultValue="" />

--- a/katagami-commons/specs/palette_system.ioa.toml
+++ b/katagami-commons/specs/palette_system.ioa.toml
@@ -200,6 +200,14 @@ params = ["credits"]
 hint = "Credit the artists, movements, studios, or traditions this palette is attributable to. JSON list of {name, kind (artist|movement|studio|tradition), note}. Credit ALL influences — never pass a recognizable style off as original. Editable on Published without re-publishing."
 
 [[action]]
+name = "SetModelProvenance"
+kind = "input"
+from = ["Draft", "UnderReview", "Published"]
+effect = [{ type = "set_bool", var = "has_model_provenance", value = "true" }]
+params = ["model_provenance"]
+hint = "Record which AI models produced this palette. JSON {style:{model}, source:{model}, images:{model, provider, tool}}: the model that authored the palette, the model that sourced/researched it, and the model that generated any sample imagery. Editable on Published without re-publishing."
+
+[[action]]
 name = "SetFeatured"
 kind = "input"
 from = ["Draft", "UnderReview", "Published"]

--- a/ui/src/app/(site)/art-styles/[id]/page.tsx
+++ b/ui/src/app/(site)/art-styles/[id]/page.tsx
@@ -14,6 +14,7 @@ import { PageHero } from "@/components/page-hero";
 import { StickyNote, SectionHeading, Stamp, Perforation } from "@/components/scrapbook";
 import { CopyButton } from "@/components/copy-button";
 import { Credits } from "@/components/credits";
+import { ModelProvenance } from "@/components/model-provenance";
 import { InlineRemix } from "@/components/remix/inline-remix";
 
 export const dynamic = "force-dynamic";
@@ -174,6 +175,8 @@ export default async function ArtStyleDetailPage({ params }: { params: Promise<{
       </StickyNote>
 
       <Credits raw={f.credits} />
+
+      <ModelProvenance raw={f.model_provenance} />
 
       {guidance && (guidance.do?.length || guidance.dont?.length) ? (
         <div className="grid gap-4 sm:grid-cols-2">

--- a/ui/src/app/(site)/language/[id]/page.tsx
+++ b/ui/src/app/(site)/language/[id]/page.tsx
@@ -25,6 +25,7 @@ import { EmbodimentTabs, type EmbodimentTab } from "@/components/embodiment-tabs
 import { DesignShowcase } from "@/components/design-showcase";
 import { ShadcnPreview } from "@/components/shadcn-preview";
 import { Credits } from "@/components/credits";
+import { ModelProvenance } from "@/components/model-provenance";
 import { PageHero } from "@/components/page-hero";
 import { shadcnDesignMdMarkdown } from "@/lib/shadcn-export";
 import {
@@ -381,6 +382,8 @@ export default async function LanguageDetailPage({
       </div>
 
       <Credits raw={f.credits} />
+
+      <ModelProvenance raw={f.model_provenance} />
 
       {canRemix ? (
         <section>

--- a/ui/src/app/(site)/palettes/[id]/page.tsx
+++ b/ui/src/app/(site)/palettes/[id]/page.tsx
@@ -15,6 +15,7 @@ import { readableTextColor } from "@/lib/shadcn-export";
 import { PageHero } from "@/components/page-hero";
 import { StickyNote, SectionHeading, Stamp, Perforation } from "@/components/scrapbook";
 import { Credits } from "@/components/credits";
+import { ModelProvenance } from "@/components/model-provenance";
 import { CopyButton } from "@/components/copy-button";
 import { InlineRemix } from "@/components/remix/inline-remix";
 import { KX_BTN_PAPER } from "@/lib/katagami-ui";
@@ -190,6 +191,8 @@ export default async function PaletteDetailPage({ params }: { params: Promise<{ 
       </StickyNote>
 
       <Credits raw={f.credits} />
+
+      <ModelProvenance raw={f.model_provenance} />
 
       {guidance && (guidance.do?.length || guidance.dont?.length) ? (
         <div className="grid gap-4 sm:grid-cols-2">

--- a/ui/src/components/model-provenance.tsx
+++ b/ui/src/components/model-provenance.tsx
@@ -1,0 +1,37 @@
+import { parseJson } from "@/lib/odata";
+
+type ModelRef = { model?: string; tool?: string } | string;
+type Provenance = { style?: ModelRef; source?: ModelRef; images?: ModelRef };
+
+function modelOf(r?: ModelRef): string {
+  if (!r) return "";
+  return typeof r === "string" ? r : r.model || "";
+}
+
+/**
+ * Which AI models produced this entity: the model that authored the recipe/spec,
+ * the model that sourced/identified it, and the model that generated its sample
+ * images. Renders nothing when no provenance is recorded.
+ */
+export function ModelProvenance({ raw }: { raw?: string }) {
+  const p = parseJson<Provenance>(raw) ?? {};
+  const rows = (
+    [
+      ["produced by", modelOf(p.style)],
+      ["sourced by", modelOf(p.source)],
+      ["images by", modelOf(p.images)],
+    ] as [string, string][]
+  ).filter(([, v]) => v.length > 0);
+  if (rows.length === 0) return null;
+
+  return (
+    <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground/70">
+      {rows.map(([label, value], i) => (
+        <span key={label}>
+          {i > 0 ? "  ·  " : ""}
+          {label} <span className="text-muted-foreground">{value}</span>
+        </span>
+      ))}
+    </p>
+  );
+}


### PR DESCRIPTION
## What & why
Records **which AI models produced each entity** — the gap you flagged. Today only the *image* model is recorded, buried in `reference_manifest.generator`; the model that *produced the recipe* and the model that *sourced* it were recorded nowhere.

## Changes
**Spec — `katagami-commons`**: `ModelProvenance` (JSON) + `HasModelProvenance` on `ArtStyle`, `DesignLanguage`, `PaletteSystem`; `SetModelProvenance(model_provenance)` action (Draft/UnderReview/**Published**). Shape: `{ "style":{"model":…}, "source":{"model":…}, "images":{"model":…,"tool":…} }` — produced the recipe / sourced the tradition / generated the sample images.

**UI — `ui/`**: `<ModelProvenance>` renders a compact "produced by · sourced by · images by" line on the art-style, palette, and language pages (nothing when empty).

## Verification
`tsc` + `eslint` clean; all three IOA specs parse; CSDL `ModelProvenance` on all three.

## Deploy
Intended to land on Genesis alongside the credits change so the one pending OpenPaw install deploys both. Backfill follows the install — verifiable values only, unknown producers marked, not invented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)