### PR TITLE
Hide archived language routes

### DIFF
--- a/ui/src/app/(site)/language/[id]/DESIGN.md/route.ts
+++ b/ui/src/app/(site)/language/[id]/DESIGN.md/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getDesignLanguage } from "@/lib/odata";
+import { getPublishedDesignLanguage } from "@/lib/odata";
 import { designMdToMarkdown } from "@/components/spec-panel";
 import {
   buildShadcnRegistryTheme,
@@ -65,7 +65,7 @@ export async function GET(
 
   let lang;
   try {
-    lang = await getDesignLanguage(id);
+    lang = await getPublishedDesignLanguage(id);
   } catch {
     return new NextResponse("design language not found\n", {
       status: 404,

--- a/ui/src/app/(site)/language/[id]/KATAGAMI.MD/route.ts
+++ b/ui/src/app/(site)/language/[id]/KATAGAMI.MD/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getDesignLanguage } from "@/lib/odata";
+import { getPublishedDesignLanguage } from "@/lib/odata";
 import { katagamiSpecToMarkdown } from "@/components/spec-panel";
 
 export const dynamic = "force-dynamic";
@@ -12,7 +12,7 @@ export async function GET(
 
   let lang;
   try {
-    lang = await getDesignLanguage(id);
+    lang = await getPublishedDesignLanguage(id);
   } catch {
     return new NextResponse("design language not found\n", {
       status: 404,

--- a/ui/src/app/(site)/language/[id]/SHADCN-DESIGN.md/route.ts
+++ b/ui/src/app/(site)/language/[id]/SHADCN-DESIGN.md/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { designMdToMarkdown } from "@/components/spec-panel";
-import { getDesignLanguage } from "@/lib/odata";
+import { getPublishedDesignLanguage } from "@/lib/odata";
 import { readTemperFileText } from "@/lib/temper-files";
 import {
   buildShadcnRegistryTheme,
@@ -31,7 +31,7 @@ export async function GET(
 
   let lang;
   try {
-    lang = await getDesignLanguage(id);
+    lang = await getPublishedDesignLanguage(id);
   } catch {
     return new NextResponse("design language not found\n", {
       status: 404,

--- a/ui/src/app/(site)/language/[id]/page.tsx
+++ b/ui/src/app/(site)/language/[id]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import {
-  getDesignLanguage,
+  getPublishedDesignLanguage,
   getFileUrl,
   listPaletteSystems,
   listArtStyles,
@@ -63,7 +63,7 @@ export async function generateMetadata({
   const { id } = await params;
 
   try {
-    const lang = await getDesignLanguage(id);
+    const lang = await getPublishedDesignLanguage(id);
     const name = lang.fields.name || "Untitled";
     return {
       title: pageTitle(name),
@@ -92,7 +92,7 @@ export default async function LanguageDetailPage({
 
   let lang;
   try {
-    lang = await getDesignLanguage(id);
+    lang = await getPublishedDesignLanguage(id);
   } catch {
     notFound();
   }

--- a/ui/src/app/(site)/language/[id]/shadcn-components.md/route.ts
+++ b/ui/src/app/(site)/language/[id]/shadcn-components.md/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getDesignLanguage } from "@/lib/odata";
+import { getPublishedDesignLanguage } from "@/lib/odata";
 import { readTemperFileBytes } from "@/lib/temper-files";
 import {
   isAgentAuthoredShadcnComponentSpec,
@@ -16,7 +16,7 @@ export async function GET(
 
   let lang;
   try {
-    lang = await getDesignLanguage(id);
+    lang = await getPublishedDesignLanguage(id);
   } catch {
     return new NextResponse("design language not found\n", {
       status: 404,

--- a/ui/src/app/(site)/language/[id]/shadcn-shots.json/route.ts
+++ b/ui/src/app/(site)/language/[id]/shadcn-shots.json/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getDesignLanguage } from "@/lib/odata";
+import { getPublishedDesignLanguage } from "@/lib/odata";
 import { readTemperFileBytes } from "@/lib/temper-files";
 import {
   isAgentAuthoredShadcnPreviewShots,
@@ -17,7 +17,7 @@ export async function GET(
 
   let lang;
   try {
-    lang = await getDesignLanguage(id);
+    lang = await getPublishedDesignLanguage(id);
   } catch {
     return new NextResponse("design language not found\n", {
       status: 404,

--- a/ui/src/app/(site)/language/[id]/shadcn.json/route.ts
+++ b/ui/src/app/(site)/language/[id]/shadcn.json/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getDesignLanguage } from "@/lib/odata";
+import { getPublishedDesignLanguage } from "@/lib/odata";
 import { readTemperFileBytes } from "@/lib/temper-files";
 import {
   buildShadcnRegistryTheme,
@@ -16,7 +16,7 @@ export async function GET(
 
   let lang;
   try {
-    lang = await getDesignLanguage(id);
+    lang = await getPublishedDesignLanguage(id);
   } catch {
     return new NextResponse("design language not found\n", {
       status: 404,

--- a/ui/src/lib/odata.ts
+++ b/ui/src/lib/odata.ts
@@ -441,6 +441,17 @@ export async function getDesignLanguage(id: string): Promise<DesignLanguage> {
   );
 }
 
+export async function getPublishedDesignLanguage(
+  id: string,
+): Promise<DesignLanguage> {
+  const lang = await getDesignLanguage(id);
+  const status = lang.status ?? lang.fields?.Status;
+  if (status !== "Published") {
+    throw new Error(`DesignLanguage '${id}' is not published.`);
+  }
+  return lang;
+}
+
 // ── Taxonomy ──
 
 export interface Taxonomy {


### PR DESCRIPTION
## Summary\n- Add a published-only DesignLanguage getter for public language reads\n- Make /language/[id] and all public language artifact routes return 404 for non-published languages\n\n## Verification\n- Archived and then hard-deleted production language en-019edb01-bbbc-75a2-be14-b6530caaad41 per request\n- Production https://katagami.ai/language/en-019edb01-bbbc-75a2-be14-b6530caaad41 and all artifact routes return 404\n- Production published language en-019ef593-0eda-71c1-b412-f7f6fccf2570 returns 200\n- npm run build\n- npx eslint on changed files\n- Safari verified local archived route renders 404 and a published language renders normally\n\n## Notes\n- Full npm run lint is currently blocked by an unrelated pre-existing jsx comment error in ui/src/app/(site)/lab/lab-comparison.tsx.