### PR TITLE
feat(ui): bake-off — real Katagami styling, source card, price sort

### DIFF
--- a/ui/DESIGN.md
+++ b/ui/DESIGN.md
@@ -1,0 +1,72 @@
+# Katagami — UI design system (katagami.ai)
+
+The house style of the Katagami **site itself** (not the generated design languages — those
+have their own DESIGN.md each). Extracted from `ui/src/app/globals.css` and the canonical
+components (`components/language-card.tsx`, `components/page-hero.tsx`, `app/(site)/page.tsx`).
+When you build any katagami.ai surface — gallery, studio, lab, bake-off — follow this.
+
+## The aesthetic
+
+A **riso-print specimen catalog**. Katagami were dye stencils; risograph is stencil
+duplication. The site reads as riso-printed on warm uncoated paper: a fixed drum of spot inks,
+**misregistered second passes and soft shadows instead of borders, grain instead of gloss**.
+Light mode is the default; the riso lives in the accents and effects, never in the paper.
+
+## Non-negotiables
+
+- **Sharp rectangles — do not round cards.** `.sticker-card` is `border-radius: 0`. Rounding is
+  reserved for pills, dots and avatars (`rounded-full` = 9999) and the ≤3px corner of a stamp.
+  Never put a `rounded-[16px]` / `rounded-xl` on a content card. This is the most common mistake.
+- **No borders.** Separation comes from soft shadows (`--shadow-card`), paper tint, overprint,
+  washi-tape and stamps — never a grey 1px border. (Only the status *stamp* carries a hairline,
+  and it is ink-toned, never grey.)
+- **≤3 accents, used like highlighters.** The **signature trio** carries all chrome:
+  `--sakura` (fluor pink) · `--yuzu` (riso yellow) · `--ramune` (riso blue). Support inks
+  (`--salad --matcha --shiso --teal --sumire`) stay quiet and data-driven; `--beni` (red) is
+  destructive-only. Bright and clean, never muddy — no pastel washes, no gradients (use flat ink
+  fields / overprint discs for organic color).
+- **Pure paper + ink.** Background is pure white `--washi` (#fff); text is warm near-black
+  `--sumi`. Cards are `--card` (#fff) tinted faintly by the subject's own color.
+
+## Tokens (globals.css)
+
+| Role | Token |
+|---|---|
+| Paper / card | `--washi` (#fff), `--card` (#fff) |
+| Ink / text | `--sumi` (text), `--graphite` / `--muted-foreground` (secondary) |
+| Signature trio | `--sakura`, `--yuzu`, `--ramune` |
+| Support inks | `--salad`, `--matcha`, `--shiso`, `--teal`, `--sumire` |
+| Destructive | `--beni` (red — only) |
+| Shadows | `--shadow-card`, `--shadow-card-hover`, `--shadow-sticker`, `--shadow-sticker-lift` |
+| Print | `--ink-blend` (multiply ☀ / screen ☾), `--grain-*`, `--marker-opacity` |
+
+`--radius` (6px) exists for shadcn-preview chrome; **katagami cards are radius 0.**
+
+## Type
+
+- **Display** (`font-display`; h1/h2/h3): heavy/black, `tracking-[-0.02em]…-0.03em` — titles and
+  big numbers.
+- **Mono** (`font-mono`): the caption/label voice — small (8.5–11px), `uppercase`, wide tracking
+  `[0.14–0.2em]`, muted. Eyebrows (`KATAGAMI · THE LAB`), meta, stamps.
+- **Body** (`font-sans`): prose ≥16–17px, generous leading, `text-muted-foreground` for secondary.
+
+## Components
+
+- **sticker-card** — the card. `class="sticker-card"`: sharp, borderless, paper-tint bg,
+  `--shadow-card`; hover lifts `translateY(-3px) rotate(-0.4deg)`. Tint by a subject color with
+  `--card-ink` + `background: color-mix(in srgb, <tint> 5%, var(--paper-tint-base))`.
+- **palette ink strip** — a 5px row of the subject's palette colors across the top of its preview
+  (the signature card detail; see `language-card.tsx`).
+- **marker** — highlighter behind text:
+  `<span class="marker"><span class="marker-fill" style="background:var(--yuzu)"/><span class="marker-text">word</span></span>`.
+  Use on ONE word of a title.
+- **status stamp** — status (Under review / Draft / Archived) as a rotated rubber-stamp with a
+  tape tab (`StatusStamp` in `language-card.tsx`), `rotate(-0.7deg)`, ink-toned — not a plain badge.
+- **sticker button** — sharp, borderless, hard offset shadow, lifts on hover; mono uppercase
+  label, **no emoji** (the `STICKER` constant in `lab-comparison.tsx`).
+- **mono eyebrow** — section kicker above a display title.
+
+## Spacing
+
+Generous. Padding/margin above titles (a title is never stuck to a container top). Page gutters
+`px-4`, sections `py-10…14`, card padding `p-6`+, card footer `px-3.5 py-3`.

--- a/ui/src/app/(site)/lab/bakeoff-index.tsx
+++ b/ui/src/app/(site)/lab/bakeoff-index.tsx
@@ -3,26 +3,22 @@ import type { BakeoffRoundSummary } from "@/lib/bakeoff";
 
 // The rounds index for the model bake-off. Each round is one Direction (a
 // reimagine brief) with its submitted Katagami languages; click through to play
-// the guess-the-model game over that round's entries.
+// the guess-the-model game over that round's entries. Katagami house style:
+// sharp sticker-cards, the trio ink strip, the source language as the visual.
 export function BakeoffIndex({ rounds }: { rounds: BakeoffRoundSummary[] }) {
   return (
     <div className="mx-auto max-w-7xl px-4 py-10 sm:py-14">
-      <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-[var(--sakura)]">
+      <p className="font-mono text-[11px] font-bold uppercase tracking-[0.2em] text-[var(--sakura)]">
         Katagami · the lab
       </p>
       <h1 className="mt-3 font-display text-4xl font-black tracking-[-0.03em] sm:text-5xl">
         Model bake-offs
       </h1>
-      <p className="mt-4 max-w-2xl text-[17px] leading-relaxed text-muted-foreground">
-        Each round hands one design language to every model and asks it to
-        reimagine — its own art style, palette and language. Play blind: guess
-        which model made each. Unlisted — share the link directly.
-      </p>
 
       {rounds.length === 0 ? (
         <div
-          className="mt-10 rounded-[16px] bg-card p-8"
-          style={{ boxShadow: "var(--shadow-card)" }}
+          className="sticker-card mt-10 p-8"
+          style={{ ["--card-ink" as string]: "var(--ramune)" }}
         >
           <p className="text-[17px] leading-relaxed text-muted-foreground">
             No rounds with submissions yet. Start one from a design language link;
@@ -30,41 +26,63 @@ export function BakeoffIndex({ rounds }: { rounds: BakeoffRoundSummary[] }) {
           </p>
         </div>
       ) : (
-        <div className="mt-10 grid gap-6 sm:grid-cols-2">
+        <div className="mt-10 grid gap-7 sm:grid-cols-2">
           {rounds.map((r) => (
             <Link
               key={r.id}
               href={`/lab/${r.id}`}
-              className="group flex flex-col gap-3 rounded-[16px] bg-card p-6 transition-transform hover:-translate-y-[2px]"
-              style={{ boxShadow: "var(--shadow-card)" }}
+              className="sticker-card group relative flex flex-col overflow-hidden"
             >
-              <div className="flex flex-wrap items-center gap-3">
-                {r.roundLabel && (
-                  <span className="font-mono text-[11px] font-bold uppercase tracking-[0.18em] text-[var(--ramune)]">
-                    {r.roundLabel}
+              {/* the source language being reimagined, as the visual */}
+              <div
+                className="relative w-full overflow-hidden"
+                style={{ aspectRatio: "16 / 10" }}
+              >
+                <div
+                  aria-hidden
+                  className="absolute inset-x-0 top-0 z-10 flex h-[5px]"
+                >
+                  <span className="h-full flex-1" style={{ background: "var(--sakura)" }} />
+                  <span className="h-full flex-1" style={{ background: "var(--yuzu)" }} />
+                  <span className="h-full flex-1" style={{ background: "var(--ramune)" }} />
+                </div>
+                {r.sourceThumb ? (
+                  <div
+                    className="absolute inset-0 bg-cover bg-top"
+                    style={{ backgroundImage: `url(${r.sourceThumb})` }}
+                  />
+                ) : (
+                  <div className="absolute inset-0 bg-muted" />
+                )}
+                {r.sourceName && (
+                  <span className="absolute bottom-2 left-2 z-10 inline-flex items-center bg-background/90 px-2 py-1 font-mono text-[9.5px] font-bold uppercase tracking-[0.16em] text-foreground shadow-[0_1px_0_#1e232d1f]">
+                    reimagining {r.sourceName}
                   </span>
                 )}
-                <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
-                  {r.modelCount} {r.modelCount === 1 ? "model" : "models"}
-                  {r.status === "Closed" ? " · judged" : ""}
-                </span>
               </div>
-              <span className="font-display text-2xl font-bold tracking-[-0.02em] group-hover:text-[var(--ramune)]">
-                {r.title}
-              </span>
-              {r.sourceName && (
-                <span className="text-[15px] text-muted-foreground">
-                  Reimagining{" "}
-                  <span className="font-medium text-foreground">
-                    {r.sourceName}
+
+              {/* footer meta */}
+              <div className="flex flex-1 flex-col gap-2 px-4 py-3.5">
+                <div className="flex flex-wrap items-center gap-2">
+                  {r.roundLabel && (
+                    <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-[var(--ramune)]">
+                      {r.roundLabel}
+                    </span>
+                  )}
+                  <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-muted-foreground">
+                    {r.modelCount} {r.modelCount === 1 ? "model" : "models"}
+                    {r.status === "Closed" ? " · judged" : ""}
                   </span>
-                </span>
-              )}
-              {r.brief && (
-                <span className="text-[15px] leading-relaxed text-muted-foreground">
-                  {r.brief.length > 220 ? `${r.brief.slice(0, 220)}…` : r.brief}
-                </span>
-              )}
+                </div>
+                <h3 className="font-display text-[22px] font-bold leading-tight tracking-[-0.02em] text-foreground group-hover:text-[var(--ramune)]">
+                  {r.title}
+                </h3>
+                {r.brief && (
+                  <p className="text-[14px] leading-relaxed text-muted-foreground">
+                    {r.brief.length > 160 ? `${r.brief.slice(0, 160)}…` : r.brief}
+                  </p>
+                )}
+              </div>
             </Link>
           ))}
         </div>

--- a/ui/src/app/(site)/lab/comparisons.ts
+++ b/ui/src/app/(site)/lab/comparisons.ts
@@ -44,6 +44,7 @@ export interface LabComparison {
   prompt?: string; // the brief handed to every model this round ("what was the prompt")
   sourceId?: string; // the source language being reimagined (backend rounds)
   sourceName?: string; // its display name, e.g. "Prism Works"
+  sourceThumb?: string; // a thumbnail/landing screenshot of the source language
   views: LabView[];
   blindOrder: string[]; // model keys in display order -> A, B, C, … (cost descending)
   models: Record<string, LabModel>;

--- a/ui/src/app/(site)/lab/lab-comparison.tsx
+++ b/ui/src/app/(site)/lab/lab-comparison.tsx
@@ -297,35 +297,61 @@ function MetaLine({ m }: { m: LabModel }) {
   );
 }
 
-// The submitted Katagami language behind a design (backend rounds): its name, a
-// link to the full language page, and its review status. The model is what you
-// GUESS; this is what the model actually MADE.
+// A Katagami status rubber-stamp — rotated, ink-toned, hairline as an inset
+// print artifact (never a grey border).
+const STATUS_LABEL: Record<string, string> = {
+  Draft: "Draft",
+  UnderReview: "Under review",
+  Published: "Published",
+  Archived: "Archived",
+};
+function StatusStamp({ status }: { status: string }) {
+  const label = STATUS_LABEL[status] ?? status;
+  const tone = status === "Archived" ? "var(--beni)" : "var(--ramune)";
+  return (
+    <span
+      className="inline-flex items-center rounded-[2px] px-2 py-[3px] font-mono text-[9px] font-bold uppercase leading-none tracking-[0.14em]"
+      style={{
+        color: tone,
+        background: `color-mix(in oklch, ${tone} 9%, var(--card))`,
+        boxShadow: `inset 0 0 0 1px color-mix(in oklch, ${tone} 36%, transparent)`,
+        transform: "rotate(-1.2deg)",
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+// The submitted Katagami language behind a design (backend rounds): its name, its
+// review status (as a stamp), and a link to the full language page. The model is
+// what you GUESS; this is what the model actually MADE.
 function LanguageLine({ m, center }: { m: LabModel; center?: boolean }) {
   if (!m.languageName && !m.languageId) return null;
   return (
-    <p className={`text-[14px] ${center ? "text-center" : ""}`}>
+    <div
+      className={`flex flex-wrap items-center gap-x-3 gap-y-1.5 ${center ? "justify-center" : ""}`}
+    >
+      <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-muted-foreground">
+        Language
+      </span>
       {m.languageName && (
-        <>
-          <span className="text-muted-foreground">Language: </span>
-          <span className="font-bold">{m.languageName}</span>
-        </>
+        <span className="font-display text-[16px] font-bold tracking-[-0.02em] text-foreground">
+          {m.languageName}
+        </span>
       )}
+      {m.status && m.status !== "Published" && <StatusStamp status={m.status} />}
       {m.languageId && (
         <a
           href={`/language/${m.languageId}`}
           target="_blank"
           rel="noreferrer"
-          className="ml-2 font-medium text-foreground underline-offset-4 hover:underline"
+          className="font-mono text-[11px] font-bold uppercase tracking-[0.14em] text-[var(--ramune)] underline-offset-4 hover:underline"
         >
           View language &rarr;
         </a>
       )}
-      {m.status && m.status !== "Published" && (
-        <span className="ml-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--ramune)]">
-          {m.status}
-        </span>
-      )}
-    </p>
+    </div>
   );
 }
 
@@ -645,7 +671,21 @@ function DetailsGrid({
 }) {
   const order = active.blindOrder;
   const n = order.length;
-  const anyWall = order.some((k) => active.models[k]?.wall);
+  const [sort, setSort] = useState<"default" | "price-desc" | "price-asc">(
+    "default",
+  );
+  const anyCost = order.some((k) => parseCost(active.models[k]?.cost) != null);
+  const displayOrder =
+    sort === "default"
+      ? order
+      : [...order].sort((a, b) => {
+          const ca = parseCost(active.models[a]?.cost);
+          const cb = parseCost(active.models[b]?.cost);
+          if (ca == null && cb == null) return 0;
+          if (ca == null) return 1; // models without a cost sort last
+          if (cb == null) return -1;
+          return sort === "price-desc" ? cb - ca : ca - cb;
+        });
 
   return (
     <>
@@ -665,19 +705,33 @@ function DetailsGrid({
         </div>
       </div>
 
-      <p className="mt-4 text-center font-mono text-[12px] font-bold uppercase tracking-[0.16em] text-muted-foreground">
-        All {n} designs
-      </p>
-
-      {anyWall && (
-        <p className="mt-2 text-center text-[13px] leading-relaxed text-muted-foreground">
-          Times are time-to-produce the full set under concurrent load — not a
-          solo speed benchmark; don&rsquo;t rank models by it.
-        </p>
-      )}
+      <div className="mt-4 flex flex-wrap items-center justify-center gap-x-4 gap-y-3">
+        <span className="font-mono text-[12px] font-bold uppercase tracking-[0.16em] text-muted-foreground">
+          All {n} designs
+        </span>
+        {anyCost && (
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-muted-foreground">
+              Sort
+            </span>
+            <Segmented
+              options={[
+                { key: "default", label: "Default" },
+                { key: "price-desc", label: "Price ↓" },
+                { key: "price-asc", label: "Price ↑" },
+              ]}
+              value={sort}
+              onChange={(k) =>
+                setSort(k as "default" | "price-desc" | "price-asc")
+              }
+            />
+          </div>
+        )}
+      </div>
 
       <div className="mt-6 grid gap-8 sm:grid-cols-2">
-        {order.map((key, i) => {
+        {displayOrder.map((key) => {
+          const i = order.indexOf(key);
           const m = active.models[key];
           const label = LABELS[i] ?? String(i + 1);
           const base = `/lab/${active.slug}/${m.dir}`;
@@ -885,26 +939,47 @@ export function LabComparison({ comparison: c }: { comparison: LabComparisonType
         )}
       </h1>
       <p className="mt-3 text-[17px] leading-relaxed text-muted-foreground">
-        Guess which model made each design
-        {c.sourceName && (
-          <>
-            {" — all reimagining "}
-            {c.sourceId ? (
-              <a
-                href={`/language/${c.sourceId}`}
-                target="_blank"
-                rel="noreferrer"
-                className="font-medium text-foreground underline-offset-4 hover:underline"
-              >
-                {c.sourceName}
-              </a>
-            ) : (
-              <span className="font-medium text-foreground">{c.sourceName}</span>
-            )}
-          </>
-        )}
-        .
+        Guess which model made each design.
       </p>
+
+      {/* the published Katagami language every model reimagined — shown + linked */}
+      {c.sourceName && (
+        <a
+          href={c.sourceId ? `/language/${c.sourceId}` : undefined}
+          target="_blank"
+          rel="noreferrer"
+          className="sticker-card group mt-5 flex max-w-md items-stretch overflow-hidden"
+          style={{ ["--card-ink" as string]: "var(--ramune)" }}
+        >
+          <div
+            className="relative w-28 shrink-0 overflow-hidden bg-muted"
+            style={{ aspectRatio: "4 / 3" }}
+          >
+            <div aria-hidden className="absolute inset-x-0 top-0 z-10 flex h-[4px]">
+              <span className="h-full flex-1" style={{ background: "var(--sakura)" }} />
+              <span className="h-full flex-1" style={{ background: "var(--yuzu)" }} />
+              <span className="h-full flex-1" style={{ background: "var(--ramune)" }} />
+            </div>
+            {c.sourceThumb && (
+              <div
+                className="absolute inset-0 bg-cover bg-top"
+                style={{ backgroundImage: `url(${c.sourceThumb})` }}
+              />
+            )}
+          </div>
+          <div className="flex min-w-0 flex-col justify-center gap-1 px-4 py-3">
+            <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-[var(--ramune)]">
+              Reimagining
+            </span>
+            <span className="truncate font-display text-[19px] font-bold leading-tight tracking-[-0.02em] text-foreground group-hover:text-[var(--ramune)]">
+              {c.sourceName}
+            </span>
+            <span className="font-mono text-[10.5px] uppercase tracking-[0.14em] text-muted-foreground">
+              Published language · View &rarr;
+            </span>
+          </div>
+        </a>
+      )}
 
       {/* the direction — the reimagine brief every model was given, verbatim */}
       {c.prompt && (
@@ -917,8 +992,8 @@ export function LabComparison({ comparison: c }: { comparison: LabComparisonType
           </button>
           {showPrompt && (
             <figure
-              className="mt-4 max-w-2xl rounded-[16px] bg-card p-6 sm:p-7"
-              style={{ boxShadow: "var(--shadow-card)" }}
+              className="sticker-card mt-4 max-w-2xl p-6 sm:p-7"
+              style={{ ["--card-ink" as string]: "var(--yuzu)" }}
             >
               <figcaption className="font-mono text-[11px] font-bold uppercase tracking-[0.18em] text-[var(--ramune)]">
                 The direction

--- a/ui/src/lib/bakeoff.ts
+++ b/ui/src/lib/bakeoff.ts
@@ -189,16 +189,35 @@ export interface BakeoffRoundSummary {
   roundLabel?: string;
   sourceId?: string;
   sourceName?: string;
+  sourceThumb?: string;
   modelCount: number;
   status: string; // Open / Closed
 }
 
-async function sourceName(sourceId?: string): Promise<string | undefined> {
-  if (!sourceId) return undefined;
+interface SourceInfo {
+  name?: string;
+  thumb?: string;
+}
+
+// The published language a round reimagines: its name + a thumbnail to show it
+// (landing screenshot preferred, else the embodiment thumbnail).
+async function sourceInfo(sourceId?: string): Promise<SourceInfo> {
+  if (!sourceId) return {};
   try {
-    return (await getDesignLanguage(sourceId)).fields.name?.trim() || undefined;
+    const f = (await getDesignLanguage(sourceId)).fields as Record<
+      string,
+      string | undefined
+    >;
+    const thumb =
+      (f.landing_thumbnail_asset_url || "").trim() ||
+      (f.landing_thumbnail_file_id
+        ? getFileUrl(f.landing_thumbnail_file_id)
+        : "") ||
+      (f.thumbnail_asset_url || "").trim() ||
+      (f.thumbnail_file_id ? getFileUrl(f.thumbnail_file_id) : "");
+    return { name: f.name?.trim() || undefined, thumb: thumb || undefined };
   } catch {
-    return undefined;
+    return {};
   }
 }
 
@@ -215,13 +234,15 @@ export async function listBakeoffRounds(): Promise<BakeoffRoundSummary[]> {
       const langs = await languagesForRound(d.entity_id);
       if (langs.length === 0) return null; // hide empty/placeholder rounds
       const f = d.fields;
+      const src = await sourceInfo(f.source_language_id);
       return {
         id: d.entity_id,
         title: (f.title || "Untitled round").trim(),
         brief: f.brief,
         roundLabel: f.round_label,
         sourceId: f.source_language_id,
-        sourceName: await sourceName(f.source_language_id),
+        sourceName: src.name,
+        sourceThumb: src.thumb,
         modelCount: langs.length,
         status: d.status,
       };
@@ -256,6 +277,7 @@ export async function getBakeoffRound(id: string): Promise<LabComparison | null>
   for (const k of blindOrder)
     (models[k].views ?? []).forEach((v) => present.add(v));
   const views = VIEW_ORDER.filter((v) => present.has(v));
+  const src = await sourceInfo(f.source_language_id);
 
   return {
     slug: id,
@@ -265,7 +287,8 @@ export async function getBakeoffRound(id: string): Promise<LabComparison | null>
     blurb: "",
     prompt: f.brief,
     sourceId: f.source_language_id,
-    sourceName: await sourceName(f.source_language_id),
+    sourceName: src.name,
+    sourceThumb: src.thumb,
     views: views.length ? views : ["landing"],
     blindOrder,
     models,


### PR DESCRIPTION
Holds the lab/bake-off to the **actual katagami.ai design system**, extracted into a new `ui/DESIGN.md`.

- **`ui/DESIGN.md`** — canonical katagami.ai UI design system (riso-print specimen catalog; sharp borderless sticker-cards, signature trio, stamps, no rounded cards), extracted from `globals.css` + the gallery card.
- **Sharp sticker-cards** everywhere (were rounded). **Intro paragraph removed.**
- **Source language as a linked card** (landing thumbnail + name + View language) on the index and round header — replaces the plain "all reimagining X" text.
- **Reveal restyled** — review status as a Katagami stamp; language line spaced properly (was cramped).
- **Removed** the wall-time caveat line.
- **Price sort** (Default / Price ↓ / Price ↑) over all designs.

Verified locally against the Reimagine Prism Works round (metrics now backfilled): index cards, source card, direction, all-designs grid, and sort all render. tsc + eslint + next build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)