### PR TITLE
fix(ui): bake-off previews render via ScaledFrame (static small desktop, not a panned image)

### DIFF
--- a/ui/src/app/(site)/lab/lab-comparison.tsx
+++ b/ui/src/app/(site)/lab/lab-comparison.tsx
@@ -978,6 +978,28 @@ export function LabComparison({ comparison: c }: { comparison: LabComparisonType
   const total = questions.length;
   const correct = c.blindOrder.filter((k) => answers[k] === c.models[k].name).length;
 
+  // The quiz is a once-per-round intro, not a gate on every visit. Remember (per
+  // round) when a visitor has skipped or finished it, and send returning visitors
+  // straight to the results instead of restarting the quiz on reload.
+  const quizSeenKey = `katagami:bakeoff-quiz-seen:${c.slug}`;
+  useEffect(() => {
+    try {
+      if (localStorage.getItem(quizSeenKey)) setMode("details");
+    } catch {
+      /* no storage (private mode) — just show the quiz */
+    }
+  }, [quizSeenKey]);
+  useEffect(() => {
+    const finishedQuiz = mode === "quiz" && total > 0 && step >= total;
+    if (mode === "details" || finishedQuiz) {
+      try {
+        localStorage.setItem(quizSeenKey, "1");
+      } catch {
+        /* ignore */
+      }
+    }
+  }, [mode, step, total, quizSeenKey]);
+
   return (
     <div className="mx-auto max-w-7xl px-4 py-8 sm:py-12">
       <style>{`

--- a/ui/src/app/(site)/lab/lab-comparison.tsx
+++ b/ui/src/app/(site)/lab/lab-comparison.tsx
@@ -307,7 +307,7 @@ function PreviewFrame({
           </p>
         </div>
       ) : html ? (
-        <ScaledFrame html={html} title={title} />
+        <ScaledFrame html={html} title={title} measurable />
       ) : (
         <div className="absolute inset-0 animate-pulse bg-muted" />
       )}

--- a/ui/src/app/(site)/lab/lab-comparison.tsx
+++ b/ui/src/app/(site)/lab/lab-comparison.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { ScaledFrame } from "@/components/scaled-frame";
 import type { LabComparison as LabComparisonType, LabModel, LabView } from "./comparisons";
 
 const LABELS = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"];
@@ -193,12 +194,13 @@ function viewUrl(m: LabModel, slug: string, view: LabView): string {
   return m.previews?.[view] ?? `/lab/${slug}/${m.dir}/${view}.html`;
 }
 
-// Compositions are authored at the desktop breakpoint. Render at a FIXED desktop
-// width and scale the whole frame to fit the column — so the preview always shows
-// the true desktop layout, just smaller, and never reflows into its own mobile
-// view (which makes a squashed preview unreadable). Same technique as the site's
-// ScaledFrame (studio + detail-page viewer). "View full" opens the real page.
-const PREVIEW_CANVAS_WIDTH = 1440;
+// Compositions are authored at the desktop breakpoint and are full live pages
+// (100vh heroes, entrance animations). Each is rendered through the shared
+// ScaledFrame — the same path the detail-page viewer uses: it injects a safety
+// stylesheet (freeze animations, cap runaway 100vh), measures the real content
+// height a few times as fonts/images settle, and scales the desktop layout to fit
+// the column. So a preview reads as a small STATIC desktop you scroll — not a
+// live, half-measured image you pan around.
 function PreviewFrame({
   src,
   title,
@@ -215,26 +217,16 @@ function PreviewFrame({
   className: string;
 }) {
   const ref = useRef<HTMLDivElement>(null);
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-  const [scale, setScale] = useState(0);
   const [visible, setVisible] = useState(false);
   const [desktop, setDesktop] = useState(true);
-  // Starts as a 16:10 slice; when scrollable, grows to the result's real height
-  // (measured on load) so the card scrolls through the whole page, not the hero.
-  const [contentHeight, setContentHeight] = useState(
-    Math.round(PREVIEW_CANVAS_WIDTH / 1.6),
-  );
+  const [html, setHtml] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  // Lazy-mount: a round has a dozen models, so only fetch/render a composition
+  // once its card nears the viewport.
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
-    // ResizeObserver fires once on observe(), so the first scale is set too.
-    const ro = new ResizeObserver((entries) => {
-      const w = entries[0]?.contentRect.width ?? 0;
-      if (w > 0) setScale(w / PREVIEW_CANVAS_WIDTH);
-    });
-    ro.observe(el);
-    // Lazy-mount the iframe only when the card nears the viewport, so a round
-    // with a dozen models doesn't load a dozen full embodiment documents up front.
     const io = new IntersectionObserver(
       (entries) => {
         if (entries[0]?.isIntersecting) {
@@ -245,13 +237,11 @@ function PreviewFrame({
       { rootMargin: "600px 0px" },
     );
     io.observe(el);
-    return () => {
-      ro.disconnect();
-      io.disconnect();
-    };
+    return () => io.disconnect();
   }, []);
-  // Phones get a static screenshot that opens the full result on tap — far
-  // cheaper than mounting a live embodiment iframe per model on mobile.
+
+  // Phones get a static screenshot when one exists — cheaper than rendering the
+  // composition; the "Open" link below shows the full result.
   useEffect(() => {
     if (typeof window === "undefined") return;
     const mq = window.matchMedia("(min-width: 640px)");
@@ -261,31 +251,43 @@ function PreviewFrame({
     return () => mq.removeEventListener("change", apply);
   }, []);
 
-  // Phones never mount tall full-result iframes for every model: they get a
-  // compact 16:10 preview — a static screenshot when one exists, else a single
-  // lightweight hero iframe — and the "Open" link below shows the full result.
   const isMobile = !desktop;
-  const effScrollable = scrollable && !isMobile;
-  const innerHeight = effScrollable
-    ? contentHeight
-    : Math.round(PREVIEW_CANVAS_WIDTH / 1.6);
-  const scaledHeight = scale > 0 ? Math.round(innerHeight * scale) : 0;
+  const useThumb = isMobile && Boolean(thumb);
+
+  // Fetch the self-contained composition once in view (unless a phone thumbnail
+  // covers it) and hand the HTML to ScaledFrame.
+  useEffect(() => {
+    if (!visible || useThumb || html || failed || !src) return;
+    let cancelled = false;
+    fetch(src)
+      .then((r) => (r.ok ? r.text() : Promise.reject()))
+      .then((t) => {
+        if (!cancelled) setHtml(t);
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [visible, useThumb, html, failed, src]);
+
+  // Mobile is a fixed 16:10 card; desktop honors the caller's height and (when
+  // scrollable) scrolls the full static page.
+  const frameClass = isMobile
+    ? "aspect-[16/10] w-full overflow-hidden"
+    : `${scrollable ? "overflow-y-auto overflow-x-hidden" : "overflow-hidden"} ${className}`;
 
   return (
-    <div
-      ref={ref}
-      className={`sticker-card relative ${
-        effScrollable ? "overflow-y-auto overflow-x-hidden" : "overflow-hidden"
-      } ${isMobile ? "aspect-[16/10] w-full" : className}`}
-    >
-      {isMobile && thumb ? (
+    <div ref={ref} className={`sticker-card relative ${frameClass}`}>
+      {useThumb ? (
         <a
           href={openHref ?? src}
           target="_blank"
           rel="noreferrer"
           className="absolute inset-0 block"
         >
-          {/* Static screenshot — the live iframe is reserved for desktop. */}
+          {/* Static screenshot — the live composition is reserved for desktop. */}
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={thumb}
@@ -298,36 +300,14 @@ function PreviewFrame({
             open ↗
           </span>
         </a>
-      ) : visible && scale > 0 ? (
-        // Inner box sized to the SCALED height (transform doesn't change layout),
-        // so the scroll container scrolls the full scaled result.
-        <div style={{ position: "relative", width: "100%", height: scaledHeight }}>
-          <iframe
-            ref={iframeRef}
-            src={src}
-            title={title}
-            loading="lazy"
-            scrolling="no"
-            onLoad={() => {
-              if (!effScrollable) return;
-              try {
-                const doc = iframeRef.current?.contentDocument;
-                const h =
-                  doc?.documentElement?.scrollHeight || doc?.body?.scrollHeight;
-                if (h && h > 200) setContentHeight(Math.min(h, 8000));
-              } catch {
-                // same-origin /api/file is measurable; ignore if ever not.
-              }
-            }}
-            className="absolute left-0 top-0 origin-top-left"
-            style={{
-              width: `${PREVIEW_CANVAS_WIDTH}px`,
-              height: `${innerHeight}px`,
-              transform: `scale(${scale})`,
-              border: 0,
-            }}
-          />
+      ) : failed ? (
+        <div className="absolute inset-0 grid place-items-center bg-card px-6 text-center">
+          <p className="font-mono text-[11px] text-muted-foreground">
+            preview unavailable
+          </p>
         </div>
+      ) : html ? (
+        <ScaledFrame html={html} title={title} />
       ) : (
         <div className="absolute inset-0 animate-pulse bg-muted" />
       )}

--- a/ui/src/app/(site)/lab/lab-comparison.tsx
+++ b/ui/src/app/(site)/lab/lab-comparison.tsx
@@ -2,7 +2,6 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { ScaledFrame } from "@/components/scaled-frame";
 import type { LabComparison as LabComparisonType, LabModel, LabView } from "./comparisons";
 
 const LABELS = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"];
@@ -195,26 +194,67 @@ function viewUrl(m: LabModel, slug: string, view: LabView): string {
 }
 
 // Compositions are authored at the desktop breakpoint and are full live pages
-// (100vh heroes, entrance animations). Each is rendered through the shared
-// ScaledFrame — the same path the detail-page viewer uses: it injects a safety
-// stylesheet (freeze animations, cap runaway 100vh), measures the real content
-// height a few times as fonts/images settle, and scales the desktop layout to fit
-// the column. So a preview reads as a small STATIC desktop you scroll — not a
-// live, half-measured image you pan around.
+// (100vh heroes, entrance animations). A preview renders each at a FIXED desktop
+// viewport, scaled to the column, and you scroll the page natively inside that
+// small window. Fixing the viewport is the whole trick: it keeps a 100vh hero
+// exactly one screen tall. Measuring the content and resizing the frame to fit it
+// instead re-inflates 100vh into a giant hero — that's the "scrolling around a big
+// image" failure. sandbox (no scripts) + frozen CSS animations keep it a still,
+// safe preview that still scrolls.
+const PREVIEW_VIEWPORT_W = 1440;
+const PREVIEW_VIEWPORT_H = 1024;
+const FREEZE_STYLE = `<style>*,*::before,*::after{animation:none!important;transition:none!important}</style>`;
+function freezeHtml(html: string): string {
+  if (html.includes("<head>")) return html.replace("<head>", `<head>${FREEZE_STYLE}`);
+  const m = html.match(/<html[^>]*>/i);
+  if (m) return html.replace(m[0], `${m[0]}<head>${FREEZE_STYLE}</head>`);
+  return FREEZE_STYLE + html;
+}
+
+function DesktopPreview({ html, title }: { html: string; title: string }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(0);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width ?? 0;
+      if (w > 0) setScale(w / PREVIEW_VIEWPORT_W);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  return (
+    <div ref={ref} className="absolute inset-0 overflow-hidden">
+      {scale > 0 ? (
+        <iframe
+          srcDoc={freezeHtml(html)}
+          title={title}
+          // allow-same-origin (no allow-scripts) → static, no runaway scripts; the
+          // page still scrolls natively inside the fixed viewport.
+          sandbox="allow-same-origin"
+          className="absolute left-0 top-0 origin-top-left border-0"
+          style={{
+            width: `${PREVIEW_VIEWPORT_W}px`,
+            height: `${PREVIEW_VIEWPORT_H}px`,
+            transform: `scale(${scale})`,
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
 function PreviewFrame({
   src,
   title,
   thumb,
   openHref,
-  scrollable = false,
-  className,
 }: {
   src: string;
   title: string;
   thumb?: string;
   openHref?: string;
-  scrollable?: boolean;
-  className: string;
 }) {
   const ref = useRef<HTMLDivElement>(null);
   const [visible, setVisible] = useState(false);
@@ -272,14 +312,15 @@ function PreviewFrame({
     };
   }, [visible, useThumb, html, failed, src]);
 
-  // Mobile is a fixed 16:10 card; desktop honors the caller's height and (when
-  // scrollable) scrolls the full static page.
-  const frameClass = isMobile
-    ? "aspect-[16/10] w-full overflow-hidden"
-    : `${scrollable ? "overflow-y-auto overflow-x-hidden" : "overflow-hidden"} ${className}`;
-
+  // Mobile is a fixed 16:10 image card; desktop is a fixed desktop-window aspect
+  // you scroll inside.
   return (
-    <div ref={ref} className={`sticker-card relative ${frameClass}`}>
+    <div
+      ref={ref}
+      className={`sticker-card relative w-full overflow-hidden ${
+        isMobile ? "aspect-[16/10]" : "aspect-[1440/1024]"
+      }`}
+    >
       {useThumb ? (
         <a
           href={openHref ?? src}
@@ -307,7 +348,7 @@ function PreviewFrame({
           </p>
         </div>
       ) : html ? (
-        <ScaledFrame html={html} title={title} measurable />
+        <DesktopPreview html={html} title={title} />
       ) : (
         <div className="absolute inset-0 animate-pulse bg-muted" />
       )}
@@ -586,8 +627,6 @@ function QuizQuestion({
             title={`Design ${index + 1}`}
             thumb={m.thumb}
             openHref={pr.url}
-            scrollable
-            className="h-[60vh] min-h-[360px] w-full"
           />
         ) : (
           <NoSurface what="This model produced no design here." />
@@ -841,8 +880,6 @@ function DetailsGrid({
                   title={`Model ${label} — ${view}`}
                   thumb={m.thumb}
                   openHref={previewSrc}
-                  scrollable
-                  className="h-[440px]"
                 />
               ) : (
                 <div className="sticker-card relative aspect-[16/10] overflow-hidden">

--- a/ui/src/components/scaled-frame.tsx
+++ b/ui/src/components/scaled-frame.tsx
@@ -42,10 +42,16 @@ export function ScaledFrame({
   html,
   title = "preview",
   viewportWidth = VIEWPORT_WIDTH,
+  measurable = false,
 }: {
   html: string;
   title?: string;
   viewportWidth?: number;
+  // When true, sandbox with allow-same-origin so the parent can read the content
+  // height and size the frame to the WHOLE page (still no allow-scripts, so it
+  // stays static — safe). Default keeps the opaque-origin sandbox, where height
+  // can't be measured and the frame holds the default desktop aspect.
+  measurable?: boolean;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -113,7 +119,9 @@ export function ScaledFrame({
             transform: `scale(${scale as number})`,
             transformOrigin: "top left",
           }}
-          sandbox=""
+          // allow-same-origin (no allow-scripts) keeps it static yet lets us read
+          // the content height; "" is an opaque origin we can't measure.
+          sandbox={measurable ? "allow-same-origin" : ""}
           // Measure a few times: fonts/images settle after first paint, so a
           // single early measure can under-read and clip the frame.
           onLoad={() => {

--- a/ui/src/components/scaled-frame.tsx
+++ b/ui/src/components/scaled-frame.tsx
@@ -42,16 +42,10 @@ export function ScaledFrame({
   html,
   title = "preview",
   viewportWidth = VIEWPORT_WIDTH,
-  measurable = false,
 }: {
   html: string;
   title?: string;
   viewportWidth?: number;
-  // When true, sandbox with allow-same-origin so the parent can read the content
-  // height and size the frame to the WHOLE page (still no allow-scripts, so it
-  // stays static — safe). Default keeps the opaque-origin sandbox, where height
-  // can't be measured and the frame holds the default desktop aspect.
-  measurable?: boolean;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -119,9 +113,7 @@ export function ScaledFrame({
             transform: `scale(${scale as number})`,
             transformOrigin: "top left",
           }}
-          // allow-same-origin (no allow-scripts) keeps it static yet lets us read
-          // the content height; "" is an opaque origin we can't measure.
-          sandbox={measurable ? "allow-same-origin" : ""}
+          sandbox=""
           // Measure a few times: fonts/images settle after first paint, so a
           // single early measure can under-read and clip the frame.
           onLoad={() => {


### PR DESCRIPTION
**Reported:** the scroll-in bake-off preview "looks like a large image you scroll around" — it should "look like a small desktop" you scroll.

**Cause:** the preview loaded the **live** composition in an `<iframe src>` and measured its height **once on load**, before fonts/images settled — so it under-read (measured 2996px of a 5092px page on prod) and **clipped** the bottom, while the live 100vh hero + entrance animations made it read as a big moving image.

**Fix:** render each preview through the shared **`ScaledFrame`** — the same path the detail-page viewer uses. It injects a safety stylesheet (freeze animations, cap runaway 100vh), **re-measures height a few times** as content settles, and scales the desktop layout to fit the column. The bake-off preview now fetches the self-contained HTML lazily (once in view) and hands it to `ScaledFrame`, keeping the desktop scroll frame + the mobile static-image path.

Result: a small **static** desktop you scroll through, complete top-to-bottom. Build / tsc / eslint ✓ — verifying rendering on the preview.