### PR TITLE
feat(ui): Under Review page — browse the curation queue across all categories

### DIFF
--- a/ui/scripts/check-gallery-renders-all-cards.mjs
+++ b/ui/scripts/check-gallery-renders-all-cards.mjs
@@ -16,6 +16,9 @@ const palettesPageSource = readProjectFile("src/app/(site)/palettes/page.tsx");
 const paletteDetailSource = readProjectFile("src/app/(site)/palettes/[id]/page.tsx");
 const artStylesPageSource = readProjectFile("src/app/(site)/art-styles/page.tsx");
 const artStyleDetailSource = readProjectFile("src/app/(site)/art-styles/[id]/page.tsx");
+// Shared row->item mappers the catalog pages consume; they apply the display-name
+// helper on behalf of the pages (palettes/art-styles + the Under Review queue).
+const laneItemsSource = readProjectFile("src/lib/lane-items.ts");
 const remixOptionsSource = readProjectFile("src/lib/remix-options.ts");
 const ownerPageSource = readProjectFile("src/app/(site)/owner/page.tsx");
 const sendToReviewSource = readProjectFile("src/components/send-to-review-language-button.tsx");
@@ -242,7 +245,13 @@ if (!/export function paletteDisplayName/.test(odataSource)) {
   });
 }
 
-if (!/paletteDisplayName/.test(palettesPageSource) || !/paletteDisplayName/.test(paletteDetailSource)) {
+// The page may use the helper directly, or via the shared toPaletteItem mapper
+// (which applies it) — either way the display name comes from the one helper.
+const palettePageUsesHelper =
+  /paletteDisplayName/.test(palettesPageSource) ||
+  (/toPaletteItem/.test(palettesPageSource) &&
+    /paletteDisplayName/.test(laneItemsSource));
+if (!palettePageUsesHelper || !/paletteDisplayName/.test(paletteDetailSource)) {
   violations.push({
     label: "palette catalog/detail pages do not use the shared display-name helper",
   });
@@ -254,7 +263,11 @@ if (!/export function artStyleDisplayName/.test(odataSource)) {
   });
 }
 
-if (!/artStyleDisplayName/.test(artStylesPageSource) || !/artStyleDisplayName/.test(artStyleDetailSource)) {
+const artStylePageUsesHelper =
+  /artStyleDisplayName/.test(artStylesPageSource) ||
+  (/toArtStyleItem/.test(artStylesPageSource) &&
+    /artStyleDisplayName/.test(laneItemsSource));
+if (!artStylePageUsesHelper || !/artStyleDisplayName/.test(artStyleDetailSource)) {
   violations.push({
     label: "art-style catalog/detail pages do not use the shared display-name helper",
   });

--- a/ui/src/app/(site)/art-styles/page.tsx
+++ b/ui/src/app/(site)/art-styles/page.tsx
@@ -1,10 +1,5 @@
-import {
-  artStyleDisplayName,
-  getFileUrl,
-  listArtStyles,
-  parseJson,
-  taxonomyFamilyIndex,
-} from "@/lib/odata";
+import { listArtStyles, taxonomyFamilyIndex } from "@/lib/odata";
+import { toArtStyleItem } from "@/lib/lane-items";
 import { PageHero, Marker, HeroStat } from "@/components/page-hero";
 import { ArtStyleCatalog } from "@/components/lane-catalog";
 import type { ArtStyleItem } from "@/components/art-style-card";
@@ -15,29 +10,6 @@ export const metadata = {
   title: "Art Styles — Katagami",
   description: "Engine-agnostic art-style recipes: reference images + portable prompts.",
 };
-
-function refUrls(raw?: string): string[] {
-  const ids = parseJson<string[]>(raw);
-  return Array.isArray(ids) ? ids.map((id) => getFileUrl(id)) : [];
-}
-
-// Build image URLs from the governed File ids -> /api/file proxy (reliable for
-// every style). We DON'T use reference_assets VALUES: some are assets.katagami.ai
-// CDN urls whose publish never completed (404). And reference_image_file_ids is
-// guard-limited to one id on some styles. So collect file ids from the manifest
-// (full set), the reference_assets KEYS (which are file ids), and the id field.
-function refImageUrls(fields: Record<string, string | undefined>): string[] {
-  const ids: string[] = [];
-  const add = (id: unknown) => {
-    if (typeof id === "string" && id.startsWith("fl-") && !ids.includes(id)) ids.push(id);
-  };
-  const manifest = parseJson<{ items?: Array<{ file?: string }>; references?: Array<{ file?: string }> }>(fields.reference_manifest);
-  (manifest?.items ?? manifest?.references ?? []).forEach((it) => add(it?.file));
-  const assets = parseJson<Record<string, unknown>>(fields.reference_assets);
-  if (assets && typeof assets === "object" && !Array.isArray(assets)) Object.keys(assets).forEach(add);
-  (parseJson<string[]>(fields.reference_image_file_ids) ?? []).forEach(add);
-  return ids.map((id) => getFileUrl(id));
-}
 
 export default async function ArtStylesPage() {
   // Published-only everywhere — draft/archived art styles never appear in the
@@ -51,19 +23,7 @@ export default async function ArtStylesPage() {
   const categoryNames: Record<string, string> = {};
   for (const [id, info] of taxFamily) categoryNames[id] = info.name;
   const items: ArtStyleItem[] = rows
-    .map((r) => ({
-      id: r.entity_id,
-      name: artStyleDisplayName(r.fields),
-      slug: r.fields.slug ?? "",
-      status: r.status,
-      medium: r.fields.medium ?? "",
-      promptTemplate: r.fields.prompt_template ?? "",
-      refs: refImageUrls(r.fields),
-      proofs: refUrls(r.fields.proof_shots_file_ids),
-      thumb: r.fields.thumbnail_file_id ? getFileUrl(r.fields.thumbnail_file_id) : "",
-      tags: parseJson<string[]>(r.fields.tags) ?? [],
-      taxonomyIds: parseJson<string[]>(r.fields.taxonomy_ids) ?? [],
-    }))
+    .map(toArtStyleItem)
     // Keep archived items last so they never crowd the live catalog.
     .sort((a, b) => Number(a.status === "Archived") - Number(b.status === "Archived"));
 

--- a/ui/src/app/(site)/layout.tsx
+++ b/ui/src/app/(site)/layout.tsx
@@ -101,6 +101,7 @@ const buildSearchIndex = unstable_cache(
     { name: "Studio", href: "/studio" },
     { name: "Taxonomy", href: "/taxonomy" },
     { name: "Model bake-off", href: "/model-bake-off" },
+    { name: "Under Review", href: "/under-review" },
     // Lineage + Compare hidden for now (see lib/nav.ts).
   ]) {
     items.push({

--- a/ui/src/app/(site)/palettes/page.tsx
+++ b/ui/src/app/(site)/palettes/page.tsx
@@ -1,11 +1,5 @@
-import {
-  listPaletteSystems,
-  paletteCore,
-  paletteDisplayName,
-  paletteRoles,
-  parseJson,
-  taxonomyFamilyIndex,
-} from "@/lib/odata";
+import { listPaletteSystems, taxonomyFamilyIndex } from "@/lib/odata";
+import { toPaletteItem } from "@/lib/lane-items";
 import { PageHero, Marker, HeroStat } from "@/components/page-hero";
 import { PaletteCatalog } from "@/components/lane-catalog";
 import type { PaletteItem } from "@/components/palette-card";
@@ -29,21 +23,7 @@ export default async function PalettesPage() {
   const categoryNames: Record<string, string> = {};
   for (const [id, info] of taxFamily) categoryNames[id] = info.name;
   const items: PaletteItem[] = rows
-    .map((r) => {
-      const core = paletteCore(r.fields);
-      return {
-        id: r.entity_id,
-        name: paletteDisplayName(r.fields, core),
-        slug: r.fields.slug ?? "",
-        status: r.status,
-        roles: paletteRoles(r.fields),
-        core,
-        ramps: parseJson<Record<string, Record<string, string>>>(r.fields.ramps) ?? {},
-        tags: parseJson<string[]>(r.fields.tags) ?? [],
-        featured: /^(true|1)$/i.test(String(r.fields.featured ?? "")),
-        taxonomyIds: parseJson<string[]>(r.fields.taxonomy_ids) ?? [],
-      };
-    })
+    .map(toPaletteItem)
     // Keep archived items last so they never crowd the live catalog.
     .sort((a, b) => Number(a.status === "Archived") - Number(b.status === "Archived"));
 

--- a/ui/src/app/(site)/under-review/page.tsx
+++ b/ui/src/app/(site)/under-review/page.tsx
@@ -1,0 +1,159 @@
+import {
+  listArtStyles,
+  listDesignLanguages,
+  listPaletteSystems,
+  taxonomyFamilyIndex,
+} from "@/lib/odata";
+import { toArtStyleItem, toPaletteItem } from "@/lib/lane-items";
+import { ArtStyleCatalog, PaletteCatalog } from "@/components/lane-catalog";
+import { LanguageCard } from "@/components/language-card";
+import { PageHero, Marker, HeroStat } from "@/components/page-hero";
+import { isOwner } from "@/lib/owner";
+
+export const dynamic = "force-dynamic";
+export const metadata = {
+  title: "Under Review — Katagami",
+  description:
+    "Submissions awaiting curation — design languages, palettes, and art styles in the queue, separate from the published catalog.",
+};
+
+const UNDER_REVIEW = "Status eq 'UnderReview'";
+
+function SectionHeading({
+  label,
+  count,
+  accent,
+}: {
+  label: string;
+  count: number;
+  accent: string;
+}) {
+  return (
+    <div className="flex flex-wrap items-baseline gap-3">
+      <h2 className="font-display text-[24px] font-bold leading-none tracking-[-0.02em]">
+        {label}
+      </h2>
+      <span className="font-mono text-[12px] uppercase tracking-[0.16em] text-muted-foreground">
+        <span
+          className="font-bold tabular-nums"
+          style={{ color: `var(--${accent})` }}
+        >
+          {count}
+        </span>{" "}
+        in review
+      </span>
+    </div>
+  );
+}
+
+function NoneYet({ what }: { what: string }) {
+  return (
+    <p className="font-mono text-[12px] uppercase tracking-[0.14em] text-muted-foreground">
+      No {what} under review.
+    </p>
+  );
+}
+
+export default async function UnderReviewPage() {
+  // UnderReview-only — the published catalog lives on the gallery pages; this is
+  // the curation queue, kept deliberately separate so the two never mix.
+  const owner = await isOwner();
+  const [languages, paletteRows, artRows, taxFamily] = await Promise.all([
+    listDesignLanguages(UNDER_REVIEW).catch(() => []),
+    listPaletteSystems(UNDER_REVIEW).catch(() => []),
+    listArtStyles(UNDER_REVIEW).catch(() => []),
+    taxonomyFamilyIndex().catch(
+      () => new Map<string, { name: string; parentId: string }>(),
+    ),
+  ]);
+  const categoryNames: Record<string, string> = {};
+  for (const [id, info] of taxFamily) categoryNames[id] = info.name;
+
+  const langs = languages.filter((l) => l.fields.name);
+  const palettes = paletteRows.map(toPaletteItem);
+  const artStyles = artRows.map(toArtStyleItem);
+  const total = langs.length + palettes.length + artStyles.length;
+
+  return (
+    <div className="mx-auto w-full max-w-7xl px-4 py-6 sm:py-10">
+      <PageHero
+        eyebrow="Curation queue"
+        eyebrowAccent="yuzu"
+        title={
+          <>
+            Under <Marker color="yuzu">review</Marker>
+          </>
+        }
+        description="Submissions awaiting a curator — across design languages, palettes, and art styles. These aren't published yet; they're shown here, separate from the live catalog, so you can see everything in the queue at once."
+        rightSlot={<HeroStat value={total} label="in review" accent="yuzu" />}
+      />
+
+      {total === 0 ? (
+        <div className="sticker-card mx-auto mt-10 max-w-md p-8 text-center text-sm text-muted-foreground">
+          Nothing is under review right now.
+          <div className="mt-1 font-mono text-[11px]">
+            new submissions land here first
+          </div>
+        </div>
+      ) : (
+        <div className="mt-10 space-y-16">
+          <section className="space-y-5">
+            <SectionHeading
+              label="Design languages"
+              count={langs.length}
+              accent="matcha"
+            />
+            {langs.length ? (
+              <div className="grid gap-7 sm:grid-cols-2 lg:grid-cols-3">
+                {langs.map((l, i) => (
+                  <LanguageCard
+                    key={l.entity_id}
+                    lang={l}
+                    index={i}
+                    canDelete={owner}
+                  />
+                ))}
+              </div>
+            ) : (
+              <NoneYet what="design languages" />
+            )}
+          </section>
+
+          <section className="space-y-5">
+            <SectionHeading
+              label="Palettes"
+              count={palettes.length}
+              accent="ramune"
+            />
+            {palettes.length ? (
+              <PaletteCatalog
+                items={palettes}
+                canArchive={owner}
+                categoryNames={categoryNames}
+              />
+            ) : (
+              <NoneYet what="palettes" />
+            )}
+          </section>
+
+          <section className="space-y-5">
+            <SectionHeading
+              label="Art styles"
+              count={artStyles.length}
+              accent="sakura"
+            />
+            {artStyles.length ? (
+              <ArtStyleCatalog
+                items={artStyles}
+                canArchive={owner}
+                categoryNames={categoryNames}
+              />
+            ) : (
+              <NoneYet what="art styles" />
+            )}
+          </section>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/lib/lane-items.ts
+++ b/ui/src/lib/lane-items.ts
@@ -1,0 +1,79 @@
+import {
+  artStyleDisplayName,
+  getFileUrl,
+  paletteCore,
+  paletteDisplayName,
+  paletteRoles,
+  parseJson,
+  type LaneEntity,
+} from "@/lib/odata";
+import type { PaletteItem } from "@/components/palette-card";
+import type { ArtStyleItem } from "@/components/art-style-card";
+
+// Row -> card-item mappings shared by the palette/art-style galleries and the
+// Under Review queue, so the two never drift.
+
+/** A PaletteSystem row -> the item the palette catalog renders. */
+export function toPaletteItem(r: LaneEntity): PaletteItem {
+  const core = paletteCore(r.fields);
+  return {
+    id: r.entity_id,
+    name: paletteDisplayName(r.fields, core),
+    slug: r.fields.slug ?? "",
+    status: r.status,
+    roles: paletteRoles(r.fields),
+    core,
+    ramps:
+      parseJson<Record<string, Record<string, string>>>(r.fields.ramps) ?? {},
+    tags: parseJson<string[]>(r.fields.tags) ?? [],
+    featured: /^(true|1)$/i.test(String(r.fields.featured ?? "")),
+    taxonomyIds: parseJson<string[]>(r.fields.taxonomy_ids) ?? [],
+  };
+}
+
+function refUrls(raw?: string): string[] {
+  const ids = parseJson<string[]>(raw);
+  return Array.isArray(ids) ? ids.map((id) => getFileUrl(id)) : [];
+}
+
+// Build image URLs from the governed File ids -> /api/file proxy. We DON'T use
+// reference_assets VALUES (some are failed-publish CDN urls that 404), and
+// reference_image_file_ids is guard-limited to one id on some styles — so collect
+// file ids from the manifest (full set), the reference_assets KEYS (file ids),
+// and the id field.
+function refImageUrls(fields: Record<string, string | undefined>): string[] {
+  const ids: string[] = [];
+  const add = (id: unknown) => {
+    if (typeof id === "string" && id.startsWith("fl-") && !ids.includes(id))
+      ids.push(id);
+  };
+  const manifest = parseJson<{
+    items?: Array<{ file?: string }>;
+    references?: Array<{ file?: string }>;
+  }>(fields.reference_manifest);
+  (manifest?.items ?? manifest?.references ?? []).forEach((it) => add(it?.file));
+  const assets = parseJson<Record<string, unknown>>(fields.reference_assets);
+  if (assets && typeof assets === "object" && !Array.isArray(assets))
+    Object.keys(assets).forEach(add);
+  (parseJson<string[]>(fields.reference_image_file_ids) ?? []).forEach(add);
+  return ids.map((id) => getFileUrl(id));
+}
+
+/** An ArtStyle row -> the item the art-style catalog renders. */
+export function toArtStyleItem(r: LaneEntity): ArtStyleItem {
+  return {
+    id: r.entity_id,
+    name: artStyleDisplayName(r.fields),
+    slug: r.fields.slug ?? "",
+    status: r.status,
+    medium: r.fields.medium ?? "",
+    promptTemplate: r.fields.prompt_template ?? "",
+    refs: refImageUrls(r.fields),
+    proofs: refUrls(r.fields.proof_shots_file_ids),
+    thumb: r.fields.thumbnail_file_id
+      ? getFileUrl(r.fields.thumbnail_file_id)
+      : "",
+    tags: parseJson<string[]>(r.fields.tags) ?? [],
+    taxonomyIds: parseJson<string[]>(r.fields.taxonomy_ids) ?? [],
+  };
+}

--- a/ui/src/lib/nav.ts
+++ b/ui/src/lib/nav.ts
@@ -12,6 +12,7 @@ export const NAV_LINKS: NavLink[] = [
   { href: "/art-styles", label: "Art Styles" },
   { href: "/studio", label: "Studio" },
   { href: "/model-bake-off", label: "Bake-off" },
+  { href: "/under-review", label: "Under Review" },
   // Lineage + Compare are hidden from the menu for now (routes still work via
   // direct URL); re-add here when they're ready to surface again.
 ];


### PR DESCRIPTION
Submissions land **UnderReview** until a curator publishes them, but there was no way to see what's in the queue across categories.

## New
- **`/under-review`** (added to the nav + ⌘K): lists UnderReview **design languages, palettes, and art styles**, each in its own section, reusing the existing gallery cards/catalogs. Kept separate from the published catalog so the two never mix.
- Empty-state per section + a "nothing under review" state.

## Refactor (no duplication)
Extracted the palette/art-style row→item mapping into **`lib/lane-items.ts`**, now shared by the palette gallery, the art-style gallery, and this page (previously the mapping lived inline in each gallery page).

Build / tsc / eslint ✓.