### PR TITLE
feat(ui): clean up language detail — identity row, linked palette, katagami fixes

### DIFF
--- a/ui/src/app/(site)/language/[id]/page.tsx
+++ b/ui/src/app/(site)/language/[id]/page.tsx
@@ -10,6 +10,7 @@ import {
   parseJson,
 } from "@/lib/odata";
 import { RelatedLanguages } from "@/components/related-languages";
+import { LanguageIdentity } from "@/components/language-identity";
 import { LanguageLineage } from "@/components/language-lineage";
 import { toLanguageOpts, toPaletteOpts, toArtOpts } from "@/lib/remix-options";
 import { InlineRemix } from "@/components/remix/inline-remix";
@@ -300,6 +301,9 @@ export default async function LanguageDetailPage({
       />
 
       <Perforation />
+
+      {/* Identity — what the language is BUILT WITH: its art style + palette. */}
+      <LanguageIdentity fields={f} />
 
       {/* Mobile leads with the visual preview; wider screens set spec left, visuals right. */}
       <div className="grid gap-8 sm:gap-10 md:grid-cols-[minmax(0,0.92fr)_minmax(320px,1.08fr)] md:items-start md:gap-x-10">

--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -310,20 +310,22 @@
     box-shadow: var(--shadsync-shadow);
   }
 
-  .shadsync-kit-notice {
-    border-radius: var(--radius-lg);
-    box-shadow: var(--shadow-paper);
+  /* Implementation-kit status — KATAGAMI house chrome (this is the site's own
+     card, not a previewed theme). Sharp, borderless, flat ink-tint — never a
+     gradient or a coloured border. Scoped by the data-attr so the flat tint +
+     radius 0 win over the shadcn Card's rounded-xl / bg-card utilities. */
+  .shadsync-kit-notice[data-shadcn-agent-kit] {
+    border: none !important;
+    border-radius: 0 !important;
+    box-shadow: var(--shadow-card) !important;
   }
 
-  .shadsync-kit-ready {
-    border-color: color-mix(in srgb, var(--teal) 42%, var(--border));
+  .shadsync-kit-notice[data-shadcn-agent-kit="ready"] {
+    background: color-mix(in srgb, var(--teal) 7%, var(--card)) !important;
   }
 
-  .shadsync-kit-missing {
-    border-color: color-mix(in srgb, var(--yuzu) 52%, var(--border));
-    background:
-      linear-gradient(135deg, color-mix(in srgb, var(--yuzu) 14%, transparent), transparent 48%),
-      var(--card);
+  .shadsync-kit-notice[data-shadcn-agent-kit="missing"] {
+    background: color-mix(in srgb, var(--yuzu) 12%, var(--card)) !important;
   }
 
   .shadsync-compatibility-panel {

--- a/ui/src/components/design-md-showcase.tsx
+++ b/ui/src/components/design-md-showcase.tsx
@@ -1,26 +1,21 @@
 "use client";
 
-import { useState } from "react";
-import { Copy, Check } from "lucide-react";
-import { trackCopy } from "@/lib/analytics";
 import { parseJson } from "@/lib/odata";
 import {
   buildDesignMdFrontMatter,
   type SpecPanelProps,
 } from "@/components/spec-panel";
 
-// Katagami-styled DESIGN.md preview: large, airy sticker cards showing the
-// distilled palette / typography / spacing / shape so the rich JSON behind
-// the spec is visible at-a-glance, not just downloadable.
+// Katagami-styled DESIGN.md preview. The palette now lives in the identity
+// row at the top of the page (resolved from the linked PaletteSystem), so this
+// "at a glance" card focuses on the one thing it shows best: a live type
+// specimen rendered in the language's own typefaces.
 export function DesignMdShowcase(
   props: SpecPanelProps & { compact?: boolean },
 ) {
   const tokens = parseJson<Record<string, unknown>>(props.tokens);
   const fm = buildDesignMdFrontMatter(props, tokens);
-  const colors = (fm.colors as Record<string, string>) ?? {};
   const typography = (fm.typography as Record<string, TypographyToken>) ?? {};
-  const spacing = (fm.spacing as Record<string, string>) ?? {};
-  const rounded = (fm.rounded as Record<string, string>) ?? {};
 
   const fontFamilies = Array.from(
     new Set(
@@ -30,57 +25,14 @@ export function DesignMdShowcase(
     ),
   );
 
-  const hasColors = Object.keys(colors).length > 0;
-  const hasTypography = Object.keys(typography).length > 0;
-  const hasSpacing = Object.keys(spacing).length > 0;
-  const hasRounded = Object.keys(rounded).length > 0;
-  const hasComponents = hasColors && hasRounded;
-
-  if (
-    !hasColors &&
-    !hasTypography &&
-    !hasSpacing &&
-    !hasRounded &&
-    !hasComponents
-  )
-    return null;
+  if (Object.keys(typography).length === 0) return null;
 
   return (
     <>
       <FontLoader families={fontFamilies} />
-      <div
-        className={props.compact ? "grid gap-5" : "grid gap-8 xl:grid-cols-2"}
-      >
-        {hasColors && (
-          <ShowcaseCard tape="sakura" title="Palette">
-            <PaletteGrid colors={colors} />
-          </ShowcaseCard>
-        )}
-        {hasTypography && (
-          <ShowcaseCard tape="sumire" title="Typography">
-            <TypePreview typography={typography} />
-          </ShowcaseCard>
-        )}
-        {hasComponents && (
-          <ShowcaseCard tape="yuzu" title="Components">
-            <ComponentSamples
-              colors={colors}
-              rounded={rounded}
-              typography={typography}
-            />
-          </ShowcaseCard>
-        )}
-        {hasSpacing && (
-          <ShowcaseCard tape="ramune" title="Spacing">
-            <SpacingScale spacing={spacing} />
-          </ShowcaseCard>
-        )}
-        {hasRounded && (
-          <ShowcaseCard tape="sakura" title="Shape">
-            <RoundedSamples rounded={rounded} />
-          </ShowcaseCard>
-        )}
-      </div>
+      <ShowcaseCard tape="sumire" title="Typography">
+        <TypePreview typography={typography} />
+      </ShowcaseCard>
     </>
   );
 }
@@ -162,61 +114,6 @@ function ShowcaseCard({
   );
 }
 
-// ── Palette ───────────────────────────────────────────────────────
-
-function PaletteGrid({ colors }: { colors: Record<string, string> }) {
-  return (
-    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-      {Object.entries(colors).map(([name, value]) => (
-        <ColorChip key={name} name={name} value={value} />
-      ))}
-    </div>
-  );
-}
-
-function ColorChip({ name, value }: { name: string; value: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const onCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(value);
-      trackCopy({ artifact: "color", label: name });
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    } catch {
-      /* ignore */
-    }
-  };
-
-  return (
-    <button
-      type="button"
-      onClick={onCopy}
-      title={`copy ${value}`}
-      className="group relative flex flex-col gap-2 text-left transition-transform hover:-translate-y-[1px]"
-    >
-      <span
-        aria-hidden
-        className="block h-20 w-full rounded-[2px] shadow-[inset_0_0_0_1px_rgba(30,35,45,0.06)]"
-        style={{ background: value }}
-      />
-      <span className="flex items-center justify-between gap-1">
-        <span className="truncate font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
-          {name}
-        </span>
-        {copied ? (
-          <Check className="h-3 w-3 shrink-0 text-[var(--foreground)]" />
-        ) : (
-          <Copy className="h-3 w-3 shrink-0 text-muted-foreground/40 transition-colors group-hover:text-foreground" />
-        )}
-      </span>
-      <span className="truncate font-mono text-[12px] text-foreground/85">
-        {value}
-      </span>
-    </button>
-  );
-}
-
 // ── Typography ────────────────────────────────────────────────────
 
 function TypePreview({
@@ -282,239 +179,4 @@ function sizeOf(v: string | number | undefined, fallback: number): number {
     }
   }
   return fallback;
-}
-
-// ── Spacing ───────────────────────────────────────────────────────
-
-function SpacingScale({ spacing }: { spacing: Record<string, string> }) {
-  const entries = Object.entries(spacing);
-  const sizes = entries.map(([, v]) => sizeOf(v, 0));
-  const max = Math.max(...sizes, 16);
-
-  return (
-    <ul className="space-y-3">
-      {entries.map(([key, value], i) => {
-        const px = sizes[i];
-        const pct = Math.max(6, Math.round((px / max) * 100));
-        return (
-          <li key={key} className="flex items-center gap-3">
-            <span className="w-14 shrink-0 truncate font-mono text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-              {key}
-            </span>
-            <span className="flex-1">
-              <span
-                aria-hidden
-                className="block h-2.5 rounded-[1px] bg-foreground/70"
-                style={{ width: `${pct}%` }}
-              />
-            </span>
-            <span className="w-14 shrink-0 text-right font-mono text-[11px] text-foreground/85">
-              {value}
-            </span>
-          </li>
-        );
-      })}
-    </ul>
-  );
-}
-
-// ── Components ────────────────────────────────────────────────────
-
-function pickColor(
-  colors: Record<string, string>,
-  candidates: string[],
-): string | null {
-  for (const c of candidates) {
-    if (colors[c]) return colors[c];
-  }
-  return null;
-}
-
-function pickRounded(
-  rounded: Record<string, string>,
-  candidates: string[],
-): string {
-  for (const c of candidates) {
-    if (rounded[c]) return rounded[c];
-  }
-  const first = Object.values(rounded)[0];
-  return first ?? "4px";
-}
-
-function ComponentSamples({
-  colors,
-  rounded,
-  typography,
-}: {
-  colors: Record<string, string>;
-  rounded: Record<string, string>;
-  typography: Record<string, TypographyToken>;
-}) {
-  const colorList = Object.values(colors);
-  const primary =
-    pickColor(colors, ["primary", "accent", "brand"]) ?? colorList[0];
-  const accent =
-    pickColor(colors, ["accent", "secondary", "highlight"]) ??
-    colorList[1] ??
-    primary;
-  const surface =
-    pickColor(colors, ["surface", "background", "card", "paper"]) ?? "#ffffff";
-  const text =
-    pickColor(colors, ["text", "foreground", "ink", "primary_text"]) ??
-    "#1a1a1a";
-  const muted =
-    pickColor(colors, ["muted", "subtle", "secondary_text"]) ??
-    "color-mix(in oklch, " + text + " 60%, " + surface + ")";
-
-  const buttonRadius = pickRounded(rounded, ["md", "lg", "base"]);
-  const cardRadius = pickRounded(rounded, ["lg", "xl", "md"]);
-  const inputRadius = pickRounded(rounded, ["sm", "md", "base"]);
-  const badgeRadius = pickRounded(rounded, ["full", "pill", "xl", "lg"]);
-
-  const bodyFamily =
-    typography.body?.fontFamily ||
-    typography.text?.fontFamily ||
-    "inherit";
-  const headingFamily =
-    typography.heading?.fontFamily ||
-    typography.display?.fontFamily ||
-    typography.title?.fontFamily ||
-    bodyFamily;
-
-  // Pick a contrasting button text color: if surface is light, use text;
-  // otherwise use surface.
-  const buttonTextColor = isLight(primary) ? text : "#ffffff";
-
-  return (
-    <div
-      className="space-y-5 rounded-[2px] p-5"
-      style={{ background: surface, color: text, fontFamily: bodyFamily }}
-    >
-      {/* Buttons row */}
-      <div className="flex flex-wrap items-center gap-2.5">
-        <button
-          type="button"
-          className="inline-flex items-center px-4 py-2 text-[13px] font-semibold transition-transform hover:-translate-y-[1px]"
-          style={{
-            background: primary,
-            color: buttonTextColor,
-            borderRadius: buttonRadius,
-          }}
-        >
-          Primary action
-        </button>
-        <button
-          type="button"
-          className="inline-flex items-center px-4 py-2 text-[13px] font-medium transition-transform hover:-translate-y-[1px]"
-          style={{
-            background: "transparent",
-            color: text,
-            border: `1px solid ${muted}`,
-            borderRadius: buttonRadius,
-          }}
-        >
-          Secondary
-        </button>
-        <span
-          className="inline-flex items-center px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wider"
-          style={{
-            background: accent,
-            color: isLight(accent) ? text : "#ffffff",
-            borderRadius: badgeRadius,
-          }}
-        >
-          New
-        </span>
-      </div>
-
-      {/* Input */}
-      <div className="space-y-1.5">
-        <label
-          className="block text-[11px] font-semibold uppercase tracking-wider"
-          style={{ color: muted }}
-        >
-          Email
-        </label>
-        <input
-          type="text"
-          readOnly
-          defaultValue="hello@example.com"
-          className="w-full px-3 py-2 text-[13px] focus:outline-none"
-          style={{
-            background: surface,
-            color: text,
-            border: `1px solid ${muted}`,
-            borderRadius: inputRadius,
-          }}
-        />
-      </div>
-
-      {/* Mini card */}
-      <div
-        className="px-4 py-3 shadow-[0_1px_2px_rgba(30,35,45,0.04),0_4px_12px_rgba(30,35,45,0.06)]"
-        style={{
-          background: surface,
-          borderRadius: cardRadius,
-          border: `1px solid ${muted}`,
-        }}
-      >
-        <div
-          className="text-[15px] font-bold leading-tight"
-          style={{ fontFamily: headingFamily, color: text }}
-        >
-          Card title
-        </div>
-        <p
-          className="mt-1 text-[12px] leading-relaxed"
-          style={{ color: muted }}
-        >
-          Components rendered with this language&rsquo;s tokens —
-          colors, type, and rounded corners as specified.
-        </p>
-      </div>
-    </div>
-  );
-}
-
-// Rough perceived-lightness check on a hex color so we can pick a
-// readable text color for buttons / badges.
-function isLight(hex: string): boolean {
-  const m = hex.match(/^#([0-9a-fA-F]{3,8})$/);
-  if (!m) return false;
-  let h = m[1];
-  if (h.length === 3) h = h.split("").map((c) => c + c).join("");
-  if (h.length === 4) h = h.slice(0, 3).split("").map((c) => c + c).join("");
-  if (h.length === 8) h = h.slice(0, 6);
-  if (h.length !== 6) return false;
-  const r = parseInt(h.slice(0, 2), 16);
-  const g = parseInt(h.slice(2, 4), 16);
-  const b = parseInt(h.slice(4, 6), 16);
-  // sRGB luma
-  const luma = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-  return luma > 0.6;
-}
-
-// ── Rounded ───────────────────────────────────────────────────────
-
-function RoundedSamples({ rounded }: { rounded: Record<string, string> }) {
-  const entries = Object.entries(rounded);
-  return (
-    <div className="grid grid-cols-2 gap-5 sm:grid-cols-3">
-      {entries.map(([key, value]) => (
-        <div key={key} className="flex flex-col items-center gap-2">
-          <span
-            aria-hidden
-            className="block h-14 w-14 bg-foreground/15 shadow-[inset_0_0_0_1px_rgba(30,35,45,0.12)]"
-            style={{ borderRadius: value }}
-          />
-          <span className="truncate font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
-            {key}
-          </span>
-          <span className="truncate font-mono text-[11px] text-foreground/85">
-            {value}
-          </span>
-        </div>
-      ))}
-    </div>
-  );
 }

--- a/ui/src/components/language-identity.tsx
+++ b/ui/src/components/language-identity.tsx
@@ -1,0 +1,244 @@
+import Link from "next/link";
+import { ArrowUpRight } from "lucide-react";
+import {
+  listArtStyles,
+  getPaletteSystem,
+  getFileUrl,
+  parseJson,
+  paletteCore,
+  paletteDisplayName,
+  artStyleDisplayName,
+  type PaletteCore,
+} from "@/lib/odata";
+
+const isHex = (c?: string): c is string =>
+  typeof c === "string" && /^#[0-9a-f]{3,8}$/i.test(c);
+
+const NEUTRAL_ORDER = ["bg", "surface", "text", "muted", "border"];
+
+interface AppliedColors {
+  primary?: string;
+  secondary?: string;
+  accent?: string;
+  background?: string;
+  surface?: string;
+  text?: string;
+  muted?: string;
+  border?: string;
+  [key: string]: string | undefined;
+}
+
+/** Build a palette view from a language's OWN tokens.colors — the applied
+ *  palette, used when no first-class PaletteSystem is linked yet. signature is
+ *  the identity inks; neutrals the ground. */
+function appliedPalette(tokensRaw?: string): PaletteCore {
+  const colors = parseJson<{ colors?: AppliedColors }>(tokensRaw)?.colors ?? {};
+  const signature = [colors.primary, colors.accent, colors.secondary]
+    .filter(isHex)
+    .map((hex) => ({ hex }));
+  const neutrals: Record<string, string> = {};
+  for (const [k, v] of Object.entries({
+    bg: colors.background,
+    surface: colors.surface,
+    text: colors.text,
+    muted: colors.muted,
+    border: colors.border,
+  }))
+    if (isHex(v)) neutrals[k] = v;
+  return { signature, neutrals, semantic: {}, mood: {} };
+}
+
+/**
+ * The identity row — what a language is BUILT WITH: its art style and its
+ * palette, surfaced right under the hero. The palette is the first-class
+ * PaletteSystem linked by `default_palette_id`; until that link is stamped it
+ * falls back to the language's own applied tokens.colors (same colours, so the
+ * row is correct today and gains a "view palette" link once wired).
+ */
+export async function LanguageIdentity({
+  fields,
+}: {
+  fields: Record<string, string | undefined>;
+}) {
+  const imagery =
+    parseJson<{ pairs_with?: string }>(fields.imagery_direction) ?? {};
+  const artSlug = fields.default_art_style_id
+    ? undefined
+    : imagery.pairs_with?.trim();
+
+  const arts = await listArtStyles("Status eq 'Published'").catch(() => []);
+  const art = fields.default_art_style_id
+    ? arts.find((a) => a.entity_id === fields.default_art_style_id)
+    : artSlug
+      ? arts.find((a) => a.fields.slug === artSlug)
+      : undefined;
+
+  // The linked palette is a real PaletteSystem entity. Resolve it when present;
+  // otherwise derive the applied palette from the language's own tokens.
+  const linked = fields.default_palette_id
+    ? await getPaletteSystem(fields.default_palette_id).catch(() => null)
+    : null;
+  const palette = linked
+    ? {
+        core: paletteCore(linked.fields),
+        name: paletteDisplayName(linked.fields),
+        href: `/palettes/${linked.entity_id}`,
+      }
+    : {
+        core: appliedPalette(fields.tokens),
+        name: "Applied palette",
+        href: undefined as string | undefined,
+      };
+
+  const hasArt = Boolean(art);
+  const hasPalette = palette.core.signature.length > 0;
+  if (!hasArt && !hasPalette) return null;
+
+  const artThumb = art?.fields.thumbnail_file_id
+    ? getFileUrl(art.fields.thumbnail_file_id)
+    : "";
+
+  return (
+    <section aria-label="Built with" data-reveal className="space-y-5">
+      <div className="flex items-center gap-3">
+        <span
+          className="ink-stamp shrink-0"
+          style={{ ["--ink" as string]: "var(--ramune)" }}
+        >
+          built with
+        </span>
+      </div>
+
+      <div className="grid gap-5 md:grid-cols-2">
+        {hasArt ? <ArtStyleCard art={art!} thumb={artThumb} /> : null}
+        {hasPalette ? <PaletteStrip palette={palette} /> : null}
+      </div>
+    </section>
+  );
+}
+
+function ArtStyleCard({
+  art,
+  thumb,
+}: {
+  art: Awaited<ReturnType<typeof listArtStyles>>[number];
+  thumb: string;
+}) {
+  return (
+    <Link
+      href={`/art-styles/${art.entity_id}`}
+      className="sticker-card group flex items-stretch overflow-hidden"
+      style={{ ["--card-ink" as string]: "var(--matcha)" }}
+    >
+      <span
+        className="w-28 shrink-0 bg-cover bg-center sm:w-36"
+        style={
+          thumb
+            ? { backgroundImage: `url(${thumb})` }
+            : { background: "var(--foreground)", opacity: 0.06 }
+        }
+        aria-hidden
+      />
+      <span className="flex min-w-0 flex-1 flex-col justify-center gap-1 px-4 py-4">
+        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+          Art style
+        </span>
+        <span className="truncate font-display text-[18px] font-bold leading-tight tracking-[-0.015em]">
+          {artStyleDisplayName(art.fields)}
+        </span>
+        {art.fields.medium ? (
+          <span className="truncate font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+            {art.fields.medium}
+          </span>
+        ) : null}
+        <span className="mt-1 inline-flex items-center gap-1 font-mono text-[11px] font-bold uppercase tracking-[0.14em] text-foreground/80 group-hover:text-foreground">
+          View art style
+          <ArrowUpRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+        </span>
+      </span>
+    </Link>
+  );
+}
+
+function PaletteStrip({
+  palette,
+}: {
+  palette: {
+    core: PaletteCore;
+    name: string;
+    href?: string;
+  };
+}) {
+  const { signature, neutrals, mood } = palette.core;
+  const sig = signature.length ? signature : [{ hex: "#888888" }];
+  const tint = sig[0].hex || "var(--teal)";
+  const hasNeutrals = NEUTRAL_ORDER.some((k) => neutrals[k]);
+
+  const body = (
+    <>
+      {/* SIGNATURE — the identity inks, a full-bleed band */}
+      <div className="flex h-20 w-full sm:h-24">
+        {sig.slice(0, 5).map((s, i) => (
+          <span
+            key={`${s.hex}-${i}`}
+            className="h-full flex-1"
+            style={{ background: s.hex }}
+          />
+        ))}
+      </div>
+      {/* NEUTRALS — the thin ground line */}
+      {hasNeutrals ? (
+        <div className="flex h-2.5 w-full">
+          {NEUTRAL_ORDER.filter((k) => neutrals[k]).map((k) => (
+            <span
+              key={k}
+              className="h-full flex-1"
+              style={{ background: neutrals[k] }}
+            />
+          ))}
+        </div>
+      ) : null}
+      <div className="flex flex-1 items-end justify-between gap-2 px-4 py-3.5">
+        <span className="min-w-0">
+          <span className="block font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+            Palette
+          </span>
+          <span className="block truncate font-display text-[18px] font-bold leading-tight tracking-[-0.015em]">
+            {palette.name}
+          </span>
+          {mood.temperature || mood.key_hue ? (
+            <span className="mt-0.5 block truncate font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground/85">
+              {[mood.temperature, mood.key_hue].filter(Boolean).join(" · ")}
+            </span>
+          ) : null}
+        </span>
+        {palette.href ? (
+          <span className="inline-flex shrink-0 items-center gap-1 font-mono text-[11px] font-bold uppercase tracking-[0.14em] text-foreground/80 group-hover:text-foreground">
+            View
+            <ArrowUpRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+          </span>
+        ) : null}
+      </div>
+    </>
+  );
+
+  if (palette.href) {
+    return (
+      <Link
+        href={palette.href}
+        className="sticker-card group flex flex-col overflow-hidden"
+        style={{ ["--card-ink" as string]: tint }}
+      >
+        {body}
+      </Link>
+    );
+  }
+  return (
+    <article
+      className="sticker-card group flex flex-col overflow-hidden"
+      style={{ ["--card-ink" as string]: tint }}
+    >
+      {body}
+    </article>
+  );
+}

--- a/ui/src/components/language-lineage.tsx
+++ b/ui/src/components/language-lineage.tsx
@@ -3,10 +3,7 @@ import { ArrowUpRight, GitBranch } from "lucide-react";
 import {
   listDesignLanguages,
   getDesignLanguage,
-  listArtStyles,
-  getFileUrl,
   parseJson,
-  artStyleDisplayName,
   type DesignLanguage,
 } from "@/lib/odata";
 
@@ -32,21 +29,24 @@ const LINEAGE_LABEL: Record<string, string> = {
   descendant: "Descended from",
 };
 
-/** A small language chip — color swatch + name + status, linking to its page. */
+/** A small language chip — color swatch + name + status, linking to its page.
+ *  Katagami sticker: sharp, borderless, tinted by the language's own ink. */
 function LangChip({ lang }: { lang: DesignLanguage }) {
   const colors = swatch(lang.fields);
+  const tint = colors[0] ?? "var(--ramune)";
   return (
     <Link
       href={`/language/${lang.entity_id}`}
-      className="group flex items-center gap-3 rounded-[16px] bg-muted/50 px-4 py-3 transition-colors hover:bg-muted"
+      className="sticker-card group flex items-center gap-3 px-4 py-3"
+      style={{ ["--card-ink" as string]: tint }}
     >
-      <span className="flex shrink-0 overflow-hidden rounded-[9999px]">
+      <span className="flex shrink-0 overflow-hidden">
         {colors.length > 0 ? (
           colors.map((c, i) => (
-            <span key={i} className="h-5 w-3" style={{ background: c }} />
+            <span key={i} className="h-6 w-3.5" style={{ background: c }} />
           ))
         ) : (
-          <span className="h-5 w-9 bg-foreground/10" />
+          <span className="h-6 w-10 bg-foreground/10" />
         )}
       </span>
       <span className="min-w-0 flex-1">
@@ -63,14 +63,9 @@ function LangChip({ lang }: { lang: DesignLanguage }) {
 }
 
 /**
- * Lineage + art style for a design language — surfaces the real entity graph
- * on the detail page: the art style the language is built with, the
- * ancestor(s) it descends from, and the children that descend from it.
- *
- * NOTE: the language→art-style link is carried today by
- * imagery_direction.pairs_with (a slug), not the first-class
- * default_art_style_id, so we resolve by slug. Once slugs are unique +
- * default_art_style_id is backfilled this becomes an exact id join.
+ * Lineage for a design language — the ancestor(s) it descends from and the
+ * children that descend from it. (The art style + palette a language is built
+ * with live in the identity row at the top of the page; see LanguageIdentity.)
  */
 export async function LanguageLineage({
   currentId,
@@ -79,31 +74,19 @@ export async function LanguageLineage({
   currentId: string;
   fields: Record<string, string | undefined>;
 }) {
-  const imagery = parseJson<{ pairs_with?: string }>(fields.imagery_direction) ?? {};
-  const artSlug =
-    fields.default_art_style_id ? undefined : imagery.pairs_with?.trim();
   const parentIds = parseJson<string[]>(fields.parent_ids) ?? [];
   const lineageType = (fields.lineage_type || "").toLowerCase();
 
-  // Published list drives children + art-style resolve; parents are fetched by
-  // id directly (a source parent is often still UnderReview).
+  // Published list drives children; parents are fetched by id directly (a
+  // source parent is often still UnderReview).
   let published: DesignLanguage[] = [];
-  let arts: Awaited<ReturnType<typeof listArtStyles>> = [];
   try {
-    [published, arts] = await Promise.all([
-      listDesignLanguages("Status eq 'Published'").catch(() => []),
-      listArtStyles("Status eq 'Published'").catch(() => []),
-    ]);
+    published = await listDesignLanguages("Status eq 'Published'").catch(
+      () => [],
+    );
   } catch {
     /* empty-safe */
   }
-
-  const art =
-    fields.default_art_style_id
-      ? arts.find((a) => a.entity_id === fields.default_art_style_id)
-      : artSlug
-        ? arts.find((a) => a.fields.slug === artSlug)
-        : undefined;
 
   const parents = (
     await Promise.all(
@@ -117,96 +100,51 @@ export async function LanguageLineage({
       (parseJson<string[]>(l.fields.parent_ids) ?? []).includes(currentId),
   );
 
-  if (!art && parents.length === 0 && children.length === 0) return null;
+  if (parents.length === 0 && children.length === 0) return null;
 
-  const artThumb = art?.fields.thumbnail_file_id
-    ? getFileUrl(art.fields.thumbnail_file_id)
-    : "";
   const parentLabel = LINEAGE_LABEL[lineageType] || "Descended from";
 
   return (
-    <section aria-label="Lineage and art style" className="space-y-7">
+    <section aria-label="Lineage" className="space-y-7">
       <div className="sticker-perforation" />
       <div className="flex items-end gap-3">
         <span
           className="ink-stamp shrink-0"
-          style={{ ["--ink" as string]: "var(--matcha, #2f9e6e)" }}
+          style={{ ["--ink" as string]: "var(--matcha)" }}
         >
           lineage
         </span>
         <h2 className="font-display text-2xl font-bold leading-tight tracking-[-0.02em] sm:text-[28px]">
-          Family &amp; art style
+          Family
         </h2>
       </div>
 
       <div className="grid gap-6 md:grid-cols-2">
-        {/* Art style the language is built with */}
-        {art ? (
+        {parents.length > 0 ? (
           <div className="space-y-3">
-            <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
-              Built with the art style
+            <span className="flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+              <GitBranch className="h-3 w-3" />
+              {parentLabel}
             </span>
-            <Link
-              href={`/art-styles/${art.entity_id}`}
-              className="group flex items-stretch gap-4 overflow-hidden rounded-[16px] bg-muted/50 transition-colors hover:bg-muted"
-            >
-              <span
-                className="h-auto w-28 shrink-0 bg-cover bg-center sm:w-32"
-                style={
-                  artThumb
-                    ? { backgroundImage: `url(${artThumb})` }
-                    : { background: "var(--foreground)", opacity: 0.06 }
-                }
-                aria-hidden
-              />
-              <span className="flex min-w-0 flex-1 flex-col justify-center gap-1 py-4 pr-4">
-                <span className="font-display text-[18px] font-bold leading-tight tracking-[-0.01em]">
-                  {artStyleDisplayName(art.fields)}
-                </span>
-                {art.fields.medium ? (
-                  <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
-                    {art.fields.medium}
-                  </span>
-                ) : null}
-                <span className="mt-1 inline-flex items-center gap-1 text-[13px] font-medium text-foreground/80 group-hover:text-foreground">
-                  View art style
-                  <ArrowUpRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
-                </span>
-              </span>
-            </Link>
+            <div className="grid gap-2">
+              {parents.map((p) => (
+                <LangChip key={p.entity_id} lang={p} />
+              ))}
+            </div>
           </div>
         ) : (
           <span />
         )}
-
-        {/* Ancestry + descendants */}
-        {parents.length > 0 || children.length > 0 ? (
-          <div className="space-y-5">
-            {parents.length > 0 ? (
-              <div className="space-y-3">
-                <span className="flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
-                  <GitBranch className="h-3 w-3" />
-                  {parentLabel}
-                </span>
-                <div className="grid gap-2">
-                  {parents.map((p) => (
-                    <LangChip key={p.entity_id} lang={p} />
-                  ))}
-                </div>
-              </div>
-            ) : null}
-            {children.length > 0 ? (
-              <div className="space-y-3">
-                <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
-                  {children.length} descendant{children.length === 1 ? "" : "s"}
-                </span>
-                <div className="grid gap-2">
-                  {children.map((c) => (
-                    <LangChip key={c.entity_id} lang={c} />
-                  ))}
-                </div>
-              </div>
-            ) : null}
+        {children.length > 0 ? (
+          <div className="space-y-3">
+            <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+              {children.length} descendant{children.length === 1 ? "" : "s"}
+            </span>
+            <div className="grid gap-2">
+              {children.map((c) => (
+                <LangChip key={c.entity_id} lang={c} />
+              ))}
+            </div>
           </div>
         ) : (
           <span />

--- a/ui/src/components/shadcn-preview.tsx
+++ b/ui/src/components/shadcn-preview.tsx
@@ -747,7 +747,7 @@ function ImplementationKitNotice({
   return (
     <Card
       className={cn(
-        "shadsync-kit-notice border-0 ring-0 bg-card/95 shadow-[var(--shadow-card)]",
+        "shadsync-kit-notice border-0 ring-0",
         hasAgentKit ? "shadsync-kit-ready" : "shadsync-kit-missing",
       )}
       data-testid="shadcn-implementation-kit-status"
@@ -755,19 +755,29 @@ function ImplementationKitNotice({
     >
       <CardHeader className="gap-3">
         <div className="flex flex-wrap items-center gap-2">
-          <Badge className="shadsync-status">
+          <span
+            className="inline-flex shrink-0 items-center px-2.5 py-0.5 font-mono text-[10px] font-semibold uppercase tracking-[0.14em]"
+            style={{
+              background: hasAgentKit
+                ? "color-mix(in srgb, var(--teal) 16%, var(--card))"
+                : "color-mix(in srgb, var(--yuzu) 24%, var(--card))",
+              color: hasAgentKit
+                ? "color-mix(in oklch, var(--teal) 72%, var(--foreground))"
+                : "color-mix(in oklch, var(--yuzu) 68%, var(--foreground))",
+            }}
+          >
             {hasAgentKit ? "agent-authored kit" : "needs agent-authored kit"}
-          </Badge>
+          </span>
           {componentSpecStatus === previewShotsStatus ? (
             <ArtifactStatusBadge status={componentSpecStatus} />
           ) : (
             <>
-              <Badge variant="outline" className="h-5 rounded-md font-mono text-[10px] uppercase tracking-[0.14em]">
+              <span className="inline-flex h-5 items-center bg-[color-mix(in_srgb,var(--foreground)_7%,var(--card))] px-2 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
                 recipes {statusLabel(componentSpecStatus)}
-              </Badge>
-              <Badge variant="outline" className="h-5 rounded-md font-mono text-[10px] uppercase tracking-[0.14em]">
+              </span>
+              <span className="inline-flex h-5 items-center bg-[color-mix(in_srgb,var(--foreground)_7%,var(--card))] px-2 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
                 shots {statusLabel(previewShotsStatus)}
-              </Badge>
+              </span>
             </>
           )}
         </div>


### PR DESCRIPTION
Reworks the design-language detail page per review feedback.

## Answering the palette question first
There is **no first-class palette linked to a language today** — only the language's own `tokens.colors` (the applied palette). The art style *is* linked (via `imagery_direction.pairs_with` → ArtStyle), but the palette is not (`default_palette_id` is never stamped). So the "two palettes" were really one ad-hoc palette plus the unrelated catalog. This PR builds the UI against a **real** `default_palette_id` contract and falls back to the applied colours until the pipeline wires it (Phase B).

## What changed
- **Identity row (top, "Built with")** — new `language-identity.tsx`: the art style + the language's palette, surfaced right under the hero. Palette resolves the linked `PaletteSystem` (`default_palette_id`) with a "view palette →" link; falls back to applied `tokens.colors` so it's correct today.
- **DESIGN.md "at a glance"** — removed the **Components**, **Spacing** and **Shape** cards (and the big Palette card, now compact in the identity row); kept the live Typography specimen.
- **shadcn implementation kit** — the "compatibility only" notice no longer renders as a **yellow gradient + coloured border + rounded card**. Now flat ink-tint (yuzu/teal), borderless, sharp — the katagami way. (Root cause: `.shadsync-kit-missing` used a `linear-gradient` + `border-color`; the flat-tint fix needed `!important` to beat Tailwind v4's utilities layer, matching the existing `.shadsync-*` pattern.)
- **Family & lineage** — art style moved up to the identity row; the section keeps ancestry + descendants, restyled from rounded `bg-muted` chips to sharp, borderless sticker chips tinted by each language's own ink.

## Follow-on — Phase B (separate effort, `commons` + `curation`)
Stamp a first-class `default_palette_id` on each language (mirroring `default_art_style_id`) by deriving its `PaletteSystem` from its own colours, so the linked palette becomes a real entity for every language. The UI here already consumes that contract.

## Verification
- `next build` ✓, `tsc --noEmit` ✓, eslint ✓.
- Loaded real languages locally (Swiss Grid System, Warm Editorial): identity row renders the palette sharp/borderless; Components/Spacing/Shape gone; kit notice computed bg is a flat faint-yuzu (`backgroundImage: none`, border 0, radius 0) — gradient/border/rounded eliminated.
- Art-style card + lineage chips: logic copied verbatim from the prior live component; styling reuses the verified `sticker-card`/`ink-stamp` classes. (Couldn't exercise on the sparse local dataset, which has no language with an art-style or lineage link.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)