### PR TITLE
feat(ui): owner-gated A/B before/after review at /ab (bake-off primitives)

### DIFF
--- a/ui/src/app/(site)/ab/ab-data.ts
+++ b/ui/src/app/(site)/ab/ab-data.ts
@@ -1,0 +1,127 @@
+// Typed manifest for the owner-gated A/B before/after review.
+//
+// Each item is one design language with its ORIGINAL (before) and the REVISED
+// descendant (after) it was forked into, plus the three surfaces (landing /
+// embodiment / dashboard) — each carrying the before + after composition file
+// ids that the page renders side-by-side. Values are inlined from the curation
+// run so the page has no runtime manifest fetch.
+//
+// Provenance (one bake-off-style fix pass): the descendants were generated from
+// targeted critique against the originals under one rulebook + revision run.
+export const RULEBOOK_VERSION = "aa054051042e";
+export const REVISION_RUN = "wb9gk6j9e";
+
+export type AbSurfaceKind = "landing" | "embodiment" | "dashboard";
+
+export interface AbSurface {
+  surface: AbSurfaceKind;
+  before_file_id: string;
+  after_file_id: string;
+}
+
+export interface AbItem {
+  /** Display name of the design language. */
+  name: string;
+  /** The original (before) design language entity id. */
+  original_id: string;
+  /** The revised descendant (after) design language entity id. */
+  descendant_id: string;
+  /** Optional reviewer caveat shown as a warning on the language block. */
+  note: string | null;
+  surfaces: AbSurface[];
+}
+
+export const AB_ITEMS: AbItem[] = [
+  {
+    name: "Bouba",
+    original_id: "en-019efd9f-f4db-7db3-acf9-20d906c311f0",
+    descendant_id: "en-019f1533-2372-78f3-b754-6a2f716d8dba",
+    note: null,
+    surfaces: [
+      {
+        surface: "landing",
+        before_file_id: "fl-019efd9f-ceff-7000-97ce-157b4cef2d46",
+        after_file_id: "fl-019f152f-c261-73b0-a6aa-c761f7b2f944",
+      },
+      {
+        surface: "embodiment",
+        before_file_id: "fl-019efd9f-c73d-7710-a878-be08f247430d",
+        after_file_id: "fl-019f152f-c528-7842-ab5f-82eb3bf55d1d",
+      },
+      {
+        surface: "dashboard",
+        before_file_id: "fl-019efd9f-d25c-7432-bddd-2b861ae2b773",
+        after_file_id: "fl-019f152f-c847-77b1-866e-4ab52ce21f98",
+      },
+    ],
+  },
+  {
+    name: "Gloaming",
+    original_id: "en-019efdd8-0abe-7a33-af5b-e17b74d76a68",
+    descendant_id: "en-019f1526-827f-7c52-b121-4b4e64a86666",
+    note: null,
+    surfaces: [
+      {
+        surface: "landing",
+        before_file_id: "fl-019efdd7-f9ea-7850-a1af-260009245114",
+        after_file_id: "fl-019f1530-6e07-7d21-b770-a6988db16926",
+      },
+      {
+        surface: "embodiment",
+        before_file_id: "fl-019efdd7-f707-7713-9253-6d9cfd46184c",
+        after_file_id: "fl-019f1530-70e7-7ae1-868a-459dd07f8bfd",
+      },
+      {
+        surface: "dashboard",
+        before_file_id: "fl-019efdd7-fc2e-7ad3-ad42-a9194cef23a7",
+        after_file_id: "fl-019f1530-791a-7210-a072-c8880816539c",
+      },
+    ],
+  },
+  {
+    name: "Cadence",
+    original_id: "en-019efd27-384d-7dc1-a053-cd1193c95856",
+    descendant_id: "en-019f152e-a9c5-73c0-9b4a-d51d39308fe1",
+    note: null,
+    surfaces: [
+      {
+        surface: "landing",
+        before_file_id: "fl-019efd27-1cd6-7bd1-bce1-982cc3dbde98",
+        after_file_id: "fl-019f152c-f79c-7f41-a68e-ee23d7edd1d0",
+      },
+      {
+        surface: "embodiment",
+        before_file_id: "fl-019efd27-15d5-7173-b070-382f8e00ef88",
+        after_file_id: "fl-019f152c-f523-7ac1-948a-b6093925e915",
+      },
+      {
+        surface: "dashboard",
+        before_file_id: "fl-019efd27-23f2-7370-b14d-d9fd023819c5",
+        after_file_id: "fl-019f152c-f9d1-7f73-ab1e-f3617afde3cf",
+      },
+    ],
+  },
+  {
+    name: "Celadon",
+    original_id: "en-019efdd9-8a27-7f23-a206-ed48cae66ca2",
+    descendant_id: "en-019f1534-1eed-7d92-9bea-7dd8223fca96",
+    note: "Imagery fix pending (gpt-image-2 billing-blocked) — the AFTER keeps the original ceramic images. Judge the type / fixed chart / flattened cards / unified radii / cleaned gradient, not the photos.",
+    surfaces: [
+      {
+        surface: "landing",
+        before_file_id: "fl-019efdd9-6ab5-7880-a551-c721d89004bc",
+        after_file_id: "fl-019f1530-68be-73a0-ba45-ae4e54fb0dcf",
+      },
+      {
+        surface: "embodiment",
+        before_file_id: "fl-019efdd9-6369-7fe3-b595-8703bff7c9ba",
+        after_file_id: "fl-019f1530-6665-7153-b620-3a72b7442ca2",
+      },
+      {
+        surface: "dashboard",
+        before_file_id: "fl-019efdd9-725e-7221-a585-654941cbb088",
+        after_file_id: "fl-019f1530-6411-7712-8061-e52916ab3eff",
+      },
+    ],
+  },
+];

--- a/ui/src/app/(site)/ab/ab-review.tsx
+++ b/ui/src/app/(site)/ab/ab-review.tsx
@@ -1,0 +1,507 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Check, Download, Loader2, Save } from "lucide-react";
+import { EmbodimentViewer } from "@/components/embodiment-viewer";
+import { PageHero, Marker } from "@/components/page-hero";
+import { Perforation, Stamp } from "@/components/scrapbook";
+import {
+  AB_ITEMS,
+  REVISION_RUN,
+  RULEBOOK_VERSION,
+  type AbItem,
+  type AbSurfaceKind,
+} from "./ab-data";
+import {
+  recordAbFeedback,
+  type AbRecord,
+  type AbWinner,
+} from "./actions";
+
+const SURFACES: { key: AbSurfaceKind; label: string }[] = [
+  { key: "landing", label: "Landing" },
+  { key: "embodiment", label: "Embodiment" },
+  { key: "dashboard", label: "Dashboard" },
+];
+
+const WINNER_OPTIONS: { key: AbWinner; label: string }[] = [
+  { key: "A", label: "A better" },
+  { key: "B", label: "B better" },
+  { key: "tie", label: "Tie" },
+];
+
+const STORAGE_KEY = "katagami:ab-review:v1";
+
+// One surface verdict (or the overall verdict, dimension === "overall").
+interface Pick {
+  winner: AbWinner;
+  note: string;
+}
+
+// Per-language local state: a verdict per surface + one overall verdict.
+type LangPicks = {
+  surfaces: Partial<Record<AbSurfaceKind, Pick>>;
+  overall?: Pick;
+};
+type AllPicks = Record<string, LangPicks>; // keyed by language name
+
+function loadPicks(): AllPicks {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as AllPicks) : {};
+  } catch {
+    return {};
+  }
+}
+
+// The trio ink strip (sakura / yuzu / ramune) — the lab's signature top edge.
+function TrioStrip({ height = 4 }: { height?: number }) {
+  return (
+    <span
+      aria-hidden
+      className="absolute inset-x-0 top-0 z-10 flex"
+      style={{ height }}
+    >
+      <span className="h-full flex-1" style={{ background: "var(--sakura)" }} />
+      <span className="h-full flex-1" style={{ background: "var(--yuzu)" }} />
+      <span className="h-full flex-1" style={{ background: "var(--ramune)" }} />
+    </span>
+  );
+}
+
+// Shared segmented control — same look as the lab's Segmented.
+function Segmented<T extends string>({
+  options,
+  value,
+  onChange,
+  size = "md",
+}: {
+  options: { key: T; label: string }[];
+  value: T;
+  onChange: (k: T) => void;
+  size?: "sm" | "md";
+}) {
+  const pad = size === "sm" ? "px-3 py-1 text-[11px]" : "px-4 py-1.5 text-xs";
+  return (
+    <div className="inline-flex bg-card p-1 shadow-[0_1px_0_#1e232d1f]">
+      {options.map((o) => (
+        <button
+          key={o.key}
+          type="button"
+          onClick={() => onChange(o.key)}
+          className={`font-mono transition-colors ${pad} ${
+            value === o.key
+              ? "bg-foreground font-bold text-background"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// A · before / B · after pane: a mono eyebrow over the full-page composition.
+function Pane({
+  label,
+  side,
+  fileId,
+}: {
+  label: string;
+  side: "A" | "B";
+  fileId: string;
+}) {
+  const ink = side === "A" ? "var(--sakura)" : "var(--ramune)";
+  return (
+    <div className="min-w-0">
+      <div className="mb-2 flex items-center gap-2">
+        <span
+          className="grid h-6 w-6 shrink-0 place-items-center bg-foreground font-display text-[13px] font-bold text-background"
+          style={{ background: ink }}
+        >
+          {side}
+        </span>
+        <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-muted-foreground">
+          {label}
+        </span>
+      </div>
+      <div className="sticker-card relative overflow-hidden">
+        <TrioStrip height={3} />
+        <EmbodimentViewer fileId={fileId} />
+      </div>
+    </div>
+  );
+}
+
+// One verdict control: A / B / tie segmented + a note input.
+function VerdictControl({
+  label,
+  pick,
+  onChange,
+}: {
+  label: string;
+  pick: Pick | undefined;
+  onChange: (next: Pick) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-muted-foreground">
+          {label}
+        </span>
+        <Segmented
+          size="sm"
+          options={WINNER_OPTIONS}
+          value={pick?.winner ?? ("" as AbWinner)}
+          onChange={(winner) =>
+            onChange({ winner, note: pick?.note ?? "" })
+          }
+        />
+      </div>
+      <input
+        type="text"
+        value={pick?.note ?? ""}
+        onChange={(e) =>
+          onChange({ winner: pick?.winner ?? ("" as AbWinner), note: e.target.value })
+        }
+        placeholder="Optional note — what tipped it"
+        className="h-9 w-full max-w-xl bg-background/70 px-3 text-sm outline-none transition-colors placeholder:text-muted-foreground focus:bg-background"
+        style={{ boxShadow: "var(--shadow-card)" }}
+      />
+    </div>
+  );
+}
+
+function LanguageBlock({
+  item,
+  picks,
+  onSurfacePick,
+  onOverallPick,
+}: {
+  item: AbItem;
+  picks: LangPicks;
+  onSurfacePick: (surface: AbSurfaceKind, pick: Pick) => void;
+  onOverallPick: (pick: Pick) => void;
+}) {
+  const [surface, setSurface] = useState<AbSurfaceKind>("landing");
+  const current =
+    item.surfaces.find((s) => s.surface === surface) ?? item.surfaces[0];
+
+  return (
+    <section
+      className="sticker-card relative overflow-hidden p-5 pt-7 sm:p-7 sm:pt-9"
+      style={{ ["--card-ink" as string]: "var(--ramune)" }}
+    >
+      <TrioStrip height={4} />
+
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <span className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-[var(--sakura)]">
+            design language
+          </span>
+          <h2 className="mt-1.5 font-display text-3xl font-black tracking-[-0.03em] sm:text-4xl">
+            {item.name}
+          </h2>
+        </div>
+        <Segmented
+          options={SURFACES}
+          value={surface}
+          onChange={(k) => setSurface(k)}
+        />
+      </div>
+
+      {item.note ? (
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <Stamp color="yuzu" rotate={-2}>
+            imagery note
+          </Stamp>
+          <p className="max-w-2xl text-[13.5px] leading-relaxed text-muted-foreground">
+            {item.note}
+          </p>
+        </div>
+      ) : null}
+
+      {/* Only the selected surface's two frames mount — keyed by surface so
+          switching tabs re-fetches the new pair. */}
+      <div key={surface} className="mt-6 grid gap-6 lg:grid-cols-2">
+        <Pane
+          side="A"
+          label="A · before · original"
+          fileId={current.before_file_id}
+        />
+        <Pane
+          side="B"
+          label="B · after · revised"
+          fileId={current.after_file_id}
+        />
+      </div>
+
+      <Perforation className="mt-7" />
+
+      <div className="mt-6 grid gap-6 lg:grid-cols-2">
+        <VerdictControl
+          label={`This surface — ${surface}`}
+          pick={picks.surfaces[surface]}
+          onChange={(next) => onSurfacePick(surface, next)}
+        />
+        <VerdictControl
+          label="Overall — this language"
+          pick={picks.overall}
+          onChange={onOverallPick}
+        />
+      </div>
+    </section>
+  );
+}
+
+// Build the durable records from local picks. One per surface verdict + one
+// overall verdict, only where a winner has been chosen.
+function buildRecords(items: AbItem[], all: AllPicks): AbRecord[] {
+  const ts = new Date().toISOString();
+  const records: AbRecord[] = [];
+
+  for (const item of items) {
+    const lang = all[item.name];
+    if (!lang) continue;
+
+    const resolve = (winner: AbWinner) => {
+      if (winner === "A") {
+        return { chosen_id: item.original_id, rejected_id: item.descendant_id };
+      }
+      if (winner === "B") {
+        return { chosen_id: item.descendant_id, rejected_id: item.original_id };
+      }
+      return { chosen_id: "tie", rejected_id: "tie" };
+    };
+
+    for (const surface of item.surfaces) {
+      const pick = lang.surfaces[surface.surface];
+      if (!pick?.winner) continue;
+      records.push({
+        type: "pairwise",
+        ts,
+        name: item.name,
+        surface: surface.surface,
+        winner: pick.winner,
+        ...resolve(pick.winner),
+        dimension: surface.surface,
+        note: pick.note ?? "",
+        rulebook_version: RULEBOOK_VERSION,
+        revision_run: REVISION_RUN,
+      });
+    }
+
+    if (lang.overall?.winner) {
+      records.push({
+        type: "pairwise",
+        ts,
+        name: item.name,
+        surface: "overall",
+        winner: lang.overall.winner,
+        ...resolve(lang.overall.winner),
+        dimension: "overall",
+        note: lang.overall.note ?? "",
+        rulebook_version: RULEBOOK_VERSION,
+        revision_run: REVISION_RUN,
+      });
+    }
+  }
+
+  return records;
+}
+
+function downloadJsonl(records: AbRecord[]) {
+  const body = records.map((r) => JSON.stringify(r)).join("\n") + "\n";
+  const blob = new Blob([body], { type: "application/x-ndjson" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `ab-verdicts-${new Date().toISOString().slice(0, 19).replace(/[:T]/g, "-")}.jsonl`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+const STICKER =
+  "inline-flex items-center justify-center gap-2 px-5 py-2.5 font-mono text-[11px] font-bold uppercase tracking-[0.16em] shadow-[0_2px_0_#1e232d29] transition-all hover:-translate-y-[2px] hover:shadow-[0_4px_0_#1e232d29] disabled:pointer-events-none disabled:opacity-50";
+
+type SaveState =
+  | { kind: "idle" }
+  | { kind: "saving" }
+  | { kind: "saved"; count: number }
+  | { kind: "error"; message: string };
+
+export function AbReview({ items = AB_ITEMS }: { items?: AbItem[] }) {
+  const [picks, setPicks] = useState<AllPicks>({});
+  const [hydrated, setHydrated] = useState(false);
+  const [save, setSave] = useState<SaveState>({ kind: "idle" });
+
+  // Hydrate from localStorage after mount (avoids SSR/client mismatch). Read in
+  // a microtask so the setState lands in an async callback, not synchronously in
+  // the effect body — same pattern the embodiment viewer uses for its fetch.
+  useEffect(() => {
+    let cancelled = false;
+    Promise.resolve().then(() => {
+      if (cancelled) return;
+      setPicks(loadPicks());
+      setHydrated(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Persist every change so nothing is lost on reload.
+  useEffect(() => {
+    if (!hydrated) return;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(picks));
+    } catch {
+      /* private mode — picks just won't persist */
+    }
+  }, [picks, hydrated]);
+
+  const setSurfacePick = useCallback(
+    (name: string, surface: AbSurfaceKind, pick: Pick) => {
+      setSave({ kind: "idle" });
+      setPicks((prev) => {
+        const lang = prev[name] ?? { surfaces: {} };
+        return {
+          ...prev,
+          [name]: {
+            ...lang,
+            surfaces: { ...lang.surfaces, [surface]: pick },
+          },
+        };
+      });
+    },
+    [],
+  );
+
+  const setOverallPick = useCallback((name: string, pick: Pick) => {
+    setSave({ kind: "idle" });
+    setPicks((prev) => {
+      const lang = prev[name] ?? { surfaces: {} };
+      return { ...prev, [name]: { ...lang, overall: pick } };
+    });
+  }, []);
+
+  const records = useMemo(() => buildRecords(items, picks), [items, picks]);
+  const count = records.length;
+
+  const onSave = async () => {
+    if (count === 0) return;
+    setSave({ kind: "saving" });
+    const res = await recordAbFeedback(records);
+    if (res.ok) {
+      setSave({ kind: "saved", count: res.count ?? count });
+    } else {
+      setSave({ kind: "error", message: res.error ?? "Save failed." });
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-8 sm:py-12">
+      <PageHero
+        eyebrow={
+          <>
+            <span>owner</span>
+            <span className="font-mono text-muted-foreground/70">·</span>
+            <span className="font-mono lowercase tracking-wide">review</span>
+          </>
+        }
+        eyebrowAccent="ramune"
+        title={
+          <>
+            Before / <Marker color="yuzu">After</Marker>
+          </>
+        }
+        description={
+          <>
+            Targeted fixes from critique, regenerated as descendants. For each
+            language and surface, see the original (A) beside the revised (B),
+            then call it: A, B, or a tie. Picks save to this browser as you go.
+          </>
+        }
+        rightSlot={
+          <div className="flex flex-col items-end gap-1.5">
+            <span className="font-display text-[44px] font-bold leading-none tracking-[-0.04em] tabular-nums sm:text-[56px]">
+              {count}
+            </span>
+            <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+              verdicts recorded
+            </span>
+          </div>
+        }
+      />
+
+      <div className="mt-10 space-y-12">
+        {items.map((item) => (
+          <LanguageBlock
+            key={item.name}
+            item={item}
+            picks={picks[item.name] ?? { surfaces: {} }}
+            onSurfacePick={(surface, pick) =>
+              setSurfacePick(item.name, surface, pick)
+            }
+            onOverallPick={(pick) => setOverallPick(item.name, pick)}
+          />
+        ))}
+      </div>
+
+      {/* Save bar — sticks to the bottom so the verdict is always one click away. */}
+      <div className="sticky bottom-4 z-30 mt-12">
+        <div
+          className="relative flex flex-col gap-3 overflow-hidden bg-card/95 px-5 py-4 backdrop-blur-sm sm:flex-row sm:items-center sm:justify-between"
+          style={{ boxShadow: "var(--shadow-card-hover)" }}
+        >
+          <TrioStrip height={3} />
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="font-mono text-[11px] font-bold uppercase tracking-[0.16em] text-muted-foreground">
+              {count} {count === 1 ? "verdict" : "verdicts"} ready
+            </span>
+            {save.kind === "saved" ? (
+              <span className="inline-flex items-center gap-1.5 font-mono text-[11px] font-bold uppercase tracking-[0.16em] text-[var(--ramune)]">
+                <Check className="h-3.5 w-3.5" />
+                saved {save.count} to the commons
+              </span>
+            ) : null}
+            {save.kind === "error" ? (
+              <span className="max-w-md font-mono text-[11px] text-destructive">
+                {save.message} — your picks are still in this browser and the
+                export below.
+              </span>
+            ) : null}
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={() => downloadJsonl(records)}
+              disabled={count === 0}
+              className={`${STICKER} bg-card text-foreground`}
+            >
+              <Download className="h-3.5 w-3.5" />
+              Export JSONL
+            </button>
+            <button
+              type="button"
+              onClick={onSave}
+              disabled={count === 0 || save.kind === "saving"}
+              className={`${STICKER} bg-foreground text-background`}
+            >
+              {save.kind === "saving" ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Save className="h-3.5 w-3.5" />
+              )}
+              Save feedback
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/app/(site)/ab/actions.ts
+++ b/ui/src/app/(site)/ab/actions.ts
@@ -1,0 +1,145 @@
+"use server";
+
+import { assertOwner } from "@/lib/owner";
+
+// Durable storage for owner A/B verdicts. Appends JSONL to a single Files entity
+// in the `katagami-contrib` workspace at /feedback/ab-verdicts.jsonl.
+//
+// How the Temper FS write works (verified against the deployed backend):
+//   1. POST Workspaces('katagami-contrib')/Paw.FS.CreateFile {path, mime_type}
+//      — a path-idempotent `creat`: returns the SAME file id for a given path
+//      and does NOT truncate existing content. The created file id comes back
+//      as `fields.last_file_id`. (The workspace state also carries cosmetic
+//      `error_message`/`last_file_path` diagnostics from a path-listing budget
+//      cap — they don't affect last_file_id, so we ignore them.)
+//   2. GET  Files('<id>')/$value — the existing accumulated JSONL (404 = first
+//      write, treated as empty).
+//   3. PUT  Files('<id>')/$value — the existing content + the new lines.
+//
+// So append = create-or-resolve, read, concatenate, put-back.
+function cleanEnv(value: string | undefined, fallback: string): string {
+  return (value ?? fallback).replace(/\\n/g, "").trim() || fallback;
+}
+
+const API_BASE = cleanEnv(
+  process.env.NEXT_PUBLIC_TEMPER_API_URL,
+  "http://localhost:3500",
+);
+const TENANT = cleanEnv(process.env.NEXT_PUBLIC_TEMPER_TENANT, "default");
+const API_KEY = cleanEnv(process.env.TEMPER_API_KEY, "");
+
+const WORKSPACE = "katagami-contrib";
+const VERDICTS_PATH = "/feedback/ab-verdicts.jsonl";
+const VERDICTS_MIME = "application/x-ndjson";
+
+const authedHeaders: Record<string, string> = {
+  "X-Tenant-Id": TENANT,
+  // Writes are made by the app acting as an agent principal.
+  "x-temper-principal-kind": "agent",
+  ...(API_KEY ? { Authorization: `Bearer ${API_KEY}` } : {}),
+};
+
+export type AbWinner = "A" | "B" | "tie";
+
+export interface AbRecord {
+  type: "pairwise";
+  ts: string;
+  name: string;
+  surface: string;
+  winner: AbWinner;
+  chosen_id: string;
+  rejected_id: string;
+  dimension: string;
+  note: string;
+  rulebook_version: string;
+  revision_run: string;
+}
+
+export interface RecordAbResult {
+  ok: boolean;
+  count?: number;
+  error?: string;
+}
+
+/** Create-or-resolve the verdicts file and return its canonical file id. */
+async function resolveVerdictsFileId(): Promise<string> {
+  const res = await fetch(
+    `${API_BASE}/tdata/Workspaces('${WORKSPACE}')/Paw.FS.CreateFile`,
+    {
+      method: "POST",
+      headers: { ...authedHeaders, "Content-Type": "application/json" },
+      body: JSON.stringify({ path: VERDICTS_PATH, mime_type: VERDICTS_MIME }),
+      cache: "no-store",
+    },
+  );
+  if (!res.ok) {
+    throw new Error(`CreateFile ${res.status}: ${await res.text()}`);
+  }
+  const body = (await res.json()) as {
+    fields?: { last_file_id?: string };
+  };
+  const fileId = body.fields?.last_file_id;
+  if (!fileId) {
+    throw new Error("CreateFile did not return a file id.");
+  }
+  return fileId;
+}
+
+/** The current JSONL contents of the verdicts file ("" if it has none yet). */
+async function readVerdicts(fileId: string): Promise<string> {
+  const res = await fetch(`${API_BASE}/tdata/Files('${fileId}')/$value`, {
+    headers: authedHeaders,
+    cache: "no-store",
+  });
+  if (res.status === 404) return "";
+  if (!res.ok) {
+    throw new Error(`Read $value ${res.status}: ${await res.text()}`);
+  }
+  return res.text();
+}
+
+async function writeVerdicts(fileId: string, content: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/tdata/Files('${fileId}')/$value`, {
+    method: "PUT",
+    headers: { ...authedHeaders, "Content-Type": VERDICTS_MIME },
+    body: content,
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`Write $value ${res.status}: ${await res.text()}`);
+  }
+}
+
+export async function recordAbFeedback(
+  records: AbRecord[],
+): Promise<RecordAbResult> {
+  await assertOwner();
+
+  if (!Array.isArray(records) || records.length === 0) {
+    return { ok: true, count: 0 };
+  }
+
+  const lines = records.map((r) => JSON.stringify(r)).join("\n") + "\n";
+
+  try {
+    const fileId = await resolveVerdictsFileId();
+    const existing = await readVerdicts(fileId);
+    // A whitespace-only file (empty, or the single-newline "cleared" state the
+    // backend keeps because it rejects a zero-length $value) is treated as no
+    // prior content, so we never prepend a blank line. Otherwise keep the file
+    // newline-terminated so each PUT is a clean append.
+    const hasContent = existing.trim().length > 0;
+    const prefix = !hasContent
+      ? ""
+      : existing.endsWith("\n")
+        ? existing
+        : existing + "\n";
+    await writeVerdicts(fileId, prefix + lines);
+    return { ok: true, count: records.length };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/ui/src/app/(site)/ab/page.tsx
+++ b/ui/src/app/(site)/ab/page.tsx
@@ -1,0 +1,14 @@
+import { notFound } from "next/navigation";
+import { isOwner } from "@/lib/owner";
+import { AB_ITEMS } from "./ab-data";
+import { AbReview } from "./ab-review";
+
+// Owner-only. Unlisted on purpose — not added to header-nav, mobile-nav, or the
+// search index. Reachable only by URL, exactly like /lab. A non-owner request
+// 404s (the route reveals nothing about its existence).
+export const dynamic = "force-dynamic";
+
+export default async function AbReviewPage() {
+  if (!(await isOwner())) notFound();
+  return <AbReview items={AB_ITEMS} />;
+}


### PR DESCRIPTION
## What this adds

An owner-only **A/B before/after review** page at `/ab`, built from the existing bake-off `/lab` primitives. For each critiqued design language it shows the **original (A)** beside its **revised descendant (B)** per surface (landing / embodiment / dashboard), and lets the owner record an A / B / tie verdict per surface and overall — the pairwise feedback that seeds the taste-training set.

## Access (only Rita, for now)

Gated by the app's existing **owner mode** — `if (!(await isOwner())) notFound();`. A non-owner request 404s and the route reveals nothing about its existence. It is **unlisted** (not added to header-nav, mobile-nav, or the search index), exactly like `/lab`. Unlock once at `/owner` with the `KATAGAMI_OWNER_SECRET` passphrase (30-day cookie).

## Files (all under `ui/src/app/(site)/ab/`)
- `page.tsx` — server component, `force-dynamic`, owner-gated.
- `ab-data.ts` — typed manifest of the 4 languages (Bouba, Gloaming, Cadence, Celadon) with before/after file ids per surface; Celadon carries the "imagery fix pending" caveat.
- `ab-review.tsx` — client UI: `PageHero`/`Marker`, per-language `sticker-card` + trio ink strip + `Segmented` surface toggle, two side-by-side `EmbodimentViewer` panes (full-page via `ScaledFrame`), A/B/tie + note per surface and overall, localStorage persistence, Export JSONL + Save.
- `actions.ts` — `"use server"` `recordAbFeedback`: `assertOwner()`, then append the verdicts as JSONL to `katagami-contrib:/feedback/ab-verdicts.jsonl`.

## Verification (local, on branch)
- `tsc --noEmit`, eslint, and `next build` all clean (`/ab` compiles as a dynamic route).
- Gate proven: `GET /ab` with no cookie → **404**; with the owner cookie → **200** rendering all four languages, both panes, the Celadon note, and the controls.
- Before/after panes render **full pages** (not crops) via `ScaledFrame`.
- Save path exercised end-to-end: picking B on Bouba (surface + overall) and clicking Save wrote exactly 2 records to the commons file in the correct shape (winner B → chosen = descendant, rejected = original).

## Design contract
No borders, radius-0 `sticker-card`, ≤3 accents (trio), mono eyebrows, light-mode default, responsive (panes stack on mobile).

## Deploy note
The gate reads `KATAGAMI_OWNER_SECRET` — it must be set in the deployed environment (it already powers the existing curator owner-mode), and the verdict writes need `TEMPER_API_KEY` + `NEXT_PUBLIC_TEMPER_API_URL`. Local-only verification so far; nothing deployed. The UI repo's remote is GitHub (`arni-labs/katagami`); it has no Genesis counterpart to sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xmdzh3mzpgrYcdPPyndjWp