### PR TITLE
feat(ui): art-style gallery self-normalizes medium into clean shelf families

### DIFF
--- a/ui/src/components/lane-catalog.tsx
+++ b/ui/src/components/lane-catalog.tsx
@@ -46,7 +46,33 @@ function paletteShelfKey(p: PaletteItem): string {
   });
 }
 
-/** Art styles have no token palette, so they shelve by medium (largest medium
+/** The 7 controlled mediums the gallery shelves by. `medium` is un-enforced, so
+ *  agents keep dropping sub-techniques ("linocut", "risograph", "cyanotype",
+ *  "glazed glass") into it — which would fragment the catalog into singleton
+ *  shelves. Map anything off-vocab to its family here so the gallery stays a
+ *  handful of clean shelves no matter what gets written. The raw medium still
+ *  shows on the card and powers search; only the SHELF grouping is normalized. */
+const MEDIUM_VOCAB = new Set([
+  "illustration", "photography", "painting", "print", "3d", "collage", "mixed",
+]);
+const MEDIUM_FAMILY: Array<[RegExp, string]> = [
+  [/glass|glaz/, "mixed"],
+  [/graphite|pencil|charcoal/, "illustration"],
+  [/cut.?paper|d[eé]coup|papercut|collage/, "collage"],
+  [/photo|cathode|infrared|\bfilm\b|tintype|collodion|cyanotype|daguerre|polaroid/, "photography"],
+  [/print|engrav|risograph|woodblock|mokuhanga|linocut|letterpress|etch|screen.?print|silkscreen|litho|offset|overprint|\bplate\b/, "print"],
+  [/watercol|gouache|\boil\b|ink.?wash|acrylic|fresco|tempera|paint/, "painting"],
+  [/\b3d\b|render|voxel|\bclay\b|sculpt|isometric/, "3d"],
+  [/vector|pictogram|\bicon|drawing|comic|manga|crayon|pastel|\bink\b|\bline\b|illustration/, "illustration"],
+];
+function normalizeMedium(raw: string | undefined): string {
+  const m = (raw || "").trim().toLowerCase();
+  if (MEDIUM_VOCAB.has(m)) return m;
+  for (const [re, fam] of MEDIUM_FAMILY) if (re.test(m)) return fam;
+  return "mixed";
+}
+
+/** Art styles have no token palette, so they shelve by medium family (largest
  *  first), with archived collected last. */
 function mediumShelves(items: ArtStyleItem[]): ShelfBucket<ArtStyleItem>[] {
   const buckets = new Map<string, ArtStyleItem[]>();
@@ -56,7 +82,7 @@ function mediumShelves(items: ArtStyleItem[]): ShelfBucket<ArtStyleItem>[] {
       archived.push(a);
       continue;
     }
-    const key = (a.medium || "mixed").trim().toLowerCase() || "mixed";
+    const key = normalizeMedium(a.medium);
     const bucket = buckets.get(key);
     if (bucket) bucket.push(a);
     else buckets.set(key, [a]);


### PR DESCRIPTION
## Why
The art-style gallery shelves by `medium`, but `medium` is **un-enforced** — agents keep writing *sub-techniques* (`linocut`, `risograph`, `cyanotype`, `glazed glass`, `vector pictograms`, …) into it, so the catalog fragments into singleton shelves. This recurs every time new styles land (13 shelves → normalize → drifts back, 4 new outliers appeared *during* a manual fix). Hand-normalizing the data is whack-a-mole against a live pipeline.

## Change (one file)
`lane-catalog.tsx`: add `normalizeMedium()` mapping any medium to its controlled family, and key `mediumShelves` by it. The raw medium still renders on the card and powers search — only the **shelf grouping** is normalized, so the gallery can never fragment again regardless of what's written.

## Proof
`normalizeMedium` over the live 37 published styles → **6 clean shelves, all in-vocab** (print 9, illustration 9, photography 6, painting 6, mixed 4, collage 3). `tsc` + `eslint` clean.

## Follow-up (deeper, Temper-side)
This fixes the *display*. The source fix is write-time enum enforcement on `SetMedium` (push the sub-technique to `tags`) so the data stays clean too — tracked under ARN-101 (agent-contributor) / the un-enforced-`medium` gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)