### PR TITLE
feat(ui): studio panels only offer swap-ready languages

### DIFF
--- a/ui/src/lib/remix-options.ts
+++ b/ui/src/lib/remix-options.ts
@@ -22,7 +22,14 @@ function refUrls(raw?: string): string[] {
 }
 
 export function toLanguageOpts(rows: Row[]): LanguageOpt[] {
-  return rows.map((l) => {
+  // Studio panels swap palette + hero image onto a language's Landing and
+  // Dashboard compositions; a language missing either can't be swapped, so it
+  // never appears as an option. Filtered here so every panel that sources
+  // through this builder — the studio and the art-style / language / palette
+  // detail remixes — is covered at once.
+  return rows
+    .filter((l) => Boolean(l.fields.landing_file_id) && Boolean(l.fields.dashboard_file_id))
+    .map((l) => {
     const philosophy = parseJson<{ summary?: string }>(l.fields.philosophy);
     const thumb =
       l.fields.thumbnail_asset_url ||


### PR DESCRIPTION
## What & why
The studio + every remix panel offered **all 199 published languages**, but only the few with swap-formatted Landing + Dashboard compositions can actually be palette/image-swapped — so ~196 were dead options. This filters them out.

## Change (one file)
`toLanguageOpts` (the single builder every panel sources through — `/studio`, and the art-style / language / palette detail remixes) now keeps only languages with **both** `landing_file_id` and `dashboard_file_id`. Filtering in the one shared place covers all panels at once. Client-side because the OData `$filter` on these fields is unreliable (ARN-97 projection bug).

## Effect (verified on live data)
199 → **3**: `Civic Press`, `Phosphor`, and one test entity (`Codex Fresh Workspace Repair Proof…` — should be archived separately, then it's the 2 real ones). Forward-compatible: reformatted languages reappear automatically.

## Verification
`tsc` + `eslint` clean; functional proof run against the real 199-language dataset (→ 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)