### PR TITLE
fix(ui): polish language-detail identity row (placement, ratio, palette name, arrows)

### DIFF
--- a/ui/src/app/(site)/language/[id]/page.tsx
+++ b/ui/src/app/(site)/language/[id]/page.tsx
@@ -302,9 +302,6 @@ export default async function LanguageDetailPage({
 
       <Perforation />
 
-      {/* Identity — what the language is BUILT WITH: its art style + palette. */}
-      <LanguageIdentity fields={f} />
-
       {/* Mobile leads with the visual preview; wider screens set spec left, visuals right. */}
       <div className="grid gap-8 sm:gap-10 md:grid-cols-[minmax(0,0.92fr)_minmax(320px,1.08fr)] md:items-start md:gap-x-10">
         <section data-reveal className="order-2 md:order-1 md:col-start-1">
@@ -387,6 +384,10 @@ export default async function LanguageDetailPage({
           </section>
         </div>
       </div>
+
+      {/* Identity — what the language is BUILT WITH: its art style + palette.
+          Sits UNDER the embodiment, never above it. */}
+      <LanguageIdentity fields={f} />
 
       <Credits raw={f.credits} />
 

--- a/ui/src/components/language-identity.tsx
+++ b/ui/src/components/language-identity.tsx
@@ -85,8 +85,11 @@ export async function LanguageIdentity({
         href: `/palettes/${linked.entity_id}`,
       }
     : {
+        // No linked PaletteSystem yet → the language's own colours, shown
+        // without a borrowed name (just "Palette"). A name appears once the
+        // pipeline links a real PaletteSystem (Phase B).
         core: appliedPalette(fields.tokens),
-        name: "Applied palette",
+        name: undefined as string | undefined,
         href: undefined as string | undefined,
       };
 
@@ -127,19 +130,25 @@ function ArtStyleCard({
   return (
     <Link
       href={`/art-styles/${art.entity_id}`}
-      className="sticker-card group flex items-stretch overflow-hidden"
+      className="sticker-card group flex flex-col overflow-hidden"
       style={{ ["--card-ink" as string]: "var(--matcha)" }}
     >
-      <span
-        className="w-28 shrink-0 bg-cover bg-center sm:w-36"
-        style={
-          thumb
-            ? { backgroundImage: `url(${thumb})` }
-            : { background: "var(--foreground)", opacity: 0.06 }
-        }
-        aria-hidden
-      />
-      <span className="flex min-w-0 flex-1 flex-col justify-center gap-1 px-4 py-4">
+      {/* The proof image at its OWN aspect ratio — never cropped to a strip. */}
+      {thumb ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={thumb}
+          alt={`${artStyleDisplayName(art.fields)} proof`}
+          className="block w-full"
+        />
+      ) : (
+        <span
+          aria-hidden
+          className="block w-full"
+          style={{ aspectRatio: "16 / 10", background: "var(--foreground)", opacity: 0.06 }}
+        />
+      )}
+      <span className="flex flex-1 flex-col gap-1 px-4 py-3.5">
         <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
           Art style
         </span>
@@ -165,7 +174,7 @@ function PaletteStrip({
 }: {
   palette: {
     core: PaletteCore;
-    name: string;
+    name?: string;
     href?: string;
   };
 }) {
@@ -203,9 +212,11 @@ function PaletteStrip({
           <span className="block font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
             Palette
           </span>
-          <span className="block truncate font-display text-[18px] font-bold leading-tight tracking-[-0.015em]">
-            {palette.name}
-          </span>
+          {palette.name ? (
+            <span className="block truncate font-display text-[18px] font-bold leading-tight tracking-[-0.015em]">
+              {palette.name}
+            </span>
+          ) : null}
           {mood.temperature || mood.key_hue ? (
             <span className="mt-0.5 block truncate font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground/85">
               {[mood.temperature, mood.key_hue].filter(Boolean).join(" · ")}

--- a/ui/src/components/related-languages.tsx
+++ b/ui/src/components/related-languages.tsx
@@ -1,3 +1,4 @@
+import { ArrowUpRight } from "lucide-react";
 import { TrackedLink } from "@/components/tracked-link";
 import { listDesignLanguages, parseJson } from "@/lib/odata";
 
@@ -85,12 +86,10 @@ export async function RelatedLanguages({
                   shares {shared.slice(0, 3).join(" · ")}
                 </span>
               </span>
-              <span
+              <ArrowUpRight
                 aria-hidden
-                className="shrink-0 font-mono text-[12px] text-muted-foreground transition-transform group-hover:translate-x-0.5"
-              >
-                →
-              </span>
+                className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+              />
             </TrackedLink>
           );
         })}


### PR DESCRIPTION
Review polish on the "Built with" identity row shipped in #98.

- **Placement** — moved the identity row **below the embodiment** (it was above it).
- **Art-style image** — renders at its **own aspect ratio** (an `<img>`, not a cropped fixed-width side strip). No more squish.
- **Palette wording** — dropped "Applied palette". The name shows only when the palette has one (a linked `PaletteSystem`); otherwise just the "Palette" label + the colours.
- **Arrows** — consistent diagonal `ArrowUpRight` everywhere on the page: the related-languages "open" affordance was a side `→`, now matches the identity + lineage links.

Verified: `next build` ✓, `tsc` ✓, eslint ✓; visual check on the preview deploy against real data (Sumiha → Pigment Wash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)