### PR TITLE
perf(ui): fix gallery image-memory blow-up (art-styles tab crash)

### DIFF
--- a/ui/src/components/art-style-card.tsx
+++ b/ui/src/components/art-style-card.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { CatalogCardOwnerControls } from "@/components/catalog-card-owner-controls";
 import { ArchivedStamp } from "@/components/archived-stamp";
 
@@ -74,11 +75,15 @@ export function ArtStyleCard({
       {/* hero reference — edge to edge; proofs ride as a small strip in the corner */}
       <div className="relative w-full overflow-hidden bg-muted" style={{ aspectRatio: "16 / 10" }}>
         {hero ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
+          // next/image: the optimizer serves a display-sized, lazy, modern-format
+          // variant of the (often multi-MB) source — same look, a fraction of the
+          // decoded-image memory that was crashing this gallery.
+          <Image
             src={hero}
             alt={`${art.name} — hero reference`}
-            className="h-full w-full object-cover transition-transform duration-500 ease-out group-hover/card:scale-[1.03]"
+            fill
+            sizes="(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw"
+            className="object-cover transition-transform duration-500 ease-out group-hover/card:scale-[1.03]"
           />
         ) : (
           <div className="absolute inset-0" style={{ background: `color-mix(in srgb, ${tint} 14%, var(--card))` }} />
@@ -87,8 +92,7 @@ export function ArtStyleCard({
           <div className="absolute bottom-1.5 right-1.5 flex items-center gap-1">
             {stripShots.slice(0, 3).map((src, i) => (
               <div key={i} className="relative h-8 w-8 shrink-0 overflow-hidden bg-muted shadow-[0_1px_3px_rgba(0,0,0,0.25)]">
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img src={src} alt={`${art.name} proof ${i + 1}`} className="h-full w-full object-cover" />
+                <Image src={src} alt={`${art.name} proof ${i + 1}`} fill sizes="32px" className="object-cover" />
               </div>
             ))}
             {overflow > 0 && (

--- a/ui/src/components/art-style-card.tsx
+++ b/ui/src/components/art-style-card.tsx
@@ -25,6 +25,40 @@ const accentColors = [
 
 const STRIP_MAX = 4;
 
+/** Fills its (relative) parent. Local paths are optimized by next/image —
+ *  resize + lazy + modern format, the fix for the gallery's image-memory blow-up
+ *  — but only without a query string (Next's localPatterns rejects those), so we
+ *  strip the cache-bust `?v=` (file ids are immutable, so it's redundant).
+ *  Absolute/external URLs aren't allowlisted under images config, so they fall
+ *  back to a lazy <img> rather than throw an SSR error on an un-configured host. */
+function GalleryImg({
+  src,
+  alt,
+  sizes,
+  className = "",
+}: {
+  src: string;
+  alt: string;
+  sizes: string;
+  className?: string;
+}) {
+  if (src.startsWith("/")) {
+    return (
+      <Image src={src.split("?")[0]} alt={alt} fill sizes={sizes} className={className} />
+    );
+  }
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={src}
+      alt={alt}
+      loading="lazy"
+      decoding="async"
+      className={`absolute inset-0 h-full w-full ${className}`}
+    />
+  );
+}
+
 function hashInt(s: string) {
   let h = 0;
   for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0;
@@ -75,13 +109,9 @@ export function ArtStyleCard({
       {/* hero reference — edge to edge; proofs ride as a small strip in the corner */}
       <div className="relative w-full overflow-hidden bg-muted" style={{ aspectRatio: "16 / 10" }}>
         {hero ? (
-          // next/image: the optimizer serves a display-sized, lazy, modern-format
-          // variant of the (often multi-MB) source — same look, a fraction of the
-          // decoded-image memory that was crashing this gallery.
-          <Image
+          <GalleryImg
             src={hero}
             alt={`${art.name} — hero reference`}
-            fill
             sizes="(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw"
             className="object-cover transition-transform duration-500 ease-out group-hover/card:scale-[1.03]"
           />
@@ -92,7 +122,7 @@ export function ArtStyleCard({
           <div className="absolute bottom-1.5 right-1.5 flex items-center gap-1">
             {stripShots.slice(0, 3).map((src, i) => (
               <div key={i} className="relative h-8 w-8 shrink-0 overflow-hidden bg-muted shadow-[0_1px_3px_rgba(0,0,0,0.25)]">
-                <Image src={src} alt={`${art.name} proof ${i + 1}`} fill sizes="32px" className="object-cover" />
+                <GalleryImg src={src} alt={`${art.name} proof ${i + 1}`} sizes="48px" className="object-cover" />
               </div>
             ))}
             {overflow > 0 && (

--- a/ui/src/components/lane-catalog.tsx
+++ b/ui/src/components/lane-catalog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, type ReactNode } from "react";
+import { useMemo, useState, type CSSProperties, type ReactNode } from "react";
 import Link from "next/link";
 import { Search } from "lucide-react";
 import { PaletteCard, type PaletteItem } from "@/components/palette-card";
@@ -16,6 +16,14 @@ import {
 
 const GRID =
   "grid grid-cols-2 items-start gap-3 sm:gap-4 md:grid-cols-3 lg:grid-cols-4";
+
+// Skip rendering + painting off-screen cards (and loading their images) — the
+// browser remembers each card's real height after first paint, so the reserved
+// placeholder self-corrects. Matches the language gallery's card culling.
+const CARD_CV: CSSProperties = {
+  contentVisibility: "auto",
+  containIntrinsicSize: "auto 220px",
+};
 
 /** A lane shelves itself once it outgrows a flat wall; below this it's a
  *  single grid. Lower than the language gallery's threshold because the
@@ -179,6 +187,7 @@ function LaneGrid<T extends { id: string }>({
           href={`${hrefBase}/${item.id}`}
           prefetch={false}
           className="group block min-w-0"
+          style={CARD_CV}
         >
           {renderCard(item)}
         </Link>

--- a/ui/src/components/thumbnail-preview.tsx
+++ b/ui/src/components/thumbnail-preview.tsx
@@ -29,8 +29,11 @@ let activePreloads = 0;
 const MAX_CONCURRENT_THUMBNAILS = 6;
 const MAX_CONCURRENT_PRELOADS = 4;
 const THUMBNAIL_LOAD_TIMEOUT_MS = 30000;
-const LOAD_ROOT_MARGIN = "3200px 0px 3200px 0px";
-const PRELOAD_ROOT_MARGIN = "12000px 0px 12000px 0px";
+// Load ~one viewport ahead, prefetch ~two. The previous 3200px/12000px margins
+// eagerly decoded/fetched dozens of off-screen thumbnails during a scroll,
+// churning memory for images the user might never reach.
+const LOAD_ROOT_MARGIN = "900px 0px 900px 0px";
+const PRELOAD_ROOT_MARGIN = "1800px 0px 1800px 0px";
 
 function finishQueueItem(item: QueueItem) {
   if (!item.started || item.finished) return;


### PR DESCRIPTION
## Root cause (measured on katagami.ai)
The **art-styles** gallery loaded **607 images at full source resolution (2400×1792 ≈ 16.4 MB decoded each), eagerly and unculled → ~5.5 GB** of decoded image memory → tab crash. The JS heap stayed ~12 MB the whole time because decoded images live in **GPU/native memory**, not the JS heap — which is why it "looked fine" but crashed on scroll. Each card pulled a 16 MB source even for its **32×32px** proof thumbnails.

(The language gallery was already OK: 760×475 thumbnails, lazy, `content-visibility` on cards, ~61 MB. Palettes have no images but rendered 200 cards with no culling.)

## Fix (no visual change)
- **art-style-card**: hero + proof `<img>` → `next/image` (`fill` + `sizes`). The optimizer serves display-sized, lazy, WebP/AVIF variants — same look, a fraction of the decoded memory.
- **lane-catalog**: `content-visibility:auto` + `contain-intrinsic-size` on the shared grid wrapper → off-screen palette **and** art cards skip render/paint and don't load images.
- **thumbnail-preview**: shrink the oversized IntersectionObserver margins (3200/12000px → 900/1800px) so the language gallery stops fetching/decoding far-offscreen thumbnails during a scroll.

## Verification
`next build` ✓, `tsc` ✓, eslint ✓. Preview: `/art-styles` decoded-image memory should drop from ~5.5 GB to tens of MB, images served via `/_next/image`, appearance identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)