### PR TITLE
fix(ui): bake-off perf + file-download hardening; hide Lineage/Compare from nav

### DIFF
--- a/ui/src/app/(site)/lab/[slug]/page.tsx
+++ b/ui/src/app/(site)/lab/[slug]/page.tsx
@@ -6,7 +6,9 @@ import { LabComparison } from "../lab-comparison";
 // commons (the round's submitted languages), so it reflects submissions as they
 // land — including those still UnderReview.
 
-export const dynamic = "force-dynamic";
+// ISR: cache the assembled round per slug and revalidate in the background. It
+// was force-dynamic, re-scanning the catalog on every open (slow TTFB).
+export const revalidate = 60;
 
 export default async function LabComparisonPage({
   params,

--- a/ui/src/app/(site)/lab/lab-comparison.tsx
+++ b/ui/src/app/(site)/lab/lab-comparison.tsx
@@ -210,6 +210,7 @@ function PreviewFrame({
 }) {
   const ref = useRef<HTMLDivElement>(null);
   const [scale, setScale] = useState(0);
+  const [visible, setVisible] = useState(false);
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
@@ -219,13 +220,28 @@ function PreviewFrame({
       if (w > 0) setScale(w / PREVIEW_CANVAS_WIDTH);
     });
     ro.observe(el);
-    return () => ro.disconnect();
+    // Lazy-mount the iframe only when the card nears the viewport, so a round
+    // with a dozen models doesn't load a dozen full embodiment documents up front.
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          setVisible(true);
+          io.disconnect();
+        }
+      },
+      { rootMargin: "600px 0px" },
+    );
+    io.observe(el);
+    return () => {
+      ro.disconnect();
+      io.disconnect();
+    };
   }, []);
   // A 16:10 desktop slice (the hero region), scaled to the column width.
   const canvasHeight = Math.round(PREVIEW_CANVAS_WIDTH / 1.6);
   return (
     <div ref={ref} className={`sticker-card relative overflow-hidden ${className}`}>
-      {scale > 0 ? (
+      {visible && scale > 0 ? (
         <iframe
           src={src}
           title={title}

--- a/ui/src/app/(site)/layout.tsx
+++ b/ui/src/app/(site)/layout.tsx
@@ -100,9 +100,8 @@ const buildSearchIndex = unstable_cache(
     { name: "Art Styles", href: "/art-styles" },
     { name: "Studio", href: "/studio" },
     { name: "Taxonomy", href: "/taxonomy" },
-    { name: "Lineage", href: "/lineage" },
-    { name: "Compare", href: "/compare" },
     { name: "Model bake-off", href: "/model-bake-off" },
+    // Lineage + Compare hidden for now (see lib/nav.ts).
   ]) {
     items.push({
       id: page.href,

--- a/ui/src/app/(site)/model-bake-off/page.tsx
+++ b/ui/src/app/(site)/model-bake-off/page.tsx
@@ -5,7 +5,9 @@ import { BakeoffIndex } from "../lab/bakeoff-index";
 // reachable at /model-bake-off. Each round is a Direction (a reimagine brief)
 // with its submitted Katagami languages.
 
-export const dynamic = "force-dynamic";
+// ISR: serve the assembled rounds index from the edge cache, revalidating in the
+// background. It was force-dynamic, re-scanning the catalog on every open (slow).
+export const revalidate = 60;
 
 export const metadata = {
   title: "Model Bake Off — Katagami",

--- a/ui/src/app/api/file/[id]/route.ts
+++ b/ui/src/app/api/file/[id]/route.ts
@@ -61,6 +61,12 @@ const GENERIC_CONTENT_TYPES = new Set([
   "application/binary",
   "application/unknown",
   "*/*",
+  // Explicitly download-forcing mimes some uploads carry — sniff these too so a
+  // mis-mimed embodiment/landing renders inline instead of downloading.
+  "application/x-download",
+  "application/force-download",
+  "application/download",
+  "application/x-msdownload",
 ]);
 
 // Sniff a real content type from the bytes when the stored mime is generic.

--- a/ui/src/lib/bakeoff.ts
+++ b/ui/src/lib/bakeoff.ts
@@ -6,6 +6,7 @@
 // quiz/score/details experience is identical — only the data source changed,
 // from a static manifest to the live commons.
 
+import { unstable_cache } from "next/cache";
 import {
   listDirections,
   getDirection,
@@ -252,7 +253,7 @@ function roundTitle(
 }
 
 /** All bake-off rounds that actually have submissions, newest first. */
-export async function listBakeoffRounds(): Promise<BakeoffRoundSummary[]> {
+async function buildBakeoffRounds(): Promise<BakeoffRoundSummary[]> {
   let dirs: Direction[];
   try {
     dirs = (await listDirections()).filter(isBakeoff);
@@ -283,8 +284,17 @@ export async function listBakeoffRounds(): Promise<BakeoffRoundSummary[]> {
     .sort((a, b) => b.id.localeCompare(a.id)); // uuid-v7 ids sort by creation time
 }
 
+// Cache the assembled summaries — building them scans the catalog per round, so
+// it must not re-run on every request. Small payload (ids/titles/counts/source),
+// well under the Data Cache entry cap. Revalidate-window matches the rest of the app.
+export const listBakeoffRounds = unstable_cache(
+  buildBakeoffRounds,
+  ["bakeoff-rounds-v1"],
+  { revalidate: 60 },
+);
+
 /** One round, shaped for the game component. null if not a bake-off / no entries. */
-export async function getBakeoffRound(id: string): Promise<LabComparison | null> {
+async function buildBakeoffRound(id: string): Promise<LabComparison | null> {
   let dir: Direction;
   try {
     dir = await getDirection(id);
@@ -325,3 +335,10 @@ export async function getBakeoffRound(id: string): Promise<LabComparison | null>
     judged: dir.status === "Closed",
   };
 }
+
+// Cache per round id — the round's metadata + preview URLs are small + stable.
+export const getBakeoffRound = unstable_cache(
+  buildBakeoffRound,
+  ["bakeoff-round-v1"],
+  { revalidate: 60 },
+);

--- a/ui/src/lib/nav.ts
+++ b/ui/src/lib/nav.ts
@@ -11,9 +11,9 @@ export const NAV_LINKS: NavLink[] = [
   { href: "/palettes", label: "Palettes" },
   { href: "/art-styles", label: "Art Styles" },
   { href: "/studio", label: "Studio" },
-  { href: "/lineage", label: "Lineage" },
-  { href: "/compare", label: "Compare" },
   { href: "/model-bake-off", label: "Bake-off" },
+  // Lineage + Compare are hidden from the menu for now (routes still work via
+  // direct URL); re-add here when they're ready to surface again.
 ];
 
 /** Is `href` the active section for the current pathname? */


### PR DESCRIPTION
Diagnosed with a parallel investigation workflow + adversarial verification.

## Download bug (clicking a preview downloads a file)
**Already fixed for the reported case by #89** — the verifier refuted the `type="button"`/`<form>` theory (there is no `<form>`). The real cause: bake-off embodiment HTML was stored with a generic `octet-stream` mime; the old `/api/file` route forwarded it with no disposition → the browser downloaded it. #89's route now sniffs → `text/html` + forces `Content-Disposition: inline` (verified live). **Hardened further** here: explicit download-forcing mimes (`application/x-download`, etc.) are treated as generic too, so a mis-mimed embodiment can never force a download.

## Perf (slow load — all rounds + a specific round)
Both pages were `force-dynamic`, re-scanning the whole catalog on every open (`direction_id` filter isn't honored server-side — ARN-97 — so it returns + re-filters the catalog), and a round mounted ~12 full embodiment iframes at once.
- `listBakeoffRounds` + `getBakeoffRound` → `unstable_cache` (small payloads).
- `/model-bake-off` + `/lab/[slug]` → ISR (`revalidate: 60`).
- Preview iframes **lazy-mount** (IntersectionObserver) — no dozen-document load up front.

## Nav
Hide **Lineage** + **Compare** from the menu + ⌘K for now (routes still work via URL).

Build/tsc/eslint ✓. Follow-up (next): the "scroll the full result inline / mobile images" bake-off UX.