### PR TITLE
perf(ui): stream the shadcn kit on the language detail page

### DIFF
--- a/ui/src/app/(site)/language/[id]/page.tsx
+++ b/ui/src/app/(site)/language/[id]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
@@ -14,22 +15,19 @@ import { LanguageIdentity } from "@/components/language-identity";
 import { LanguageLineage } from "@/components/language-lineage";
 import { toLanguageOpts, toPaletteOpts, toArtOpts } from "@/lib/remix-options";
 import { InlineRemix } from "@/components/remix/inline-remix";
-import { readTemperFileText } from "@/lib/temper-files";
 import {
   designMdToMarkdown,
   katagamiSpecToMarkdown,
-  shadcnThemeJson,
   SpecPanel,
 } from "@/components/spec-panel";
 import { SpecActions } from "@/components/spec-actions";
 import { DesignMdShowcase } from "@/components/design-md-showcase";
 import { EmbodimentTabs, type EmbodimentTab } from "@/components/embodiment-tabs";
 import { DesignShowcase } from "@/components/design-showcase";
-import { ShadcnPreview } from "@/components/shadcn-preview";
+import { ShadcnKitSection } from "@/components/shadcn-kit-section";
 import { Credits } from "@/components/credits";
 import { ModelProvenance } from "@/components/model-provenance";
 import { PageHero } from "@/components/page-hero";
-import { shadcnDesignMdMarkdown } from "@/lib/shadcn-export";
 import {
   StickyNote,
   SectionHeading,
@@ -201,48 +199,10 @@ export default async function LanguageDetailPage({
   };
   const katagamiMarkdown = katagamiSpecToMarkdown(specProps);
   const designMd = designMdToMarkdown(specProps);
-  const [
-    storedShadcnTheme,
-    storedShadcnComponentSpec,
-    storedShadcnPreviewShots,
-  ] = await Promise.all([
-    readTemperFileText(f.shadcn_export_file_id),
-    readTemperFileText(f.shadcn_component_spec_file_id),
-    readTemperFileText(f.shadcn_preview_shots_file_id),
-  ]);
-  const shadcnTheme = storedShadcnTheme ?? shadcnThemeJson(specProps);
-  const shadcnThemeStatus = storedShadcnTheme
-    ? lang.booleans.shadcn_export_verified
-      ? "validated"
-      : "stored-unverified"
-    : "generated-preview";
-  const shadcnComponentStatus = storedShadcnComponentSpec
-    ? lang.booleans.shadcn_component_spec_verified
-      ? "validated"
-      : "stored-unverified"
-    : "generated-preview";
-  const shadcnPreviewShotsStatus = storedShadcnPreviewShots
-    ? lang.booleans.shadcn_preview_shots_verified
-      ? "validated"
-      : "stored-unverified"
-    : "generated-preview";
-  const shadcnDesignMd = shadcnDesignMdMarkdown({
-    languageId: id,
-    name,
-    slug: f.slug,
-    tokens: f.tokens,
-    philosophy: f.philosophy,
-    rules: f.rules,
-    layout: f.layout_principles,
-    guidance: f.guidance,
-    designMd,
-    themeJson: shadcnTheme,
-    componentSpec: storedShadcnComponentSpec,
-    previewShotsJson: storedShadcnPreviewShots,
-    themeStatus: shadcnThemeStatus,
-    componentSpecStatus: shadcnComponentStatus,
-    previewShotsStatus: shadcnPreviewShotsStatus,
-  });
+  // The shadcn implementation kit (3 stored-file reads + markdown generation) is
+  // rendered in a streamed <ShadcnKitSection> Suspense island below — it no
+  // longer blocks the page's TTFB. The shadcn download is served on demand by
+  // the /DESIGN.with-shadcn.md route.
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-4 py-6 sm:space-y-10 sm:py-10">
@@ -294,8 +254,6 @@ export default async function LanguageDetailPage({
         languageId={id}
         katagamiSpec={katagamiMarkdown}
         designMd={designMd}
-        shadcnTheme={shadcnTheme}
-        shadcnDesignMd={shadcnDesignMd}
         slug={f.slug}
         variant="hero"
       />
@@ -362,24 +320,20 @@ export default async function LanguageDetailPage({
               implementation kit
             </SectionHeading>
             <StickyNote tint="teal" className="p-4 sm:p-5">
-              <ShadcnPreview
-                languageId={id}
-                languageName={name}
-                slug={f.slug}
-                tokensRaw={f.tokens}
-                philosophyRaw={f.philosophy}
-                rulesRaw={f.rules}
-                layoutRaw={f.layout_principles}
-                guidanceRaw={f.guidance}
-                storedThemeJson={storedShadcnTheme}
-                storedComponentSpec={storedShadcnComponentSpec}
-                storedPreviewShots={storedShadcnPreviewShots}
-                shadcnDesignMd={shadcnDesignMd}
-                themeStatus={shadcnThemeStatus}
-                componentSpecStatus={shadcnComponentStatus}
-                previewShotsStatus={shadcnPreviewShotsStatus}
-                compact
-              />
+              <Suspense
+                fallback={
+                  <div className="h-40 animate-pulse rounded-[2px] bg-foreground/5" />
+                }
+              >
+                <ShadcnKitSection
+                  languageId={id}
+                  name={name}
+                  designMd={designMd}
+                  fields={f}
+                  booleans={lang.booleans}
+                  specProps={specProps}
+                />
+              </Suspense>
             </StickyNote>
           </section>
         </div>

--- a/ui/src/components/shadcn-kit-section.tsx
+++ b/ui/src/components/shadcn-kit-section.tsx
@@ -1,0 +1,89 @@
+import {
+  shadcnThemeJson,
+  type SpecPanelProps,
+} from "@/components/spec-panel";
+import { shadcnDesignMdMarkdown } from "@/lib/shadcn-export";
+import { ShadcnPreview } from "@/components/shadcn-preview";
+import { readTemperFileText } from "@/lib/temper-files";
+
+/**
+ * The shadcn implementation kit, rendered as a streamed (Suspense) island so its
+ * 3 stored-file reads + markdown generation no longer block the page's TTFB. The
+ * hero, spec and embodiment paint immediately; this fills in a beat later.
+ */
+export async function ShadcnKitSection({
+  languageId,
+  name,
+  designMd,
+  fields,
+  booleans,
+  specProps,
+}: {
+  languageId: string;
+  name: string;
+  designMd: string;
+  fields: Record<string, string | undefined>;
+  booleans: Record<string, boolean>;
+  specProps: SpecPanelProps;
+}) {
+  const [storedShadcnTheme, storedShadcnComponentSpec, storedShadcnPreviewShots] =
+    await Promise.all([
+      readTemperFileText(fields.shadcn_export_file_id),
+      readTemperFileText(fields.shadcn_component_spec_file_id),
+      readTemperFileText(fields.shadcn_preview_shots_file_id),
+    ]);
+  const shadcnTheme = storedShadcnTheme ?? shadcnThemeJson(specProps);
+  const shadcnThemeStatus = storedShadcnTheme
+    ? booleans.shadcn_export_verified
+      ? "validated"
+      : "stored-unverified"
+    : "generated-preview";
+  const shadcnComponentStatus = storedShadcnComponentSpec
+    ? booleans.shadcn_component_spec_verified
+      ? "validated"
+      : "stored-unverified"
+    : "generated-preview";
+  const shadcnPreviewShotsStatus = storedShadcnPreviewShots
+    ? booleans.shadcn_preview_shots_verified
+      ? "validated"
+      : "stored-unverified"
+    : "generated-preview";
+  const shadcnDesignMd = shadcnDesignMdMarkdown({
+    languageId,
+    name,
+    slug: fields.slug,
+    tokens: fields.tokens,
+    philosophy: fields.philosophy,
+    rules: fields.rules,
+    layout: fields.layout_principles,
+    guidance: fields.guidance,
+    designMd,
+    themeJson: shadcnTheme,
+    componentSpec: storedShadcnComponentSpec,
+    previewShotsJson: storedShadcnPreviewShots,
+    themeStatus: shadcnThemeStatus,
+    componentSpecStatus: shadcnComponentStatus,
+    previewShotsStatus: shadcnPreviewShotsStatus,
+  });
+
+  return (
+    <ShadcnPreview
+      languageId={languageId}
+      languageName={name}
+      slug={fields.slug}
+      tokensRaw={fields.tokens}
+      philosophyRaw={fields.philosophy}
+      rulesRaw={fields.rules}
+      layoutRaw={fields.layout_principles}
+      guidanceRaw={fields.guidance}
+      storedThemeJson={storedShadcnTheme}
+      storedComponentSpec={storedShadcnComponentSpec}
+      storedPreviewShots={storedShadcnPreviewShots}
+      shadcnDesignMd={shadcnDesignMd}
+      themeStatus={shadcnThemeStatus}
+      componentSpecStatus={shadcnComponentStatus}
+      previewShotsStatus={shadcnPreviewShotsStatus}
+      compact
+    />
+  );
+}

--- a/ui/src/components/spec-actions.tsx
+++ b/ui/src/components/spec-actions.tsx
@@ -8,8 +8,6 @@ interface SpecActionsProps {
   languageId?: string;
   katagamiSpec: string;
   designMd: string;
-  shadcnTheme: string;
-  shadcnDesignMd?: string;
   slug?: string;
   variant?: "compact" | "hero";
 }
@@ -71,7 +69,6 @@ export function SpecActions({
   languageId,
   katagamiSpec,
   designMd,
-  shadcnDesignMd,
   slug,
   variant = "compact",
 }: SpecActionsProps) {
@@ -93,15 +90,26 @@ export function SpecActions({
     return `${window.location.origin}${path}/${suffix}`;
   };
 
-  const markdownFor = (f: Format) =>
-    f === "katagami"
-      ? katagamiSpec
-      : f === "design-md"
-        ? designMd
-        : shadcnDesignMd ?? designMd;
+  // katagami + design-md are inlined; the shadcn DESIGN.md is generated on demand
+  // by its route (kept off the page's critical-path render), so fetch it only
+  // when the user actually copies/downloads it.
+  const resolveMarkdown = async (f: Format): Promise<string> => {
+    if (f === "katagami") return katagamiSpec;
+    if (f === "design-md") return designMd;
+    if (!languageId) return designMd;
+    try {
+      const res = await fetch(
+        `/language/${encodeURIComponent(languageId)}/${URL_SUFFIX["shadcn-md"]}`,
+      );
+      if (res.ok) return await res.text();
+    } catch {
+      /* fall back to the plain DESIGN.md below */
+    }
+    return designMd;
+  };
 
   const handleCopy = async () => {
-    const md = markdownFor(format);
+    const md = await resolveMarkdown(format);
     const url = urlFor(format);
     const refLine = url ? `\n\nSource: ${url}` : "";
     await writeClipboard(`${PREAMBLE[format]}${refLine}\n\n${md}`);
@@ -117,8 +125,8 @@ export function SpecActions({
     flash("link");
   };
 
-  const handleDownload = () => {
-    const blob = new Blob([markdownFor(format)], {
+  const handleDownload = async () => {
+    const blob = new Blob([await resolveMarkdown(format)], {
       type: "text/markdown;charset=utf-8",
     });
     const url = URL.createObjectURL(blob);

--- a/ui/src/components/spec-panel.tsx
+++ b/ui/src/components/spec-panel.tsx
@@ -3,7 +3,6 @@ import { parseJson } from "@/lib/odata";
 import {
   buildShadcnRegistryTheme,
   shadcnCssBlock,
-  shadcnDesignMdMarkdown,
   shadcnThemeToJson,
   shadcnUsageMarkdown,
 } from "@/lib/shadcn-export";
@@ -1220,18 +1219,6 @@ export function SpecPanel(props: SpecPanelProps) {
   const katagamiMarkdown = katagamiSpecToMarkdown(props);
   const designMd = designMdToMarkdown(props);
   const shadcnJson = shadcnThemeJson(props);
-  const shadcnDesignMd = shadcnDesignMdMarkdown({
-    languageId: props.languageId,
-    name: props.name,
-    slug: props.slug,
-    tokens: props.tokens,
-    philosophy: props.philosophy,
-    rules: props.rules,
-    layout: props.layout,
-    guidance: props.guidance,
-    designMd,
-    themeJson: shadcnJson,
-  });
 
   return (
     <div className="relative min-w-0">
@@ -1241,8 +1228,6 @@ export function SpecPanel(props: SpecPanelProps) {
             languageId={props.languageId}
             katagamiSpec={katagamiMarkdown}
             designMd={designMd}
-            shadcnTheme={shadcnJson}
-            shadcnDesignMd={shadcnDesignMd}
             slug={props.slug}
           />
         </div>


### PR DESCRIPTION
The language detail page stayed ~2s TTFB (no warming across hits) even after the data-cache work, because it read **3 stored shadcn files + generated markdown at the top level on every request**, blocking the render. Those reads only feed (a) the shadcn download — already served by the `/DESIGN.with-shadcn.md` route — and (b) the below-the-fold implementation-kit preview.

- Move the reads + markdown into a streamed **`<ShadcnKitSection>` Suspense island**, so the hero/spec/embodiment paint immediately and the kit streams in.
- **SpecActions**: drop the dead `shadcnTheme` prop and the pre-computed `shadcnDesignMd`; fetch the shadcn DESIGN.md from its route on demand on copy/download.
- **SpecPanel**: same — no longer pre-builds the shadcn DESIGN.md for its actions.

No appearance change. Verified: build/tsc/eslint clean; preview TTFB + shadcn kit + download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)