### PR TITLE
perf(ui): cache Temper reads with unstable_cache (auth-header fix for #103)

### DIFF
--- a/ui/src/app/(site)/layout.tsx
+++ b/ui/src/app/(site)/layout.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from "next/cache";
 import Link from "next/link";
 import { HeaderNav } from "@/components/header-nav";
 import { MobileNav } from "@/components/mobile-nav";
@@ -28,8 +29,13 @@ interface TokensLite {
   colors?: Record<string, string | undefined>;
 }
 
-async function buildSearchIndex(): Promise<PaletteIndexItem[]> {
-  const items: PaletteIndexItem[] = [];
+// The ⌘K search index is identical on every page, but it lives in this layout
+// so it was rebuilt — 3 catalog fetches + parsing every item — on every single
+// page render (the dominant shared TTFB cost across all pages). Cache the whole
+// built index so it's produced once per window, not per request.
+const buildSearchIndex = unstable_cache(
+  async (): Promise<PaletteIndexItem[]> => {
+    const items: PaletteIndexItem[] = [];
 
   try {
     // Search only surfaces the public catalog — Published only (palettes and
@@ -106,8 +112,11 @@ async function buildSearchIndex(): Promise<PaletteIndexItem[]> {
     });
   }
 
-  return items;
-}
+    return items;
+  },
+  ["site-search-index-v1"],
+  { revalidate: 60 },
+);
 
 export default async function SiteLayout({
   children,

--- a/ui/src/lib/odata.ts
+++ b/ui/src/lib/odata.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from "next/cache";
 import {
   demoArtStyles,
   demoDesignLanguages,
@@ -35,16 +36,42 @@ const headers: Record<string, string> = {
 // OData reads are GET-only (mutations live in odata-mutations.ts), so they're
 // safe to cache. Every page re-fetched the whole catalog from Temper on each
 // request with `no-store`, which made SSR slow (2.5–3.5s TTFB) and every reload
-// re-do all of it. A short revalidate window serves cached data (fast) and stays
-// fresh: UI mutations already revalidatePath the affected routes, and new
-// pipeline-published content appears within the window.
+// re-do all of it.
+//
+// IMPORTANT: fetch-level `next.revalidate` does NOT cache these — Next opts any
+// fetch carrying an Authorization header out of the fetch Data Cache. So we cache
+// the parsed RESULT via unstable_cache (keyed by path), which is independent of
+// the request/headers. It stays fresh: UI mutations already revalidatePath the
+// affected routes, and new pipeline-published content appears within the window.
 const ODATA_REVALIDATE_SECONDS = 60;
 
+async function odataFetch<T>(path: string): Promise<T> {
+  const res = await fetch(odataUrl(path), { headers, cache: "no-store" });
+  if (!res.ok) {
+    throw new Error(`OData ${res.status}: ${await res.text()}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+// Entries over Next's ~2MB Data Cache limit are simply re-fetched (not cached);
+// correctness is unaffected, those reads just stay uncached.
+const cachedOdataFetch = unstable_cache(
+  (path: string) => odataFetch<unknown>(path),
+  ["odata-read-v1"],
+  { revalidate: ODATA_REVALIDATE_SECONDS },
+);
+
 async function odata<T>(path: string, init?: RequestInit): Promise<T> {
+  const method = (init?.method ?? "GET").toUpperCase();
+  // Reads (GET, no body) are cached; anything else (defensive — mutations live
+  // in odata-mutations.ts) goes straight through, uncached.
+  if (method === "GET" && !init?.body) {
+    return cachedOdataFetch(path) as Promise<T>;
+  }
   const res = await fetch(odataUrl(path), {
     ...init,
     headers: { ...headers, ...init?.headers },
-    next: { revalidate: ODATA_REVALIDATE_SECONDS },
+    cache: "no-store",
   });
   if (!res.ok) {
     throw new Error(`OData ${res.status}: ${await res.text()}`);

--- a/ui/src/lib/temper-files.ts
+++ b/ui/src/lib/temper-files.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import { unstable_cache } from "next/cache";
 
 function cleanEnv(value: string | undefined, fallback: string): string {
   const cleaned = (value ?? fallback).replace(/\\n/g, "").trim();
@@ -20,23 +21,34 @@ export async function readTemperFileBytes(
   const fetchHeaders: Record<string, string> = { "X-Tenant-Id": TENANT };
   if (API_KEY) fetchHeaders.Authorization = `Bearer ${API_KEY}`;
 
-  // File ids are immutable (a re-export gets a new id), so the content for a
-  // given id never changes — cache it. The language detail page reads several
-  // of these per request (shadcn export / component spec / preview shots); with
-  // no-store every load + reload re-fetched them all from Temper.
   const res = await fetch(`${API_BASE}/tdata/Files('${fileId}')/$value`, {
     headers: fetchHeaders,
-    next: { revalidate: 300 },
+    cache: "no-store",
   });
 
   if (!res.ok) return null;
   return res.arrayBuffer();
 }
 
+// The detail page reads several files per request (shadcn export / component
+// spec / preview shots) and re-did them on every load + reload. File ids are
+// immutable (a re-export gets a new id), so a given id's content never changes —
+// cache the decoded text. fetch-level revalidate can't cache these (the
+// Authorization header opts them out of the fetch Data Cache), so cache the
+// result via unstable_cache. (Entries over Next's ~2MB limit just stay uncached.)
+const cachedFileText = unstable_cache(
+  async (fileId: string): Promise<string | null> => {
+    const bytes = await readTemperFileBytes(fileId);
+    if (!bytes) return null;
+    return new TextDecoder().decode(bytes);
+  },
+  ["temper-file-text-v1"],
+  { revalidate: 300 },
+);
+
 export async function readTemperFileText(
   fileId?: string,
 ): Promise<string | null> {
-  const bytes = await readTemperFileBytes(fileId);
-  if (!bytes) return null;
-  return new TextDecoder().decode(bytes);
+  if (!fileId?.trim()) return null;
+  return cachedFileText(fileId);
 }


### PR DESCRIPTION
Follow-up to #103. The fetch-level `next.revalidate` I added there **never cached** — Next opts any fetch with an `Authorization` header out of the fetch Data Cache, so prod SSR stayed ~1.6–2.5s (verified: `x-vercel-cache: MISS`, no TTFB drop across 5 consecutive hits).

Fix: cache the **result** via `unstable_cache` (keyed by path / file id), which is independent of request headers:
- **odata** reads (GET-only) → `unstable_cache`, revalidate 60s.
- **temper-files** → cache the decoded text → `unstable_cache`, revalidate 300s.

Stays fresh (UI mutations already `revalidatePath`; pipeline content appears within the window). Entries over Next's ~2MB Data Cache limit simply stay uncached (correctness unaffected). No appearance change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)