### PR TITLE
feat(ui): bake-off — browse by model (everything one model made)

### DIFF
--- a/ui/src/app/(site)/lab/bakeoff-index.tsx
+++ b/ui/src/app/(site)/lab/bakeoff-index.tsx
@@ -1,11 +1,18 @@
 import Link from "next/link";
-import type { BakeoffRoundSummary } from "@/lib/bakeoff";
+import type { BakeoffModelEntry, BakeoffRoundSummary } from "@/lib/bakeoff";
 
 // The rounds index for the model bake-off. Each round is one Direction (a
 // reimagine brief) with its submitted Katagami languages; click through to play
 // the guess-the-model game over that round's entries. Katagami house style:
 // sharp sticker-cards, the trio ink strip, the source language as the visual.
-export function BakeoffIndex({ rounds }: { rounds: BakeoffRoundSummary[] }) {
+// `models` powers "browse by model" — everything one model made, across rounds.
+export function BakeoffIndex({
+  rounds,
+  models,
+}: {
+  rounds: BakeoffRoundSummary[];
+  models: BakeoffModelEntry[];
+}) {
   return (
     <div className="mx-auto max-w-7xl px-4 py-10 sm:py-14">
       <p className="font-mono text-[11px] font-bold uppercase tracking-[0.2em] text-[var(--sakura)]">
@@ -14,6 +21,30 @@ export function BakeoffIndex({ rounds }: { rounds: BakeoffRoundSummary[] }) {
       <h1 className="mt-3 font-display text-4xl font-black tracking-[-0.03em] sm:text-5xl">
         Model bake-offs
       </h1>
+
+      {models.length > 0 && (
+        <section className="mt-8">
+          <p className="font-mono text-[11px] font-bold uppercase tracking-[0.16em] text-muted-foreground">
+            Browse by model
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2.5">
+            {models.map((m) => (
+              <Link
+                key={m.slug}
+                href={`/model-bake-off/model/${m.slug}`}
+                className="group inline-flex items-baseline gap-2 bg-card px-3.5 py-2 shadow-[0_1px_0_#1e232d1f] transition-colors hover:bg-foreground hover:text-background"
+              >
+                <span className="font-display text-[15px] font-bold tracking-[-0.01em]">
+                  {m.name}
+                </span>
+                <span className="font-mono text-[11px] font-bold tabular-nums text-muted-foreground group-hover:text-background/70">
+                  {m.count}
+                </span>
+              </Link>
+            ))}
+          </div>
+        </section>
+      )}
 
       {rounds.length === 0 ? (
         <div

--- a/ui/src/app/(site)/lab/lab-comparison.tsx
+++ b/ui/src/app/(site)/lab/lab-comparison.tsx
@@ -253,7 +253,7 @@ function DesktopPreview({ html, title }: { html: string; title: string }) {
   );
 }
 
-function PreviewFrame({
+export function PreviewFrame({
   src,
   title,
   thumb,

--- a/ui/src/app/(site)/lab/page.tsx
+++ b/ui/src/app/(site)/lab/page.tsx
@@ -1,4 +1,4 @@
-import { listBakeoffRounds } from "@/lib/bakeoff";
+import { listBakeoffModels, listBakeoffRounds } from "@/lib/bakeoff";
 import { BakeoffIndex } from "./bakeoff-index";
 
 // Unlisted on purpose — not added to header-nav, mobile-nav, or the search
@@ -7,6 +7,9 @@ import { BakeoffIndex } from "./bakeoff-index";
 export const dynamic = "force-dynamic";
 
 export default async function LabIndex() {
-  const rounds = await listBakeoffRounds();
-  return <BakeoffIndex rounds={rounds} />;
+  const [rounds, models] = await Promise.all([
+    listBakeoffRounds(),
+    listBakeoffModels(),
+  ]);
+  return <BakeoffIndex rounds={rounds} models={models} />;
 }

--- a/ui/src/app/(site)/model-bake-off/model/[slug]/page.tsx
+++ b/ui/src/app/(site)/model-bake-off/model/[slug]/page.tsx
@@ -1,0 +1,176 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import {
+  getBakeoffModel,
+  type BakeoffModelSubmission,
+} from "@/lib/bakeoff";
+import { PreviewFrame } from "@/app/(site)/lab/lab-comparison";
+import { PageHero, Marker, HeroStat } from "@/components/page-hero";
+import type { LabView } from "@/app/(site)/lab/comparisons";
+
+export const revalidate = 60;
+
+const VIEW_ORDER: LabView[] = [
+  "landing",
+  "dashboard",
+  "embodiment",
+  "immersive",
+];
+
+function primaryPreview(
+  previews?: Partial<Record<LabView, string>>,
+): { url: string; view: LabView } | null {
+  if (!previews) return null;
+  for (const v of VIEW_ORDER) {
+    const url = previews[v];
+    if (url) return { url, view: v };
+  }
+  return null;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const model = await getBakeoffModel(slug);
+  return {
+    title: model
+      ? `${model.name} — Model Bake Off — Katagami`
+      : "Bake-off model — Katagami",
+    description: model
+      ? `Every design ${model.name} produced across the Katagami model bake-off.`
+      : undefined,
+  };
+}
+
+export default async function BakeoffModelPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const model = await getBakeoffModel(slug);
+  if (!model) notFound();
+
+  return (
+    <div className="mx-auto w-full max-w-7xl px-4 py-6 sm:py-10">
+      <Link
+        href="/model-bake-off"
+        className="ink-underline inline-block font-mono text-[11px] font-bold uppercase tracking-[0.18em] text-muted-foreground transition-colors hover:text-foreground"
+      >
+        All models
+      </Link>
+      <div className="mt-3">
+        <PageHero
+          eyebrow="Bake-off · by model"
+          eyebrowAccent="ramune"
+          title={
+            <>
+              Everything <Marker color="ramune">{model.name}</Marker> made
+            </>
+          }
+          description={`Every design ${model.name} produced across the bake-off — one per round, each answering a different reimagine brief. Open any to see its full landing, dashboard, and embodiment.`}
+          rightSlot={
+            <HeroStat value={model.count} label="designs" accent="ramune" />
+          }
+        />
+      </div>
+
+      <div className="mt-10 grid gap-x-8 gap-y-12 sm:grid-cols-2">
+        {model.submissions.map((s) => (
+          <SubmissionCard
+            key={s.model.languageId ?? s.roundId}
+            submission={s}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SubmissionCard({ submission }: { submission: BakeoffModelSubmission }) {
+  const m = submission.model;
+  const preview = primaryPreview(m.previews);
+  const stats = (
+    [
+      ["cost", m.cost],
+      ["total tokens", m.tokens],
+      ["time", m.wall],
+    ] as [string, string | undefined][]
+  ).filter(([, v]) => v);
+
+  return (
+    <div className="flex min-w-0 flex-col gap-3">
+      {preview ? (
+        <PreviewFrame
+          src={preview.url}
+          title={`${m.languageName} — ${preview.view}`}
+          thumb={m.thumb}
+          openHref={preview.url}
+        />
+      ) : (
+        <div className="sticker-card relative grid aspect-[1440/1024] place-items-center bg-card">
+          <p className="font-mono text-[11px] text-muted-foreground">
+            no preview
+          </p>
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-baseline gap-x-2.5 gap-y-1">
+        <h3 className="font-display text-[19px] font-bold tracking-[-0.02em]">
+          {m.languageName}
+        </h3>
+        {m.status && m.status !== "Published" ? (
+          <span className="font-mono text-[9px] font-bold uppercase tracking-[0.16em] text-[var(--ramune)]">
+            {m.status === "UnderReview" ? "under review" : m.status}
+          </span>
+        ) : null}
+      </div>
+
+      <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+        {submission.sourceName ? (
+          <>
+            reimagining{" "}
+            <span className="text-foreground">{submission.sourceName}</span>
+          </>
+        ) : (
+          submission.roundTitle
+        )}
+      </p>
+
+      {stats.length > 0 ? (
+        <div className="flex flex-wrap items-end gap-x-5 gap-y-1.5 pt-0.5">
+          {stats.map(([label, v]) => (
+            <span key={label} className="inline-flex flex-col">
+              <span className="font-display text-[17px] font-black leading-none tracking-[-0.02em] tabular-nums text-foreground">
+                {v}
+              </span>
+              <span className="mt-1 font-mono text-[9px] font-bold uppercase tracking-[0.2em] text-muted-foreground">
+                {label}
+              </span>
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-1.5 pt-0.5 font-mono text-[11px] font-bold uppercase tracking-[0.14em]">
+        {m.languageId ? (
+          <Link
+            href={`/language/${m.languageId}`}
+            className="ink-underline text-[var(--ramune)]"
+          >
+            View language
+          </Link>
+        ) : null}
+        <Link
+          href={`/lab/${submission.roundId}`}
+          className="ink-underline text-muted-foreground transition-colors hover:text-foreground"
+        >
+          See the round
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/app/(site)/model-bake-off/page.tsx
+++ b/ui/src/app/(site)/model-bake-off/page.tsx
@@ -1,4 +1,4 @@
-import { listBakeoffRounds } from "@/lib/bakeoff";
+import { listBakeoffModels, listBakeoffRounds } from "@/lib/bakeoff";
 import { BakeoffIndex } from "../lab/bakeoff-index";
 
 // The published model bake-off — the rounds index. Unlisted on purpose;
@@ -16,6 +16,9 @@ export const metadata = {
 };
 
 export default async function ModelBakeOffPage() {
-  const rounds = await listBakeoffRounds();
-  return <BakeoffIndex rounds={rounds} />;
+  const [rounds, models] = await Promise.all([
+    listBakeoffRounds(),
+    listBakeoffModels(),
+  ]);
+  return <BakeoffIndex rounds={rounds} models={models} />;
 }

--- a/ui/src/lib/bakeoff.ts
+++ b/ui/src/lib/bakeoff.ts
@@ -346,3 +346,76 @@ export const getBakeoffRound = unstable_cache(
   ["bakeoff-round-v1"],
   { revalidate: 60 },
 );
+
+// ---- Per-model view: everything one model made across every bake-off round ----
+
+export interface BakeoffModelSubmission {
+  roundId: string;
+  roundTitle: string;
+  sourceName?: string;
+  model: LabModel;
+}
+export interface BakeoffModelEntry {
+  /** Authoring model, display name (e.g. "Composer 2.5"). */
+  name: string;
+  /** URL slug. */
+  slug: string;
+  count: number;
+  submissions: BakeoffModelSubmission[];
+}
+
+export function bakeoffModelSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+// Aggregate every round's submissions by authoring model. Reuses the cached
+// per-round data — a fan-out over rounds (warm: cheap; cold: pays each round's
+// catalog read once, then the 60s cache holds it).
+async function buildBakeoffModels(): Promise<BakeoffModelEntry[]> {
+  const rounds = await listBakeoffRounds();
+  const byModel = new Map<string, BakeoffModelEntry>();
+  for (const r of rounds) {
+    const round = await getBakeoffRound(r.id);
+    if (!round) continue;
+    for (const key of round.blindOrder) {
+      const m = round.models[key];
+      if (!m) continue;
+      const name = (m.name || "Unknown").trim();
+      const slug = bakeoffModelSlug(name);
+      let entry = byModel.get(slug);
+      if (!entry) {
+        entry = { name, slug, count: 0, submissions: [] };
+        byModel.set(slug, entry);
+      }
+      entry.submissions.push({
+        roundId: r.id,
+        roundTitle: r.title,
+        sourceName: r.sourceName,
+        model: m,
+      });
+      entry.count += 1;
+    }
+  }
+  // Newest first within a model (round ids are uuid-v7, time-ordered).
+  for (const e of byModel.values())
+    e.submissions.sort((a, b) => b.roundId.localeCompare(a.roundId));
+  return [...byModel.values()].sort(
+    (a, b) => b.count - a.count || a.name.localeCompare(b.name),
+  );
+}
+
+export const listBakeoffModels = unstable_cache(
+  buildBakeoffModels,
+  ["bakeoff-models-v1"],
+  { revalidate: 60 },
+);
+
+export async function getBakeoffModel(
+  slug: string,
+): Promise<BakeoffModelEntry | null> {
+  const all = await listBakeoffModels();
+  return all.find((m) => m.slug === slug) ?? null;
+}


### PR DESCRIPTION
**Asked:** in the bake-off, see *per model* everything it made (e.g. everything Composer made, everything Grok made), with per-model access, styled like the rest.

## New
- **`/model-bake-off/model/[slug]`** — a per-model page: every design that model produced across the bake-off, one per round, each with its preview (the same `PreviewFrame` the round uses), the source it reimagined, cost/token/time stats, and links to the language + the round. Styled with `PageHero` + a grid, like the galleries / Under Review.
- **"Browse by model"** chips on the bake-off index (name + submission count) link straight in.

## Data
- `lib/bakeoff`: `listBakeoffModels()` + `getBakeoffModel(slug)` — aggregate every round's submissions by authoring model (`model_provenance.style.model`), built from the cached per-round data and cached (60s).
- Exported `PreviewFrame` from `lab-comparison` so the per-model page reuses the exact preview (fixed viewport, scripts-for-reveal, view scaling).

Build (full `npm run build`, incl. the prebuild contract test) / tsc / eslint ✓.