### PR TITLE
feat(ui): live, multi-round model bake-off screen

### DIFF
--- a/ui/src/app/(site)/lab/[slug]/page.tsx
+++ b/ui/src/app/(site)/lab/[slug]/page.tsx
@@ -1,8 +1,12 @@
 import { notFound } from "next/navigation";
-import { getComparison } from "../comparisons";
+import { getBakeoffRound } from "@/lib/bakeoff";
 import { LabComparison } from "../lab-comparison";
 
-export const dynamic = "force-static";
+// One bake-off round: slug is the Direction id. Builds the game from the live
+// commons (the round's submitted languages), so it reflects submissions as they
+// land — including those still UnderReview.
+
+export const dynamic = "force-dynamic";
 
 export default async function LabComparisonPage({
   params,
@@ -10,7 +14,7 @@ export default async function LabComparisonPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const comparison = getComparison(slug);
+  const comparison = await getBakeoffRound(slug);
   if (!comparison) notFound();
   return <LabComparison comparison={comparison} />;
 }

--- a/ui/src/app/(site)/lab/bakeoff-index.tsx
+++ b/ui/src/app/(site)/lab/bakeoff-index.tsx
@@ -1,0 +1,74 @@
+import Link from "next/link";
+import type { BakeoffRoundSummary } from "@/lib/bakeoff";
+
+// The rounds index for the model bake-off. Each round is one Direction (a
+// reimagine brief) with its submitted Katagami languages; click through to play
+// the guess-the-model game over that round's entries.
+export function BakeoffIndex({ rounds }: { rounds: BakeoffRoundSummary[] }) {
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-10 sm:py-14">
+      <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-[var(--sakura)]">
+        Katagami · the lab
+      </p>
+      <h1 className="mt-3 font-display text-4xl font-black tracking-[-0.03em] sm:text-5xl">
+        Model bake-offs
+      </h1>
+      <p className="mt-4 max-w-2xl text-[15px] leading-relaxed text-muted-foreground sm:text-base">
+        Each round hands one design language to every model and asks it to
+        reimagine — its own art style, palette and language. Play blind: guess
+        which model made each. Unlisted — share the link directly.
+      </p>
+
+      {rounds.length === 0 ? (
+        <div
+          className="mt-10 rounded-[16px] bg-card p-8"
+          style={{ boxShadow: "var(--shadow-card)" }}
+        >
+          <p className="text-[15px] leading-relaxed text-muted-foreground">
+            No rounds with submissions yet. Start one from a design language link;
+            each model&rsquo;s entry appears here as it submits.
+          </p>
+        </div>
+      ) : (
+        <div className="mt-10 grid gap-6 sm:grid-cols-2">
+          {rounds.map((r) => (
+            <Link
+              key={r.id}
+              href={`/lab/${r.id}`}
+              className="group flex flex-col gap-3 rounded-[16px] bg-card p-6 transition-transform hover:-translate-y-[2px]"
+              style={{ boxShadow: "var(--shadow-card)" }}
+            >
+              <div className="flex flex-wrap items-center gap-3">
+                {r.roundLabel && (
+                  <span className="font-mono text-[11px] font-bold uppercase tracking-[0.18em] text-[var(--ramune)]">
+                    {r.roundLabel}
+                  </span>
+                )}
+                <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+                  {r.modelCount} {r.modelCount === 1 ? "model" : "models"}
+                  {r.status === "Closed" ? " · judged" : ""}
+                </span>
+              </div>
+              <span className="font-display text-2xl font-bold tracking-[-0.02em] group-hover:text-[var(--ramune)]">
+                {r.title}
+              </span>
+              {r.sourceName && (
+                <span className="text-[14px] text-muted-foreground">
+                  Reimagining{" "}
+                  <span className="font-medium text-foreground">
+                    {r.sourceName}
+                  </span>
+                </span>
+              )}
+              {r.brief && (
+                <span className="text-sm leading-relaxed text-muted-foreground">
+                  {r.brief.length > 220 ? `${r.brief.slice(0, 220)}…` : r.brief}
+                </span>
+              )}
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/app/(site)/lab/comparisons.ts
+++ b/ui/src/app/(site)/lab/comparisons.ts
@@ -7,15 +7,23 @@
 export type LabView = "embodiment" | "landing" | "dashboard" | "immersive";
 
 export interface LabModel {
-  name: string; // revealed name
-  dir: string; // folder under public/lab/<slug>/
+  name: string; // revealed name (the MODEL — what the quiz asks you to guess)
+  dir: string; // folder under public/lab/<slug>/ (legacy static rounds only)
   views?: LabView[]; // per-model available views; defaults to the comparison's views
-  tokens?: string; // thinking tokens, display string (e.g. "132K") — shown on reveal
+  tokens?: string; // thinking tokens (headline), display string (e.g. "132K") — shown on reveal
+  tokensTotal?: string; // total tokens incl. cache (secondary), display string (e.g. "1.2M")
   cost?: string; // billed cost, display string (e.g. "$5.04") — shown on reveal
   wall?: string; // wall-clock run time, display string (e.g. "25m 09s") — shown on reveal
   harness?: string; // the CLI/agent it ran in (claude-code, codex, grok-build) — shown on reveal
   imageModel?: string; // image model used (Grok Imagine, gpt-image, …) — shown on reveal
   note?: string; // small footnote shown on reveal
+  // Backend (live Katagami) rounds: previews resolve to real file URLs instead of
+  // static /lab/<slug>/<dir>/<view>.html paths.
+  previews?: Partial<Record<LabView, string>>; // view -> rendered file URL
+  designMd?: string; // URL to the language's DESIGN.md
+  languageId?: string; // the submitted DesignLanguage id (for the detail link)
+  languageName?: string; // the language's own name (e.g. "Halation") — shown on reveal
+  status?: string; // submission lifecycle (UnderReview / Published) — small badge
 }
 
 // An alternate generation of the SAME models (e.g. "no rules") — toggled in the UI.
@@ -34,6 +42,8 @@ export interface LabComparison {
   eyebrow: string;
   blurb: string;
   prompt?: string; // the brief handed to every model this round ("what was the prompt")
+  sourceId?: string; // the source language being reimagined (backend rounds)
+  sourceName?: string; // its display name, e.g. "Prism Works"
   views: LabView[];
   blindOrder: string[]; // model keys in display order -> A, B, C, … (cost descending)
   models: Record<string, LabModel>;

--- a/ui/src/app/(site)/lab/lab-comparison.tsx
+++ b/ui/src/app/(site)/lab/lab-comparison.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import type { LabComparison as LabComparisonType, LabModel, LabView } from "./comparisons";
 
@@ -174,14 +175,22 @@ type SurfaceSet = {
   label: string;
 };
 
-// resolve a model's iframe src in a surface set + view; null if it has no design here
+// resolve a model's iframe src in a surface set + view; null if it has no design here.
+// Backend rounds carry real file URLs in `previews`; legacy static rounds fall back
+// to the /lab/<slug>/<dir>/<view>.html artifact path.
 function resolvePreview(set: SurfaceSet | null, key: string, view: LabView) {
   if (!set || !set.models[key]) return null;
   const m = set.models[key];
   const avail = m.views ?? set.views;
   if (!avail.length) return null;
   const vw = avail.includes(view) ? view : avail[0];
-  return { set, m, view: vw, base: `/lab/${set.slug}/${m.dir}` };
+  const url = m.previews?.[vw] ?? `/lab/${set.slug}/${m.dir}/${vw}.html`;
+  return { set, m, view: vw, url };
+}
+
+// the "Open in new tab" / details link target for a model's view
+function viewUrl(m: LabModel, slug: string, view: LabView): string {
+  return m.previews?.[view] ?? `/lab/${slug}/${m.dir}/${view}.html`;
 }
 
 function PreviewFrame({
@@ -274,12 +283,48 @@ function StatRow({ m }: { m: LabModel }) {
 }
 
 function MetaLine({ m }: { m: LabModel }) {
-  if (!m.harness && !m.imageModel) return null;
+  if (!m.harness && !m.imageModel && !m.tokensTotal) return null;
   return (
     <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground/80">
-      {[m.harness && `Harness: ${m.harness}`, m.imageModel && `Image: ${m.imageModel}`]
+      {[
+        m.harness && `Harness: ${m.harness}`,
+        m.imageModel && `Image: ${m.imageModel}`,
+        m.tokensTotal && `${m.tokensTotal} total tok`,
+      ]
         .filter(Boolean)
         .join(" · ")}
+    </p>
+  );
+}
+
+// The submitted Katagami language behind a design (backend rounds): its name, a
+// link to the full language page, and its review status. The model is what you
+// GUESS; this is what the model actually MADE.
+function LanguageLine({ m, center }: { m: LabModel; center?: boolean }) {
+  if (!m.languageName && !m.languageId) return null;
+  return (
+    <p className={`text-[14px] ${center ? "text-center" : ""}`}>
+      {m.languageName && (
+        <>
+          <span className="text-muted-foreground">Language: </span>
+          <span className="font-bold">{m.languageName}</span>
+        </>
+      )}
+      {m.languageId && (
+        <a
+          href={`/language/${m.languageId}`}
+          target="_blank"
+          rel="noreferrer"
+          className="ml-2 font-medium text-foreground underline-offset-4 hover:underline"
+        >
+          View language &rarr;
+        </a>
+      )}
+      {m.status && m.status !== "Published" && (
+        <span className="ml-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--ramune)]">
+          {m.status}
+        </span>
+      )}
     </p>
   );
 }
@@ -382,7 +427,6 @@ function QuizQuestion({
     usedSet = other;
   }
   const m = usedSet.models[q.key];
-  const cost = parseCost(m.cost);
   const picked = answers[q.key];
   const answered = picked !== undefined;
   const isCorrect = picked === q.name;
@@ -434,7 +478,7 @@ function QuizQuestion({
       <div className="mt-3">
         {pr ? (
           <PreviewFrame
-            src={`${pr.base}/${pr.view}.html`}
+            src={pr.url}
             title={`Design ${index + 1}`}
             className="aspect-[16/10] w-full"
           />
@@ -516,6 +560,9 @@ function QuizQuestion({
           </p>
           <StatRow m={m} />
           <MetaLine m={m} />
+          <div className="mt-2">
+            <LanguageLine m={m} center />
+          </div>
           <button onClick={onNext} className={`${STICKER} mt-5 bg-foreground text-background`}>
             {index + 1 < total ? "Next design →" : "See your score →"}
           </button>
@@ -598,6 +645,7 @@ function DetailsGrid({
 }) {
   const order = active.blindOrder;
   const n = order.length;
+  const anyWall = order.some((k) => active.models[k]?.wall);
   const [perPage, setPerPage] = useState(1);
   const [start, setStart] = useState(0);
   const maxStart = Math.max(0, n - perPage);
@@ -689,12 +737,20 @@ function DetailsGrid({
         </span>
       </div>
 
+      {anyWall && (
+        <p className="mt-3 text-center text-[12px] leading-relaxed text-muted-foreground">
+          Times are time-to-produce the full set under concurrent load — not a
+          solo speed benchmark; don&rsquo;t rank models by it.
+        </p>
+      )}
+
       <div className={`mt-6 grid gap-7 ${perPage === 2 ? "md:grid-cols-2" : "mx-auto max-w-3xl grid-cols-1"}`}>
         {pageKeys.map((key) => {
           const i = order.indexOf(key);
           const m = active.models[key];
           const label = LABELS[i];
           const base = `/lab/${active.slug}/${m.dir}`;
+          const previewSrc = viewUrl(m, active.slug, view);
           const hasView = (m.views ?? active.views).includes(view);
           const guessed = answers[key];
           const aspect = perPage === 1 ? "aspect-[16/10]" : "aspect-[4/3]";
@@ -746,10 +802,11 @@ function DetailsGrid({
               )}
 
               <MetaLine m={m} />
+              <LanguageLine m={m} />
 
               {hasView ? (
                 <PreviewFrame
-                  src={`${base}/${view}.html`}
+                  src={previewSrc}
                   title={`Model ${label} — ${view}`}
                   className={aspect}
                 />
@@ -766,7 +823,7 @@ function DetailsGrid({
               <div className="flex items-center gap-5 text-[13px]">
                 {hasView && (
                   <a
-                    href={`${base}/${view}.html`}
+                    href={previewSrc}
                     target="_blank"
                     rel="noreferrer"
                     className="font-medium text-foreground underline-offset-4 hover:underline"
@@ -774,14 +831,25 @@ function DetailsGrid({
                     Open {view}
                   </a>
                 )}
-                <a
-                  href={`${base}/DESIGN.md`}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-muted-foreground underline-offset-4 hover:underline"
-                >
-                  Design notes
-                </a>
+                {m.languageId ? (
+                  <a
+                    href={`/language/${m.languageId}`}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-muted-foreground underline-offset-4 hover:underline"
+                  >
+                    View language
+                  </a>
+                ) : (
+                  <a
+                    href={`${base}/DESIGN.md`}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-muted-foreground underline-offset-4 hover:underline"
+                  >
+                    Design notes
+                  </a>
+                )}
               </div>
             </div>
           );
@@ -857,15 +925,57 @@ export function LabComparison({ comparison: c }: { comparison: LabComparisonType
       `}</style>
 
       {/* header — Katagami highlighter on the title */}
-      <h1 className="font-display text-2xl font-black tracking-[-0.03em] sm:text-3xl">
-        Model{" "}
-        <span className="marker">
-          <span className="marker-fill" style={{ background: "var(--yuzu)" }} />
-          <span className="marker-text">Bake Off</span>
-        </span>
+      <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
+        <Link
+          href="/model-bake-off"
+          className="font-mono text-[11px] font-bold uppercase tracking-[0.18em] text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+        >
+          &larr; All rounds
+        </Link>
+        {c.tag && (
+          <span className="font-mono text-[11px] font-bold uppercase tracking-[0.18em] text-[var(--ramune)]">
+            {c.tag}
+          </span>
+        )}
+      </div>
+      <h1 className="mt-2 font-display text-2xl font-black tracking-[-0.03em] sm:text-3xl">
+        {c.title ? (
+          <>
+            <span className="marker">
+              <span className="marker-fill" style={{ background: "var(--yuzu)" }} />
+              <span className="marker-text">{c.title}</span>
+            </span>
+          </>
+        ) : (
+          <>
+            Model{" "}
+            <span className="marker">
+              <span className="marker-fill" style={{ background: "var(--yuzu)" }} />
+              <span className="marker-text">Bake Off</span>
+            </span>
+          </>
+        )}
       </h1>
       <p className="mt-2 text-[15px] text-muted-foreground">
-        Guess which model made each design.
+        Guess which model made each design
+        {c.sourceName && (
+          <>
+            {" — all reimagining "}
+            {c.sourceId ? (
+              <a
+                href={`/language/${c.sourceId}`}
+                target="_blank"
+                rel="noreferrer"
+                className="font-medium text-foreground underline-offset-4 hover:underline"
+              >
+                {c.sourceName}
+              </a>
+            ) : (
+              <span className="font-medium text-foreground">{c.sourceName}</span>
+            )}
+          </>
+        )}
+        .
       </p>
 
       {/* the prompt — hidden by default, compact, code-style */}
@@ -894,7 +1004,7 @@ export function LabComparison({ comparison: c }: { comparison: LabComparisonType
                     <div key={i}>
                       {head && (
                         <p className="text-[11px] font-bold uppercase tracking-[0.16em] text-[var(--ramune)]">
-                          <span className="text-foreground/30">// </span>
+                          <span className="text-foreground/30">{"// "}</span>
                           {head}
                         </p>
                       )}

--- a/ui/src/app/(site)/lab/page.tsx
+++ b/ui/src/app/(site)/lab/page.tsx
@@ -1,43 +1,12 @@
-import Link from "next/link";
-import { COMPARISONS } from "./comparisons";
+import { listBakeoffRounds } from "@/lib/bakeoff";
+import { BakeoffIndex } from "./bakeoff-index";
 
-// Unlisted on purpose — not added to header-nav, mobile-nav, or the search index.
-// Reachable only by URL.
+// Unlisted on purpose — not added to header-nav, mobile-nav, or the search
+// index. Reachable only by URL. Mirrors /model-bake-off.
 
-export default function LabIndex() {
-  return (
-    <div className="mx-auto max-w-7xl px-4 py-10 sm:py-14">
-      <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-[var(--sakura)]">
-        Katagami · the lab
-      </p>
-      <h1 className="mt-3 font-display text-4xl font-black tracking-[-0.03em] sm:text-5xl">
-        Model bake-offs
-      </h1>
-      <p className="mt-4 max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
-        Blind, side-by-side comparisons of how different models tackle the Katagami
-        loop. Unlisted — share the link directly.
-      </p>
+export const dynamic = "force-dynamic";
 
-      <div className="mt-10 grid gap-6 sm:grid-cols-2">
-        {COMPARISONS.map((c) => (
-          <Link
-            key={c.slug}
-            href={`/lab/${c.slug}`}
-            className="group flex flex-col gap-3 rounded-[4px] bg-card p-6 transition-transform hover:-translate-y-[2px]"
-            style={{ boxShadow: "var(--shadow-card)" }}
-          >
-            <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
-              {Object.keys(c.models).length} models · {c.judged ? "judged" : "unjudged"}
-            </span>
-            <span className="font-display text-2xl font-bold tracking-[-0.02em] group-hover:text-[var(--ramune)]">
-              {c.title}
-            </span>
-            <span className="text-sm leading-relaxed text-muted-foreground">
-              {c.blurb}
-            </span>
-          </Link>
-        ))}
-      </div>
-    </div>
-  );
+export default async function LabIndex() {
+  const rounds = await listBakeoffRounds();
+  return <BakeoffIndex rounds={rounds} />;
 }

--- a/ui/src/app/(site)/model-bake-off/page.tsx
+++ b/ui/src/app/(site)/model-bake-off/page.tsx
@@ -1,20 +1,19 @@
-import { notFound } from "next/navigation";
-import { getComparison } from "../lab/comparisons";
-import { LabComparison } from "../lab/lab-comparison";
+import { listBakeoffRounds } from "@/lib/bakeoff";
+import { BakeoffIndex } from "../lab/bakeoff-index";
 
-// The published model bake-off — the latest final run (round 17).
-// Unlisted on purpose; reachable at /model-bake-off.
+// The published model bake-off — the rounds index. Unlisted on purpose;
+// reachable at /model-bake-off. Each round is a Direction (a reimagine brief)
+// with its submitted Katagami languages.
 
-export const dynamic = "force-static";
+export const dynamic = "force-dynamic";
 
 export const metadata = {
   title: "Model Bake Off — Katagami",
   description:
-    "Blind comparison: guess which model made each Kodomo no Hi design. Twelve models, with rules and without.",
+    "Blind comparison: guess which model reimagined each Katagami design language.",
 };
 
-export default function ModelBakeOffPage() {
-  const comparison = getComparison("kodomo-no-hi-17");
-  if (!comparison) notFound();
-  return <LabComparison comparison={comparison} />;
+export default async function ModelBakeOffPage() {
+  const rounds = await listBakeoffRounds();
+  return <BakeoffIndex rounds={rounds} />;
 }

--- a/ui/src/app/api/file/[id]/route.ts
+++ b/ui/src/app/api/file/[id]/route.ts
@@ -48,6 +48,70 @@ function decodeBase64ImageValue(
   }
 }
 
+// Upstream mime types that carry no real information — the file's stored
+// mime_type was never set, or set to a download-forcing default. A browser
+// served `application/octet-stream` DOWNLOADS the response instead of rendering
+// it, so an embodiment/landing whose file was uploaded with the wrong mime
+// (some bake-off submissions do this) downloads instead of opening. These are
+// design artifacts meant to render in-browser, never to be force-downloaded.
+const GENERIC_CONTENT_TYPES = new Set([
+  "",
+  "application/octet-stream",
+  "binary/octet-stream",
+  "application/binary",
+  "application/unknown",
+  "*/*",
+]);
+
+// Sniff a real content type from the bytes when the stored mime is generic.
+// Magic numbers first (images/pdf), then a textual leading window (html/svg/
+// css/json), defaulting to text/plain — anything but octet-stream so it renders.
+function sniffContentType(bytes: ArrayBuffer): string {
+  const v = new Uint8Array(bytes);
+  if (v.length >= 4) {
+    if (v[0] === 0x89 && v[1] === 0x50 && v[2] === 0x4e && v[3] === 0x47)
+      return "image/png";
+    if (v[0] === 0xff && v[1] === 0xd8 && v[2] === 0xff) return "image/jpeg";
+    if (v[0] === 0x47 && v[1] === 0x49 && v[2] === 0x46) return "image/gif";
+    if (v[0] === 0x52 && v[1] === 0x49 && v[2] === 0x46 && v[3] === 0x46)
+      return "image/webp"; // RIFF (WebP)
+    if (v[0] === 0x25 && v[1] === 0x50 && v[2] === 0x44 && v[3] === 0x46)
+      return "application/pdf"; // %PDF
+  }
+  const head = new TextDecoder("utf-8", { fatal: false })
+    .decode(v.subarray(0, 1024))
+    .replace(/^﻿/, "")
+    .trimStart();
+  const lower = head.toLowerCase();
+  if (lower.startsWith("<?xml") && lower.includes("<svg"))
+    return "image/svg+xml";
+  if (lower.startsWith("<svg")) return "image/svg+xml";
+  if (
+    lower.startsWith("<!doctype html") ||
+    lower.startsWith("<html") ||
+    lower.includes("<html") ||
+    lower.includes("<head") ||
+    lower.includes("<body") ||
+    lower.startsWith("<!--") ||
+    head.startsWith("<")
+  )
+    return "text/html; charset=utf-8";
+  if (lower.startsWith(":root") || /\{[^{}]*:[^{}]*(;|\})/.test(head))
+    return "text/css; charset=utf-8";
+  if (head.startsWith("{") || head.startsWith("["))
+    return "application/json; charset=utf-8";
+  return "text/plain; charset=utf-8";
+}
+
+// The type we should actually serve: trust a specific stored mime, but repair a
+// generic/missing one by sniffing — so a mis-uploaded HTML file opens instead of
+// downloading.
+function resolveContentType(upstream: string, bytes: ArrayBuffer): string {
+  const base = (upstream || "").split(";")[0].trim().toLowerCase();
+  if (!GENERIC_CONTENT_TYPES.has(base)) return upstream;
+  return sniffContentType(bytes);
+}
+
 export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
@@ -69,14 +133,20 @@ export async function GET(
     );
   }
 
-  const contentType = res.headers.get("content-type") || "text/html";
+  const upstreamType = res.headers.get("content-type") || "";
   const upstreamBody = await res.arrayBuffer();
-  const body = decodeBase64ImageValue(upstreamBody, contentType);
+  // Repair a generic/missing upstream mime by sniffing the bytes, so a file
+  // uploaded as application/octet-stream (the browser DOWNLOADS those) still
+  // renders as the HTML/image/etc. it actually is.
+  const contentType = resolveContentType(upstreamType, upstreamBody) || "text/html";
+  const isImage = contentType.toLowerCase().startsWith("image/");
+  const body = isImage
+    ? decodeBase64ImageValue(upstreamBody, contentType)
+    : upstreamBody;
   // Images are content-addressed and immutable, safe to cache for a day. HTML
   // compositions (landing/embodiment/dashboard) are MUTABLE — they're re-PUT in
   // place during curation — so a 24h CDN cache makes every fix invisible for a
   // day. Short-cache HTML so edits appear within ~30s; long-cache images.
-  const isImage = contentType.toLowerCase().startsWith("image/");
   const browserCache = isImage
     ? ASSET_BROWSER_CACHE_CONTROL
     : "public, max-age=0, must-revalidate";
@@ -85,6 +155,9 @@ export async function GET(
     : "public, s-maxage=30, stale-while-revalidate=60";
   const responseHeaders = new Headers({
     "Content-Type": contentType,
+    // These are design artifacts meant to render in-browser / inside iframes —
+    // never force a download, regardless of the stored mime.
+    "Content-Disposition": "inline",
     "Cache-Control": browserCache,
     "CDN-Cache-Control": cdnCache,
     "Vercel-CDN-Cache-Control": cdnCache,

--- a/ui/src/lib/bakeoff.ts
+++ b/ui/src/lib/bakeoff.ts
@@ -1,0 +1,274 @@
+// Live bake-off rounds, built from backend Directions + their submitted
+// languages. A bake-off ROUND is a Direction with is_bakeoff=true; its entries
+// are every DesignLanguage whose `direction_id` points at it (across statuses —
+// submissions sit UnderReview until a curator publishes the keepers). Each entry
+// is mapped into the `LabComparison` shape the existing game UI renders, so the
+// quiz/score/details experience is identical — only the data source changed,
+// from a static manifest to the live commons.
+
+import {
+  listDirections,
+  getDirection,
+  listDesignLanguages,
+  getDesignLanguage,
+  getFileUrl,
+  parseJson,
+  type DesignLanguage,
+  type Direction,
+} from "./odata";
+import type {
+  LabComparison,
+  LabModel,
+  LabView,
+} from "@/app/(site)/lab/comparisons";
+
+const VIEW_ORDER: LabView[] = ["landing", "dashboard", "embodiment", "immersive"];
+
+// Raw provenance model id -> display name. Extend as new models enter the pool;
+// anything unknown is title-cased so it still reads sensibly.
+const MODEL_DISPLAY: Record<string, string> = {
+  opus: "Opus 4.8",
+  "opus-4.8": "Opus 4.8",
+  sonnet: "Sonnet 4.6",
+  haiku: "Haiku 4.5",
+  gpt: "GPT-5.5",
+  "gpt-5": "GPT-5.5",
+  grok: "Grok",
+  "grok-4.3": "Grok 4.3",
+  "grok-build": "Grok Build",
+  fugu: "Fugu",
+  "fugu-ultra": "Fugu Ultra",
+  composer: "Composer 2.5",
+  kimi: "Kimi K2.7",
+  "kimi-k2.7": "Kimi K2.7",
+  glm: "GLM 5.2",
+  "glm-5.2": "GLM 5.2",
+  minimax: "MiniMax M3",
+  "minimax-m3": "MiniMax M3",
+  deepseek: "DeepSeek V4 Pro",
+  "deepseek-v4": "DeepSeek V4 Pro",
+  qwen37: "Qwen 3.7",
+  "qwen3.7-max": "Qwen 3.7 Max",
+  "qwen36-or": "Qwen 3.6",
+  "qwen3.6-35b": "Qwen 3.6",
+};
+
+function titleCase(s: string): string {
+  return s
+    .replace(/[-_]+/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .trim();
+}
+
+function modelDisplay(raw?: string): string {
+  if (!raw || !raw.trim()) return "Unknown model";
+  const k = raw.trim();
+  return MODEL_DISPLAY[k] ?? MODEL_DISPLAY[k.toLowerCase()] ?? titleCase(k);
+}
+
+interface Metrics {
+  thinking_tokens?: number; // headline: fresh_input + output (the model's real work)
+  total_tokens?: number; // secondary: fresh + cache_read + cache_write + output
+  cost_usd?: number; // realistic API list price, cache-aware
+  wall_seconds?: number; // harness start -> exit
+  billing?: string;
+  source?: string;
+}
+
+interface Provenance {
+  style?: { model?: string };
+  source?: { model?: string };
+  images?: { model?: string; provider?: string; tool?: string };
+  metrics?: Metrics;
+}
+
+// metrics live inline in model_provenance (METRICS-CONTRACT.md): the run total is
+// carried by the DesignLanguage — do NOT sum the three entities.
+function fmtTokens(n?: number): string | undefined {
+  if (!n || n <= 0) return undefined;
+  if (n >= 1e6) return `${(n / 1e6).toFixed(2)}M`;
+  if (n >= 1e3) return `${Math.round(n / 1e3)}K`;
+  return String(n);
+}
+function fmtCost(usd?: number): string | undefined {
+  if (usd == null || usd < 0) return undefined;
+  return `$${usd.toFixed(2)}`;
+}
+function fmtWall(seconds?: number): string | undefined {
+  if (!seconds || seconds <= 0) return undefined;
+  const s = Math.round(seconds);
+  const m = Math.floor(s / 60);
+  const rem = s % 60;
+  return m > 0 ? `${m}m ${String(rem).padStart(2, "0")}s` : `${rem}s`;
+}
+
+function provenanceOf(
+  fields: Record<string, string | undefined>,
+): Provenance {
+  // model_provenance arrives as a JSON string OR an already-parsed object,
+  // depending on how it was submitted — parseJson handles both.
+  return parseJson<Provenance>(fields.model_provenance) ?? {};
+}
+
+// The model the quiz asks you to guess: the model that authored the language
+// (model_provenance.style.model is the canonical author per METRICS-CONTRACT.md).
+function modelOf(p: Provenance): string {
+  return modelDisplay(p.style?.model ?? p.source?.model);
+}
+
+// A short image-model label for the reveal line (e.g. "xai/grok-imagine-image"
+// -> "grok-imagine").
+function imageModelOf(p: Provenance): string | undefined {
+  const m = p.images?.model;
+  if (!m || !m.trim()) return undefined;
+  return m.split("/").pop()?.replace(/-image$/, "")?.trim() || m;
+}
+
+function isBakeoff(d: Direction): boolean {
+  const v = (d.fields.is_bakeoff ?? "").toString().trim().toLowerCase();
+  return v === "true" || v === "1" || v === "yes";
+}
+
+function viewsOf(f: Record<string, string | undefined>): {
+  views: LabView[];
+  previews: Partial<Record<LabView, string>>;
+} {
+  const previews: Partial<Record<LabView, string>> = {};
+  if (f.landing_file_id) previews.landing = getFileUrl(f.landing_file_id);
+  if (f.dashboard_file_id) previews.dashboard = getFileUrl(f.dashboard_file_id);
+  if (f.embodiment_file_id)
+    previews.embodiment = getFileUrl(f.embodiment_file_id);
+  const views = VIEW_ORDER.filter((v) => previews[v]);
+  return { views, previews };
+}
+
+function toModel(lang: DesignLanguage): LabModel {
+  const f = lang.fields as Record<string, string | undefined>;
+  const p = provenanceOf(f);
+  const { views, previews } = viewsOf(f);
+  const m = p.metrics ?? {};
+  return {
+    name: modelOf(p),
+    dir: "",
+    views,
+    previews,
+    imageModel: imageModelOf(p),
+    // Reveal stats — populated once the orchestrator backfills metrics; absent
+    // until then (StatRow/MetaLine render nothing rather than zeros).
+    cost: fmtCost(m.cost_usd),
+    tokens: fmtTokens(m.thinking_tokens),
+    tokensTotal: fmtTokens(m.total_tokens),
+    wall: fmtWall(m.wall_seconds),
+    languageId: lang.entity_id,
+    languageName: (f.name || "Untitled").trim(),
+    status: lang.status,
+  };
+}
+
+// Every language linked to a round. The dynamic-field server filter works
+// today; the client fallback keeps the screen correct if a kernel change ever
+// stops honoring it (a filter that silently returns everything would otherwise
+// mix rounds together).
+async function languagesForRound(id: string): Promise<DesignLanguage[]> {
+  try {
+    const rows = await listDesignLanguages(`direction_id eq '${id}'`);
+    const matched = rows.filter((l) => (l.fields.direction_id ?? "") === id);
+    if (matched.length) return matched;
+    if (rows.length === 0) return [];
+  } catch {
+    /* fall through to a full scan */
+  }
+  const all = await listDesignLanguages();
+  return all.filter((l) => (l.fields.direction_id ?? "") === id);
+}
+
+export interface BakeoffRoundSummary {
+  id: string;
+  title: string;
+  brief?: string;
+  roundLabel?: string;
+  sourceId?: string;
+  sourceName?: string;
+  modelCount: number;
+  status: string; // Open / Closed
+}
+
+async function sourceName(sourceId?: string): Promise<string | undefined> {
+  if (!sourceId) return undefined;
+  try {
+    return (await getDesignLanguage(sourceId)).fields.name?.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** All bake-off rounds that actually have submissions, newest first. */
+export async function listBakeoffRounds(): Promise<BakeoffRoundSummary[]> {
+  let dirs: Direction[];
+  try {
+    dirs = (await listDirections()).filter(isBakeoff);
+  } catch {
+    return [];
+  }
+  const summaries = await Promise.all(
+    dirs.map(async (d): Promise<BakeoffRoundSummary | null> => {
+      const langs = await languagesForRound(d.entity_id);
+      if (langs.length === 0) return null; // hide empty/placeholder rounds
+      const f = d.fields;
+      return {
+        id: d.entity_id,
+        title: (f.title || "Untitled round").trim(),
+        brief: f.brief,
+        roundLabel: f.round_label,
+        sourceId: f.source_language_id,
+        sourceName: await sourceName(f.source_language_id),
+        modelCount: langs.length,
+        status: d.status,
+      };
+    }),
+  );
+  return summaries
+    .filter((s): s is BakeoffRoundSummary => s !== null)
+    .sort((a, b) => b.id.localeCompare(a.id)); // uuid-v7 ids sort by creation time
+}
+
+/** One round, shaped for the game component. null if not a bake-off / no entries. */
+export async function getBakeoffRound(id: string): Promise<LabComparison | null> {
+  let dir: Direction;
+  try {
+    dir = await getDirection(id);
+  } catch {
+    return null;
+  }
+  if (!isBakeoff(dir)) return null;
+  const langs = await languagesForRound(id);
+  if (langs.length === 0) return null;
+
+  const f = dir.fields;
+  const models: Record<string, LabModel> = {};
+  for (const lang of langs) models[lang.entity_id] = toModel(lang);
+  // Stable A/B/C label order, by the language's own name.
+  const blindOrder = Object.keys(models).sort((a, b) =>
+    (models[a].languageName ?? "").localeCompare(models[b].languageName ?? ""),
+  );
+  // Union of available views across the round, in canonical order.
+  const present = new Set<LabView>();
+  for (const k of blindOrder)
+    (models[k].views ?? []).forEach((v) => present.add(v));
+  const views = VIEW_ORDER.filter((v) => present.has(v));
+
+  return {
+    slug: id,
+    tag: (f.round_label || "").toUpperCase(),
+    title: (f.title || "Untitled round").trim(),
+    eyebrow: "",
+    blurb: "",
+    prompt: f.brief,
+    sourceId: f.source_language_id,
+    sourceName: await sourceName(f.source_language_id),
+    views: views.length ? views : ["landing"],
+    blindOrder,
+    models,
+    judged: dir.status === "Closed",
+  };
+}

--- a/ui/src/lib/odata.ts
+++ b/ui/src/lib/odata.ts
@@ -875,6 +875,15 @@ export const getArtStyle = (id: string) =>
 export const listRemixes = (filter?: string) => listLane("Remixes", filter);
 export const getRemix = (id: string) => getLane("Remixes", id);
 
+// ── Directions (bake-off rounds) ──
+// A Direction is a reimagine brief / bake-off round. Contributor submissions
+// (DesignLanguage/ArtStyle/PaletteSystem) link to it via `direction_id`; the
+// round is every entity with that direction_id. Fields arrive snake_case:
+// is_bakeoff, title, brief, source_language_id, round_label, model_pool, tags.
+export type Direction = LaneEntity;
+export const listDirections = (filter?: string) => listLane("Directions", filter);
+export const getDirection = (id: string) => getLane("Directions", id);
+
 /** Flatten a PaletteSystem's structured fields (signature/neutrals/semantic)
  *  into the flat color set the embodiment + studio theme on. signature[0] is
  *  the primary accent (the star). */


### PR DESCRIPTION
Adapts the existing model bake-off (the guess-the-model game) to show **live bake-off rounds from the commons** — multiple rounds, each from a different Direction + brief, comparing **Katagami languages** instead of static HTML.

> Stacked on #89 (the file-proxy mime fix) — the preview iframes load bake-off languages through `/api/file`, and some are stored as `application/octet-stream`. Base will retarget to `master` once #89 merges.

## What changed
A bake-off **round = a `Direction`** (`is_bakeoff=true`); its **entries** are the `DesignLanguage`s linked via `direction_id` (across statuses — submissions sit `UnderReview` until a curator publishes). The game UI is unchanged; only the data source moved from `public/lab/*.html` to live file URLs.

- **`/model-bake-off` + `/lab`** → rounds **index**: each round card shows round label, the source language being reimagined, the brief, and model count. (Decision: backend rounds only; live data; whole round incl. UnderReview.)
- **`/lab/<direction-id>`** → the **game** for that round; previews render each language's landing/dashboard/embodiment via the proxy.
- **Reveal** shows the **model** you guess **+ the language it made** (name, `View language →`, status badge).
- **Metrics**: per-model cost / thinking-tokens / total-tokens / time read inline from `model_provenance.metrics` per `agent-kit/METRICS-CONTRACT.md`. They render once the orchestrator backfills them (0/10 carry metrics today), with a "time-to-produce, not a speed race" caveat on wall time.

New: `ui/src/lib/bakeoff.ts` (round loaders → `LabComparison`), `lab/bakeoff-index.tsx`. `Direction` loaders added to `odata.ts`.

## Verified live (Reimagine Prism Works, 10 submissions)
- Index lists the round (`CONTRIB-R1 · 10 models · Reimagining Prism Works`).
- The game renders each language's landing **in-frame** (real hero images), Landing/Dashboard/Embodiment toggle.
- Answering reveals the model (e.g. "DeepSeek V4 Pro") + the language ("Anaglyph Bureau", UnderReview, link to its page).
- `tsc` + `eslint` clean.

Screenshots attached in the PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)