### PR TITLE
feat(commons): entity-level default art-style link + credits actions

### DIFF
--- a/katagami-commons/specs/art_style.ioa.toml
+++ b/katagami-commons/specs/art_style.ioa.toml
@@ -354,6 +354,13 @@ from = ["Published"]
 effect = "increment fork_count"
 hint = "Record that a child art style was forked from this one."
 
+[[action]]
+name = "SetCredits"
+kind = "input"
+from = ["Draft", "UnderReview", "Published"]
+params = ["credits"]
+hint = "Set the credits list — named artists / movements / studios / traditions this style traces to. Each entry: { name, kind, note }. Settable while Published for backfill."
+
 # --- Output Actions ---
 
 [[action]]

--- a/katagami-commons/specs/design_language.ioa.toml
+++ b/katagami-commons/specs/design_language.ioa.toml
@@ -460,6 +460,24 @@ from = ["Draft"]
 params = ["parent_ids", "lineage_type", "generation_number"]
 hint = "Set lineage: parent_ids=[] for originals, single parent for evolution, multiple for remix."
 
+# --- Actions: Art-style link ---
+
+[[action]]
+name = "SetDefaultArtStyle"
+kind = "input"
+from = ["Draft", "UnderReview", "Published"]
+params = ["default_art_style_id"]
+hint = "Link the default art style (ArtStyle entity id) this language is built with — the entity-level pairing, distinct from imagery_direction.pairs_with. Settable while Published so the link can be backfilled without a Revise."
+
+# --- Actions: Credits ---
+
+[[action]]
+name = "SetCredits"
+kind = "input"
+from = ["Draft", "UnderReview", "Published"]
+params = ["credits"]
+hint = "Set the credits list — named artists / movements / studios / traditions a recognizable look traces to. Each entry: { name, kind, note }."
+
 # --- Actions: Review Lifecycle ---
 
 [[action]]

--- a/katagami-commons/specs/palette_system.ioa.toml
+++ b/katagami-commons/specs/palette_system.ioa.toml
@@ -323,6 +323,13 @@ from = ["Published"]
 effect = "increment fork_count"
 hint = "Record that a child palette was forked from this one."
 
+[[action]]
+name = "SetCredits"
+kind = "input"
+from = ["Draft", "UnderReview", "Published"]
+params = ["credits"]
+hint = "Set the credits list — named artists / movements / studios / traditions this palette traces to. Each entry: { name, kind, note }. Settable while Published for backfill."
+
 # --- Output Actions ---
 
 [[action]]


### PR DESCRIPTION
Adds `SetDefaultArtStyle` (design_language) — a first-class link from a language to its ArtStyle entity id, distinct from the `imagery_direction.pairs_with` slug — and `SetCredits` (design_language, art_style, palette_system) for named-source attribution.

All three actions are allowed `from = [Draft, UnderReview, Published]`, so the new links/credits can be **backfilled onto already-published entities without a Revise**.

Next after merge+deploy: backfill the new-format languages (resolve pairs_with slug → art-style id → SetDefaultArtStyle) and wire the publisher to set it going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)