### PR TITLE
perf(ui): cache Temper reads + optimized images (slow loads/reloads)

### DIFF
--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -5,6 +5,13 @@ const nextConfig: NextConfig = {
   // transformers.js (taste embeddings) ships native/onnx assets that must
   // not be bundled — load it from node_modules at runtime.
   serverExternalPackages: ["@xenova/transformers"],
+  images: {
+    // Optimized variants are keyed by an immutable file-id source (the cache-bust
+    // query is stripped before optimizing), so they never need re-optimizing.
+    // Cache them long so the image-heavy art-styles gallery serves /_next/image
+    // HITs instead of re-optimizing hundreds of images on every cold load.
+    minimumCacheTTL: 2592000, // 30 days
+  },
 };
 
 export default nextConfig;

--- a/ui/src/lib/odata.ts
+++ b/ui/src/lib/odata.ts
@@ -32,11 +32,19 @@ const headers: Record<string, string> = {
   ...(API_KEY ? { Authorization: `Bearer ${API_KEY}` } : {}),
 };
 
+// OData reads are GET-only (mutations live in odata-mutations.ts), so they're
+// safe to cache. Every page re-fetched the whole catalog from Temper on each
+// request with `no-store`, which made SSR slow (2.5–3.5s TTFB) and every reload
+// re-do all of it. A short revalidate window serves cached data (fast) and stays
+// fresh: UI mutations already revalidatePath the affected routes, and new
+// pipeline-published content appears within the window.
+const ODATA_REVALIDATE_SECONDS = 60;
+
 async function odata<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(odataUrl(path), {
     ...init,
     headers: { ...headers, ...init?.headers },
-    cache: "no-store",
+    next: { revalidate: ODATA_REVALIDATE_SECONDS },
   });
   if (!res.ok) {
     throw new Error(`OData ${res.status}: ${await res.text()}`);

--- a/ui/src/lib/temper-files.ts
+++ b/ui/src/lib/temper-files.ts
@@ -20,9 +20,13 @@ export async function readTemperFileBytes(
   const fetchHeaders: Record<string, string> = { "X-Tenant-Id": TENANT };
   if (API_KEY) fetchHeaders.Authorization = `Bearer ${API_KEY}`;
 
+  // File ids are immutable (a re-export gets a new id), so the content for a
+  // given id never changes — cache it. The language detail page reads several
+  // of these per request (shadcn export / component spec / preview shots); with
+  // no-store every load + reload re-fetched them all from Temper.
   const res = await fetch(`${API_BASE}/tdata/Files('${fileId}')/$value`, {
     headers: fetchHeaders,
-    cache: "no-store",
+    next: { revalidate: 300 },
   });
 
   if (!res.ok) return null;


### PR DESCRIPTION
## Root cause (measured)
Page TTFB was **2.6s (art-styles) / 3.5s (language detail)** — every page re-fetched the whole catalog from Temper on each request with `cache: "no-store"`, and every **reload re-did all of it**. The art-styles gallery also re-optimized hundreds of images per cold load (`/_next/image` → `x-vercel-cache: MISS`). (`/api/file` itself is already CDN-cached and fine.)

## Fix (no appearance change)
- **odata reads** (GET-only — mutations live in `odata-mutations.ts`): `no-store` → `next.revalidate: 60s`. Safe because UI mutations already `revalidatePath` the affected routes, and pipeline-published content appears within the window.
- **temper-files reads** (immutable file ids): `no-store` → `revalidate: 300s` (the detail page reads several per request).
- **`images.minimumCacheTTL: 30d`**: optimized art-style images are keyed by an immutable file-id source, so they never need re-optimizing — serve `/_next/image` HITs instead of re-optimizing on every load.

## Expected
SSR TTFB drops from ~2.5–3.5s to ~tens of ms on warm cache (gallery, art-styles, **and language detail** load + reload). Art-styles images render fast/reliably after warmup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)