### PR TITLE
fix(ui): pin curator's picks at the top of the scalable galleries (ARN-111 follow-up)

### DIFF
--- a/ui/src/app/(site)/page.tsx
+++ b/ui/src/app/(site)/page.tsx
@@ -1,5 +1,9 @@
 import { Suspense } from "react";
-import { countDesignLanguages, pageDesignLanguages } from "@/lib/odata";
+import {
+  countDesignLanguages,
+  listFeaturedDesignLanguages,
+  pageDesignLanguages,
+} from "@/lib/odata";
 import { InfiniteLanguages } from "@/components/infinite-galleries";
 import { RisoHeroPress } from "@/components/riso-hero";
 import { RisoInkField } from "@/components/riso-ink-field";
@@ -101,8 +105,13 @@ function HowItWorksFold() {
 async function GalleryGrid({ demo }: { demo?: boolean }) {
   const canDelete = demo ? false : await isOwner();
   let first: Awaited<ReturnType<typeof pageDesignLanguages>>;
+  let featured: Awaited<ReturnType<typeof listFeaturedDesignLanguages>>;
   try {
-    first = await pageDesignLanguages({ limit: 48 });
+    // Curator's picks lead the gallery; the rest paginate in.
+    [first, featured] = await Promise.all([
+      pageDesignLanguages({ limit: 48 }),
+      listFeaturedDesignLanguages(),
+    ]);
   } catch {
     return (
       <div className="sticker-card mx-auto max-w-md p-8 text-center text-sm text-muted-foreground">
@@ -111,7 +120,7 @@ async function GalleryGrid({ demo }: { demo?: boolean }) {
       </div>
     );
   }
-  if (first.items.length === 0) {
+  if (first.items.length === 0 && featured.length === 0) {
     return (
       <div className="sticker-card mx-auto max-w-md p-8 text-center text-sm text-muted-foreground">
         No design languages found.
@@ -121,6 +130,7 @@ async function GalleryGrid({ demo }: { demo?: boolean }) {
   }
   return (
     <InfiniteLanguages
+      featured={featured}
       initialItems={first.items}
       initialCursor={first.nextCursor}
       canDelete={canDelete}

--- a/ui/src/app/(site)/palettes/page.tsx
+++ b/ui/src/app/(site)/palettes/page.tsx
@@ -1,4 +1,8 @@
-import { countPaletteSystems, pagePaletteSystems } from "@/lib/odata";
+import {
+  countPaletteSystems,
+  listFeaturedPaletteSystems,
+  pagePaletteSystems,
+} from "@/lib/odata";
 import { toPaletteItem } from "@/lib/lane-items";
 import { PageHero, Marker, HeroStat } from "@/components/page-hero";
 import { InfinitePalettes } from "@/components/infinite-galleries";
@@ -14,11 +18,13 @@ export default async function PalettesPage() {
   // Published-only. Keyset-paginated + server-searched so the catalog stays fast
   // at any size — the first page renders here, the rest load on scroll.
   const owner = await isOwner();
-  const [first, total] = await Promise.all([
+  const [first, total, featuredRows] = await Promise.all([
     pagePaletteSystems({ limit: 48 }),
     countPaletteSystems(),
+    listFeaturedPaletteSystems(),
   ]);
   const items = first.items.map(toPaletteItem);
+  const featured = featuredRows.map(toPaletteItem);
 
   return (
     <div className="mx-auto w-full max-w-7xl px-4 py-6 sm:py-10">
@@ -35,6 +41,7 @@ export default async function PalettesPage() {
       />
       <div className="mt-10">
         <InfinitePalettes
+          featured={featured}
           initialItems={items}
           initialCursor={first.nextCursor}
           canArchive={owner}

--- a/ui/src/components/infinite-galleries.tsx
+++ b/ui/src/components/infinite-galleries.tsx
@@ -74,17 +74,39 @@ function InfiniteShell({
   );
 }
 
+// Owner-pinned picks lead the lane (and are de-duped from the scrolling grid).
+// They're hidden while searching — a search shows just its matches.
+function CuratorsPicks({ children }: { children: ReactNode }) {
+  return (
+    <section className="space-y-3">
+      <p className="font-mono text-[11px] font-bold uppercase tracking-[0.16em] text-[var(--yuzu)]">
+        Curator&rsquo;s picks
+      </p>
+      {children}
+    </section>
+  );
+}
+
+const LANGUAGE_GRID = "grid gap-7 sm:grid-cols-2 lg:grid-cols-3";
+
 export function InfiniteLanguages({
+  featured = [],
   initialItems,
   initialCursor,
   canDelete = false,
 }: {
+  featured?: DesignLanguage[];
   initialItems: DesignLanguage[];
   initialCursor: string | null;
   canDelete?: boolean;
 }) {
   const { items, search, setSearch, loading, cursor, sentinelRef } =
     useInfiniteList<DesignLanguage>(initialItems, initialCursor, loadLanguagePage);
+  const browsing = search.trim() === "" && featured.length > 0;
+  const pinnedIds = new Set(featured.map((f) => f.entity_id));
+  const gridItems = browsing
+    ? items.filter((l) => !pinnedIds.has(l.entity_id))
+    : items;
   return (
     <InfiniteShell
       search={search}
@@ -92,11 +114,22 @@ export function InfiniteLanguages({
       placeholder="Search languages by name or tag…"
       loading={loading}
       exhausted={cursor === null}
-      empty={items.length === 0}
+      empty={(browsing ? featured.length : 0) + gridItems.length === 0}
       sentinelRef={sentinelRef}
     >
-      <div className="grid gap-7 sm:grid-cols-2 lg:grid-cols-3">
-        {items.map((l, i) => (
+      {browsing ? (
+        <CuratorsPicks>
+          <div className={LANGUAGE_GRID}>
+            {featured.map((l, i) => (
+              <div key={l.entity_id} style={CARD_CV}>
+                <LanguageCard lang={l} index={i} canDelete={canDelete} />
+              </div>
+            ))}
+          </div>
+        </CuratorsPicks>
+      ) : null}
+      <div className={LANGUAGE_GRID}>
+        {gridItems.map((l, i) => (
           <div key={l.entity_id} style={CARD_CV}>
             <LanguageCard lang={l} index={i} canDelete={canDelete} />
           </div>
@@ -106,17 +139,46 @@ export function InfiniteLanguages({
   );
 }
 
+function PaletteGrid({
+  items,
+  canArchive,
+}: {
+  items: PaletteItem[];
+  canArchive: boolean;
+}) {
+  return (
+    <div className={LANE_GRID}>
+      {items.map((p) => (
+        <Link
+          key={p.id}
+          href={`/palettes/${p.id}`}
+          prefetch={false}
+          className="group block min-w-0"
+          style={CARD_CV}
+        >
+          <PaletteCard palette={p} owner={canArchive} />
+        </Link>
+      ))}
+    </div>
+  );
+}
+
 export function InfinitePalettes({
+  featured = [],
   initialItems,
   initialCursor,
   canArchive = false,
 }: {
+  featured?: PaletteItem[];
   initialItems: PaletteItem[];
   initialCursor: string | null;
   canArchive?: boolean;
 }) {
   const { items, search, setSearch, loading, cursor, sentinelRef } =
     useInfiniteList<PaletteItem>(initialItems, initialCursor, loadPalettePage);
+  const browsing = search.trim() === "" && featured.length > 0;
+  const pinnedIds = new Set(featured.map((f) => f.id));
+  const gridItems = browsing ? items.filter((p) => !pinnedIds.has(p.id)) : items;
   return (
     <InfiniteShell
       search={search}
@@ -124,22 +186,15 @@ export function InfinitePalettes({
       placeholder="Search palettes by name or tag…"
       loading={loading}
       exhausted={cursor === null}
-      empty={items.length === 0}
+      empty={(browsing ? featured.length : 0) + gridItems.length === 0}
       sentinelRef={sentinelRef}
     >
-      <div className={LANE_GRID}>
-        {items.map((p) => (
-          <Link
-            key={p.id}
-            href={`/palettes/${p.id}`}
-            prefetch={false}
-            className="group block min-w-0"
-            style={CARD_CV}
-          >
-            <PaletteCard palette={p} owner={canArchive} />
-          </Link>
-        ))}
-      </div>
+      {browsing ? (
+        <CuratorsPicks>
+          <PaletteGrid items={featured} canArchive={canArchive} />
+        </CuratorsPicks>
+      ) : null}
+      <PaletteGrid items={gridItems} canArchive={canArchive} />
     </InfiniteShell>
   );
 }

--- a/ui/src/lib/odata.ts
+++ b/ui/src/lib/odata.ts
@@ -1039,6 +1039,79 @@ async function countLane(set: string, demo: LaneEntity[]): Promise<number> {
 export const countPaletteSystems = () => countLane("PaletteSystems", demoPaletteSystems());
 export const countArtStyles = () => countLane("ArtStyles", demoArtStyles());
 
+// ── Curator's picks (owner-pinned `featured`) ────────────────────────────────
+// Keyset paging is newest-first, so pinned picks would otherwise scatter through
+// the list. Fetch the (small) set of featured items separately so the galleries
+// can lead with them. Bounded + filtered defensively: a re-check on the rows
+// means a non-honored boolean filter can never pin a non-featured item (worst
+// case: a pick is simply not pinned — never wrong, just unpinned).
+
+function isTruthyFlag(v: unknown): boolean {
+  return (
+    v === true ||
+    v === 1 ||
+    (typeof v === "string" && /^(true|1)$/i.test(v.trim()))
+  );
+}
+
+function isDesignLanguageFeatured(l: DesignLanguage): boolean {
+  const bag = l as unknown as Record<string, Record<string, unknown> | undefined>;
+  for (const b of [bag.booleans, bag.fields, bag.counters]) {
+    if (b && (isTruthyFlag(b.featured) || isTruthyFlag(b.Featured) || isTruthyFlag(b.isFeatured)))
+      return true;
+  }
+  return false;
+}
+
+function isLaneFeatured(e: LaneEntity): boolean {
+  return isTruthyFlag(e.fields.featured) || isTruthyFlag(e.fields.Featured);
+}
+
+// Curators set a `display_order` alongside `featured`; lower comes first.
+function displayOrderOf(e: {
+  fields: Record<string, string | undefined>;
+  counters?: Record<string, number>;
+}): number {
+  const raw =
+    e.counters?.display_order ??
+    e.fields.display_order ??
+    e.fields.displayOrder;
+  const n = typeof raw === "number" ? raw : parseInt(String(raw ?? ""), 10);
+  return Number.isNaN(n) ? 0 : n;
+}
+
+export async function listFeaturedDesignLanguages(
+  limit = 100,
+): Promise<DesignLanguage[]> {
+  try {
+    const resp = await odata<{ value?: Record<string, unknown>[] }>(
+      `DesignLanguages?$filter=Status eq 'Published' and featured eq true&$top=${limit}`,
+    );
+    return (resp.value ?? [])
+      .map(normalizeDesignLanguageRow)
+      .filter((l) => l.fields.name && isDesignLanguageFeatured(l))
+      .sort((a, b) => displayOrderOf(a) - displayOrderOf(b));
+  } catch {
+    return [];
+  }
+}
+
+export async function listFeaturedPaletteSystems(
+  limit = 100,
+): Promise<LaneEntity[]> {
+  try {
+    const resp = await odata<{ value?: Record<string, unknown>[] }>(
+      `PaletteSystems?$filter=Status eq 'Published' and featured eq true&$top=${limit}`,
+    );
+    return (resp.value ?? [])
+      .map((r) => normalizeLaneRow(r, "PaletteSystems"))
+      .filter(isLaneFeatured)
+      .sort((a, b) => displayOrderOf(a) - displayOrderOf(b));
+  } catch {
+    return [];
+  }
+}
+
 // ── Directions (bake-off rounds) ──
 // A Direction is a reimagine brief / bake-off round. Contributor submissions
 // (DesignLanguage/ArtStyle/PaletteSystem) link to it via `direction_id`; the


### PR DESCRIPTION
Follow-up to ARN-111. The keyset (newest-first) paging scattered owner-pinned **curator's picks** (`featured`) through the list — they got mixed in.

## Fix
- `listFeaturedDesignLanguages` / `listFeaturedPaletteSystems` — fetch the small featured set separately (`Status eq 'Published' and featured eq true`, bounded ≤100, re-checked on the rows so a non-honored boolean filter can never pin a non-pick, ordered by curator `display_order`).
- `InfiniteLanguages` / `InfinitePalettes` lead with a **"Curator's picks"** row, **de-duped** from the scrolling grid. Hidden while searching (a search shows just its matches).
- Languages + palettes (art styles have no `featured` field, unchanged).

Build (full `npm run build` incl. contract test) / tsc / eslint ✓.