### PR TITLE
fix(rum): buffer early custom events so on-mount language_view isn't dropped

### DIFF
--- a/ui/src/lib/analytics.ts
+++ b/ui/src/lib/analytics.ts
@@ -69,6 +69,9 @@ export async function initRum(): Promise<void> {
       trackLongTasks: true,
       defaultPrivacyLevel: "mask-user-input",
     });
+    // Replay any events fired before the SDK finished importing (e.g. the
+    // on-mount `language_view`), which would otherwise have been dropped.
+    flushPending();
   } catch {
     // SDK failed to load — leave as a no-op, never surface to the user.
     rum = null;
@@ -87,9 +90,35 @@ function clean(attrs: Attributes): Record<string, string | number | boolean> {
   return out;
 }
 
-/** Low-level: record a custom RUM action. No-op until RUM is ready. */
+// The RUM SDK is imported lazily, so events fired between first paint and the
+// import resolving (notably the on-mount `language_view`) arrive while `rum` is
+// still null. Buffer those (capped) and flush them in initRum once the SDK is
+// ready, instead of silently dropping them.
+const MAX_PENDING = 50;
+const pending: Array<{ name: string; attributes: Attributes }> = [];
+
+function flushPending(): void {
+  if (!rum) return;
+  const queued = pending.splice(0, pending.length);
+  for (const ev of queued) {
+    try {
+      rum.addAction(ev.name, clean(ev.attributes));
+    } catch {
+      /* analytics must never throw into the UI */
+    }
+  }
+}
+
+/** Low-level: record a custom RUM action. Buffers until the SDK is ready; a
+ *  permanent no-op when RUM credentials are absent. */
 export function track(name: string, attributes: Attributes = {}): void {
-  if (!rum || !initialized) return;
+  if (typeof window === "undefined" || !rumEnabled()) return;
+  if (!rum) {
+    // SDK still importing — buffer (capped) so early on-mount events aren't
+    // lost to the init race; flushed by initRum.
+    if (pending.length < MAX_PENDING) pending.push({ name, attributes });
+    return;
+  }
   try {
     rum.addAction(name, clean(attributes));
   } catch {


### PR DESCRIPTION
## Problem (found during live verification)

After #117 shipped the `language_view` instrumentation, a real browser visit to a language page **registered its page view + resources in RUM but produced zero `language_view` actions**.

Root cause: the RUM SDK is imported **lazily** (dynamic import). `trackLanguageView` fires in the detail page's mount effect, which runs *before* the import resolves — so `track()` saw `rum === null` and silently dropped it. Copy/click events survived only because they happen seconds later, after init completes. The on-mount event loses the race.

## Fix

Generic, not a band-aid: `track()` now **buffers** events (capped at 50) while the SDK is still importing, and `initRum()` **flushes** the buffer once `rum` is ready. Any early/on-mount custom event is now reliably recorded, not just `language_view`. Still a permanent no-op when RUM credentials are absent.

`tsc --noEmit` clean.

## Verify after deploy

Visit a language page → a `language_view` event with `language_name` + `language_id` lands in RUM. (I'll confirm and then flip the dashboard's language widgets to group by name.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)