### PR TITLE
fix(ui): derive bake-off round name from source language (no hardcoded title)

### DIFF
--- a/ui/src/lib/bakeoff.ts
+++ b/ui/src/lib/bakeoff.ts
@@ -238,6 +238,19 @@ async function sourceInfo(sourceId?: string): Promise<SourceInfo> {
   }
 }
 
+// The round name is DERIVED from the source language — never the orchestrator's
+// hardcoded Direction.title (which has shipped things like "(r2)"). Falls back to
+// the stored title (with any trailing "(rN)" stripped) only when there is no
+// resolvable source.
+function roundTitle(
+  sourceName: string | undefined,
+  storedTitle: string | undefined,
+): string {
+  if (sourceName && sourceName.trim()) return `Reimagine ${sourceName.trim()}`;
+  const t = (storedTitle || "").replace(/\s*\(r\d+\)\s*$/i, "").trim();
+  return t || "Untitled round";
+}
+
 /** All bake-off rounds that actually have submissions, newest first. */
 export async function listBakeoffRounds(): Promise<BakeoffRoundSummary[]> {
   let dirs: Direction[];
@@ -254,7 +267,7 @@ export async function listBakeoffRounds(): Promise<BakeoffRoundSummary[]> {
       const src = await sourceInfo(f.source_language_id);
       return {
         id: d.entity_id,
-        title: (f.title || "Untitled round").trim(),
+        title: roundTitle(src.name, f.title),
         brief: f.brief,
         roundLabel: f.round_label,
         sourceId: f.source_language_id,
@@ -299,7 +312,7 @@ export async function getBakeoffRound(id: string): Promise<LabComparison | null>
   return {
     slug: id,
     tag: (f.round_label || "").toUpperCase(),
-    title: (f.title || "Untitled round").trim(),
+    title: roundTitle(src.name, f.title),
     eyebrow: "",
     blurb: "",
     prompt: f.brief,


### PR DESCRIPTION
The round name shown on the index + round page came straight from the orchestrator's **hardcoded** `Direction.title` — which has shipped strings like "Reimagine Prism Works **(r2)**". Now the screen **derives** it from the source language ("Reimagine <source name>") and never depends on the hardcoded title; round suffixes can't leak through. Falls back to the stored title (trailing `(rN)` stripped) only when there's no resolvable source.

tsc + eslint + next build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)