### PR TITLE
feat(ui): Bake-off in top nav + mobile menu for full nav access

### DIFF
--- a/ui/src/app/(site)/layout.tsx
+++ b/ui/src/app/(site)/layout.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { HeaderNav } from "@/components/header-nav";
 import { MobileNav } from "@/components/mobile-nav";
+import { MobileMenu } from "@/components/mobile-menu";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { ScrollReveal } from "@/components/scroll-reveal";
 import {
@@ -95,6 +96,7 @@ async function buildSearchIndex(): Promise<PaletteIndexItem[]> {
     { name: "Taxonomy", href: "/taxonomy" },
     { name: "Lineage", href: "/lineage" },
     { name: "Compare", href: "/compare" },
+    { name: "Model bake-off", href: "/model-bake-off" },
   ]) {
     items.push({
       id: page.href,
@@ -154,6 +156,7 @@ export default async function SiteLayout({
           <div className="ml-auto flex items-center gap-2 md:hidden">
             <CommandPaletteTrigger />
             <ThemeToggle />
+            <MobileMenu />
           </div>
         </nav>
         {/* Halftone rule instead of a border — the header's bottom edge

--- a/ui/src/app/(site)/layout.tsx
+++ b/ui/src/app/(site)/layout.tsx
@@ -149,11 +149,11 @@ export default async function SiteLayout({
             </span>
           </Link>
           <HeaderNav />
-          <div className="ml-auto hidden items-center gap-2.5 md:flex">
+          <div className="ml-auto hidden items-center gap-2.5 lg:flex">
             <CommandPaletteTrigger />
             <ThemeToggle />
           </div>
-          <div className="ml-auto flex items-center gap-2 md:hidden">
+          <div className="ml-auto flex items-center gap-2 lg:hidden">
             <CommandPaletteTrigger />
             <ThemeToggle />
             <MobileMenu />

--- a/ui/src/components/header-nav.tsx
+++ b/ui/src/components/header-nav.tsx
@@ -8,7 +8,7 @@ import { NAV_LINKS, isActiveNav } from "@/lib/nav";
 export function HeaderNav() {
   const pathname = usePathname();
   return (
-    <div className="hidden min-w-0 flex-1 items-center gap-4 text-sm font-medium md:flex md:flex-none md:gap-4 lg:gap-5">
+    <div className="hidden min-w-0 flex-1 items-center gap-4 text-sm font-medium lg:flex lg:flex-none lg:gap-5">
       {NAV_LINKS.map((l) => {
         const active = isActiveNav(l.href, pathname);
         return (

--- a/ui/src/components/header-nav.tsx
+++ b/ui/src/components/header-nav.tsx
@@ -3,22 +3,14 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { trackNav } from "@/lib/analytics";
-
-const links = [
-  { href: "/", label: "Gallery" },
-  { href: "/palettes", label: "Palettes" },
-  { href: "/art-styles", label: "Art Styles" },
-  { href: "/studio", label: "Studio" },
-  { href: "/lineage", label: "Lineage" },
-  { href: "/compare", label: "Compare" },
-];
+import { NAV_LINKS, isActiveNav } from "@/lib/nav";
 
 export function HeaderNav() {
   const pathname = usePathname();
   return (
-    <div className="hidden min-w-0 flex-1 items-center gap-4 text-sm font-medium md:flex md:flex-none md:gap-5">
-      {links.map((l) => {
-        const active = l.href === "/" ? pathname === "/" : pathname.startsWith(l.href);
+    <div className="hidden min-w-0 flex-1 items-center gap-4 text-sm font-medium md:flex md:flex-none md:gap-4 lg:gap-5">
+      {NAV_LINKS.map((l) => {
+        const active = isActiveNav(l.href, pathname);
         return (
           <Link
             key={l.href}

--- a/ui/src/components/mobile-menu.tsx
+++ b/ui/src/components/mobile-menu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Menu, X } from "lucide-react";
@@ -45,24 +46,27 @@ export function MobileMenu() {
   }, [open]);
 
   return (
-    <div className="lg:hidden">
+    <>
       <button
         type="button"
         aria-label="Open menu"
         aria-haspopup="dialog"
         aria-expanded={open}
         onClick={() => setOpen(true)}
-        className="inline-flex h-9 w-9 items-center justify-center text-foreground/80 transition-colors hover:text-foreground"
+        className="inline-flex h-9 w-9 items-center justify-center text-foreground/80 transition-colors hover:text-foreground lg:hidden"
       >
         <Menu className="h-5 w-5" />
       </button>
 
-      {open ? (
+      {/* Portal to <body>: the header has backdrop-filter + overflow-x-clip,
+          which would otherwise trap and clip a position:fixed overlay. */}
+      {open && typeof document !== "undefined"
+        ? createPortal(
         <div
           role="dialog"
           aria-modal="true"
           aria-label="Menu"
-          className="fixed inset-0 z-50"
+          className="fixed inset-0 z-50 lg:hidden"
         >
           {/* ink-toned scrim — not pure black */}
           <button
@@ -118,8 +122,10 @@ export function MobileMenu() {
               })}
             </nav>
           </div>
-        </div>
-      ) : null}
-    </div>
+        </div>,
+            document.body,
+          )
+        : null}
+    </>
   );
 }

--- a/ui/src/components/mobile-menu.tsx
+++ b/ui/src/components/mobile-menu.tsx
@@ -12,7 +12,8 @@ import { NAV_LINKS, isActiveNav } from "@/lib/nav";
  * lists ALL top-level sections (the same as the desktop nav). It complements
  * the bottom tab bar (a 4-item quick-access subset), which it never replaces:
  * the bar stays for the thumb, the drawer covers the rest (Lineage, Compare,
- * Bake-off…). Hidden on md+ where the full header nav is shown.
+ * Bake-off…). Shown below lg (mobile + tablet); at lg+ the full inline header
+ * nav is shown instead, where all the links fit without crowding.
  */
 export function MobileMenu() {
   const pathname = usePathname();
@@ -44,7 +45,7 @@ export function MobileMenu() {
   }, [open]);
 
   return (
-    <div className="md:hidden">
+    <div className="lg:hidden">
       <button
         type="button"
         aria-label="Open menu"

--- a/ui/src/components/mobile-menu.tsx
+++ b/ui/src/components/mobile-menu.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Menu, X } from "lucide-react";
+import { trackNav } from "@/lib/analytics";
+import { NAV_LINKS, isActiveNav } from "@/lib/nav";
+
+/**
+ * Mobile "everything" menu — a slide-in drawer reachable from the header that
+ * lists ALL top-level sections (the same as the desktop nav). It complements
+ * the bottom tab bar (a 4-item quick-access subset), which it never replaces:
+ * the bar stays for the thumb, the drawer covers the rest (Lineage, Compare,
+ * Bake-off…). Hidden on md+ where the full header nav is shown.
+ */
+export function MobileMenu() {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+  const [navPath, setNavPath] = useState(pathname);
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  // Close the drawer when the route changes. Adjusting state during render via
+  // a previous-value marker is the idiomatic pattern — not setState in effect.
+  if (pathname !== navPath) {
+    setNavPath(pathname);
+    setOpen(false);
+  }
+
+  // While open: Esc closes, body scroll locks, focus moves into the drawer.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    closeRef.current?.focus();
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [open]);
+
+  return (
+    <div className="md:hidden">
+      <button
+        type="button"
+        aria-label="Open menu"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={() => setOpen(true)}
+        className="inline-flex h-9 w-9 items-center justify-center text-foreground/80 transition-colors hover:text-foreground"
+      >
+        <Menu className="h-5 w-5" />
+      </button>
+
+      {open ? (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Menu"
+          className="fixed inset-0 z-50"
+        >
+          {/* ink-toned scrim — not pure black */}
+          <button
+            type="button"
+            aria-label="Close menu"
+            tabIndex={-1}
+            onClick={() => setOpen(false)}
+            className="absolute inset-0 bg-[color-mix(in_oklch,var(--sumi)_45%,transparent)] backdrop-blur-[2px] deck-deal"
+          />
+
+          {/* the sheet — sharp, borderless, paper + shadow */}
+          <div className="absolute right-0 top-0 flex h-full w-[82%] max-w-xs flex-col bg-card shadow-[var(--shadow-card-hover)] deck-deal">
+            <div className="flex items-center justify-between px-6 pb-4 pt-[calc(env(safe-area-inset-top)+1.25rem)]">
+              <span
+                className="ink-stamp"
+                style={{ ["--ink" as string]: "var(--sakura)" }}
+              >
+                menu
+              </span>
+              <button
+                ref={closeRef}
+                type="button"
+                aria-label="Close menu"
+                onClick={() => setOpen(false)}
+                className="inline-flex h-9 w-9 items-center justify-center text-foreground/70 transition-colors hover:text-foreground"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            <span aria-hidden className="sticker-perforation mx-6" />
+
+            <nav
+              aria-label="All sections"
+              className="flex flex-col gap-1 overflow-y-auto px-5 py-5"
+            >
+              {NAV_LINKS.map((l) => {
+                const active = isActiveNav(l.href, pathname);
+                return (
+                  <Link
+                    key={l.href}
+                    href={l.href}
+                    data-active={active}
+                    onClick={() => {
+                      trackNav({ target: l.href, source: "mobile-menu" });
+                      setOpen(false);
+                    }}
+                    className="ink-underline relative inline-flex w-fit items-center py-2.5 font-display text-[24px] font-bold leading-tight tracking-[-0.02em] text-foreground/80 transition-colors data-[active=true]:text-foreground"
+                  >
+                    {l.label}
+                  </Link>
+                );
+              })}
+            </nav>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/src/lib/nav.ts
+++ b/ui/src/lib/nav.ts
@@ -1,0 +1,22 @@
+// The canonical top-level navigation. One source of truth so the desktop
+// header, the mobile menu drawer, and the search index never drift apart.
+// (The bottom tab bar on mobile is a deliberately shorter quick-access subset.)
+export interface NavLink {
+  href: string;
+  label: string;
+}
+
+export const NAV_LINKS: NavLink[] = [
+  { href: "/", label: "Gallery" },
+  { href: "/palettes", label: "Palettes" },
+  { href: "/art-styles", label: "Art Styles" },
+  { href: "/studio", label: "Studio" },
+  { href: "/lineage", label: "Lineage" },
+  { href: "/compare", label: "Compare" },
+  { href: "/model-bake-off", label: "Bake-off" },
+];
+
+/** Is `href` the active section for the current pathname? */
+export function isActiveNav(href: string, pathname: string): boolean {
+  return href === "/" ? pathname === "/" : pathname.startsWith(href);
+}


### PR DESCRIPTION
- **Bake-off in the top nav** — `/model-bake-off` is now linked in the header (and the ⌘K search index).
- **Mobile full-nav access** — a hamburger **menu drawer** in the header lists every top-level section. Lineage, Compare and Bake-off were unreachable on mobile (the header nav is `hidden` there and the bottom bar only has 4 tabs). The **bottom tab bar is unchanged** — it stays as the quick-access subset; the drawer covers the rest.
- **One source of truth** — links centralised in `lib/nav.ts`, shared by header + drawer + search so they can't drift.

Drawer: katagami-styled (sharp, borderless, ink scrim, perforation divider, ink-underline active links) and accessible (role=dialog, Esc, body scroll-lock, focus-in, closes on navigation).

Verified: `next build` ✓, `tsc` ✓, eslint ✓; visual check on preview at desktop + mobile widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)