### PR TITLE
fix(ui): make the remix entity-picker usable — curated facets + anchored, no takeover

### DIFF
--- a/ui/src/app/(site)/art-styles/[id]/page.tsx
+++ b/ui/src/app/(site)/art-styles/[id]/page.tsx
@@ -226,7 +226,6 @@ export default async function ArtStyleDetailPage({ params }: { params: Promise<{
             palettes={palOpts}
             art={artOpts}
             fixed={{ art: id }}
-            variant="drawer"
           />
         ) : (
           <div className="sticker-card p-5 text-sm text-muted-foreground">

--- a/ui/src/app/(site)/language/[id]/page.tsx
+++ b/ui/src/app/(site)/language/[id]/page.tsx
@@ -369,7 +369,6 @@ export default async function LanguageDetailPage({
             palettes={remixPalOpts}
             art={remixArtOpts}
             fixed={{ language: id }}
-            variant="drawer"
           />
         </section>
       ) : null}

--- a/ui/src/app/(site)/palettes/[id]/page.tsx
+++ b/ui/src/app/(site)/palettes/[id]/page.tsx
@@ -225,7 +225,6 @@ export default async function PaletteDetailPage({ params }: { params: Promise<{ 
             palettes={palOpts}
             art={artOpts}
             fixed={{ palette: id }}
-            variant="drawer"
           />
         ) : (
           <div className="sticker-card p-5 text-sm text-muted-foreground">

--- a/ui/src/components/remix/entity-picker.tsx
+++ b/ui/src/components/remix/entity-picker.tsx
@@ -273,7 +273,7 @@ export function EntityPicker({
               e.preventDefault(); // focus the search box, not the first row — and never scroll the page
               inputRef.current?.focus({ preventScroll: true });
             }}
-            className="z-50 flex max-h-[min(60vh,26rem)] w-[min(92vw,22rem)] flex-col overflow-hidden bg-card shadow-[0_18px_50px_rgba(30,35,45,0.24)]"
+            className="z-50 flex max-h-[min(26rem,var(--radix-popover-content-available-height))] w-[min(92vw,22rem)] flex-col overflow-hidden bg-card shadow-[0_18px_50px_rgba(30,35,45,0.24)]"
           >
             <div className="shrink-0 bg-card px-4 pb-2.5 pt-3">
               <div className="mb-2 flex items-center justify-between">

--- a/ui/src/components/remix/entity-picker.tsx
+++ b/ui/src/components/remix/entity-picker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import * as Popover from "@radix-ui/react-popover";
+import { useMemo, useRef, useState } from "react";
 import { KX_FIELD, KX_LABEL } from "@/lib/katagami-ui";
 
 // One item model for all three lanes. The picker is generic; only the media
@@ -16,14 +17,21 @@ export interface PickItem {
 }
 
 const RESULT_CAP = 60; // render at most this many; the rest are summarized (thousands-safe)
+// A facet is only a useful filter when it has a small, shared set of values. A
+// key whose values are nearly unique (e.g. a palette's free-text key-hue) is not
+// a facet — it's noise. Surface a facet only when 2..MAX_FACET_VALUES distinct
+// values exist; everything else stays reachable through the text search.
+const MAX_FACET_VALUES = 8;
 const MEDIA = "shrink-0 overflow-hidden rounded-[2px] shadow-[0_1px_3px_rgba(30,35,45,0.14)]";
+
+type Facet = readonly [string, readonly (readonly [string, number])[]]; // [key, [[value, count], …]]
 
 function haystack(it: PickItem): string {
   return [
     it.name,
     it.subtitle ?? "",
     (it.tags ?? []).join(" "),
-    Object.values(it.facets ?? {}).join(" "),
+    Object.values(it.facets ?? {}).join(" "), // free-text facets (hue, …) stay searchable even when not shown as chips
     (it.swatches ?? []).join(" "),
   ]
     .join(" ")
@@ -45,21 +53,28 @@ function useFiltered(items: PickItem[], q: string, active: Record<string, Set<st
   }, [items, q, active]);
 }
 
-function useFacets(items: PickItem[]) {
+// Only surface low-cardinality facets, each value carrying its count, sorted by
+// frequency. High-cardinality / free-text keys are dropped automatically.
+function useFacets(items: PickItem[]): Facet[] {
   return useMemo(() => {
-    const map: Record<string, Set<string>> = {};
+    const counts: Record<string, Map<string, number>> = {};
     for (const it of items) {
       for (const [k, v] of Object.entries(it.facets ?? {})) {
         if (!v) continue;
-        (map[k] ??= new Set()).add(v);
+        (counts[k] ??= new Map()).set(v, (counts[k].get(v) ?? 0) + 1);
       }
     }
-    return Object.entries(map).map(([k, vs]) => [k, [...vs].sort()] as const);
+    return Object.entries(counts)
+      .filter(([, m]) => m.size > 1 && m.size <= MAX_FACET_VALUES)
+      .map(
+        ([k, m]) =>
+          [k, [...m.entries()].sort((a, b) => b[1] - a[1])] as Facet,
+      );
   }, [items]);
 }
 
-// "Search by name, temperature, hue…" — tells the user what's searchable.
-function searchPlaceholder(facets: readonly (readonly [string, string[]])[]) {
+// "Search by name, temperature…" — tells the user what's searchable.
+function searchPlaceholder(facets: Facet[]) {
   const keys = facets.map(([k]) => k);
   return `Search by name${keys.length ? ", " + keys.join(", ") : ""}…`;
 }
@@ -84,7 +99,7 @@ function FacetChips({
   active,
   onToggle,
 }: {
-  facets: readonly (readonly [string, string[]])[];
+  facets: Facet[];
   active: Record<string, Set<string>>;
   onToggle: (key: string, val: string) => void;
 }) {
@@ -94,7 +109,7 @@ function FacetChips({
       {facets.map(([key, vals]) => (
         <div key={key} className="flex flex-wrap items-center gap-1.5">
           <span className="mr-1 font-mono text-[9px] uppercase tracking-[0.16em] text-muted-foreground/70">{key}</span>
-          {vals.map((v) => {
+          {vals.map(([v, n]) => {
             const on = active[key]?.has(v) ?? false;
             return (
               <button
@@ -102,9 +117,10 @@ function FacetChips({
                 type="button"
                 onClick={() => onToggle(key, v)}
                 data-on={on}
-                className="rounded-full bg-[color-mix(in_srgb,var(--foreground)_6%,transparent)] px-2.5 py-0.5 font-mono text-[10px] lowercase tracking-[0.04em] text-muted-foreground transition-colors hover:text-foreground data-[on=true]:bg-foreground data-[on=true]:text-background"
+                className="flex items-center gap-1 rounded-full bg-[color-mix(in_srgb,var(--foreground)_6%,transparent)] px-2.5 py-0.5 font-mono text-[10px] lowercase tracking-[0.04em] text-muted-foreground transition-colors hover:text-foreground data-[on=true]:bg-foreground data-[on=true]:text-background"
               >
                 {v}
+                <span className="tabular-nums opacity-50">{n}</span>
               </button>
             );
           })}
@@ -134,14 +150,24 @@ function ItemMedia({ item }: { item: PickItem }) {
   );
 }
 
-function ItemRow({ item, active, onPick }: { item: PickItem; active: boolean; onPick: () => void }) {
+function ItemRow({
+  item,
+  selected,
+  highlighted,
+  onPick,
+}: {
+  item: PickItem;
+  selected: boolean;
+  highlighted: boolean;
+  onPick: () => void;
+}) {
   return (
     <button
       type="button"
       role="option"
-      aria-selected={active}
+      aria-selected={selected}
       onClick={onPick}
-      data-active={active}
+      data-active={selected || highlighted}
       className="flex w-full items-center gap-3 border-l-2 border-transparent px-3 py-2 text-left transition-colors hover:bg-[color-mix(in_srgb,var(--foreground)_4%,transparent)] data-[active=true]:border-foreground data-[active=true]:bg-[color-mix(in_srgb,var(--foreground)_6%,transparent)]"
     >
       <ItemMedia item={item} />
@@ -153,25 +179,8 @@ function ItemRow({ item, active, onPick }: { item: PickItem; active: boolean; on
           </span>
         ) : null}
       </span>
-      {active ? <span aria-hidden className="shrink-0 text-[12px] font-bold text-foreground">✓</span> : null}
+      {selected ? <span aria-hidden className="shrink-0 text-[12px] font-bold text-foreground">✓</span> : null}
     </button>
-  );
-}
-
-function Trigger({ label, current, onOpen }: { label: string; current?: PickItem; onOpen: () => void }) {
-  return (
-    <div>
-      <div className={`mb-1.5 ${KX_LABEL}`}>{label}</div>
-      <button
-        type="button"
-        onClick={onOpen}
-        className="group flex w-full items-center gap-2.5 bg-card/70 px-2.5 py-2 text-left shadow-[0_1px_2px_rgba(30,35,45,0.05),0_2px_8px_rgba(30,35,45,0.05)] backdrop-blur-[3px] transition-all hover:-translate-y-[1px] hover:bg-card"
-      >
-        {current ? <ItemMedia item={current} /> : null}
-        <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-foreground">{current?.name ?? "Choose…"}</span>
-        <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-muted-foreground transition-colors group-hover:text-foreground">browse</span>
-      </button>
-    </div>
   );
 }
 
@@ -191,9 +200,11 @@ function EmptyResults() {
   );
 }
 
-// ── Variant A: command palette (⌘K-style centered modal) ──────────────────────
-
-export function CommandPicker({
+// A single in-place picker: an anchored dropdown (Radix Popover → portaled,
+// collision-aware flip/shift, viewport-clamped) on every screen. It never takes
+// over the page, steals global keys, or scrolls away — the work behind it stays
+// put and visible. Keyboard nav is scoped to the search field, not the window.
+export function EntityPicker({
   label,
   items,
   value,
@@ -208,203 +219,127 @@ export function CommandPicker({
   const [q, setQ] = useState("");
   const [active, setActive] = useState<Record<string, Set<string>>>({});
   const [cursor, setCursor] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
   const current = items.find((i) => i.id === value);
   const facets = useFacets(items);
   const filtered = useFiltered(items, q, active);
   const visible = filtered.slice(0, RESULT_CAP);
   const noun = label.toLowerCase();
 
-  function close() {
-    setOpen(false);
+  function reset() {
     setQ("");
     setActive({});
     setCursor(0);
   }
-
-  useEffect(() => {
-    if (!open) return;
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") close();
-      else if (e.key === "ArrowDown") {
-        e.preventDefault();
-        setCursor((c) => Math.min(c + 1, visible.length - 1));
-      } else if (e.key === "ArrowUp") {
-        e.preventDefault();
-        setCursor((c) => Math.max(c - 1, 0));
-      } else if (e.key === "Enter") {
-        const pick = visible[cursor];
-        if (pick) {
-          onSelect(pick.id);
-          close();
-        }
-      }
-    }
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [open, visible, cursor, onSelect]);
+  function pick(id: string) {
+    onSelect(id);
+    setOpen(false);
+    reset();
+  }
 
   return (
-    <>
-      <Trigger label={label} current={current} onOpen={() => setOpen(true)} />
-      {open ? (
-        <div className="fixed inset-0 z-50 flex items-start justify-center p-4 pt-[12vh]">
-          <div className="absolute inset-0 bg-foreground/25 backdrop-blur-[2px]" onClick={close} />
-          <div role="dialog" aria-label={label} className="relative z-10 w-full max-w-lg overflow-hidden bg-card shadow-[0_24px_70px_rgba(30,35,45,0.3)]">
-            <div className="flex items-center gap-2.5 px-4 pb-2.5 pt-3">
-              <span className="stamp text-[var(--sumire)]">{label}</span>
+    <div>
+      <div className={`mb-1.5 ${KX_LABEL}`}>{label}</div>
+      <Popover.Root
+        open={open}
+        onOpenChange={(o) => {
+          setOpen(o);
+          if (!o) reset();
+        }}
+      >
+        <Popover.Trigger asChild>
+          <button
+            type="button"
+            className="group flex w-full items-center gap-2.5 bg-card/70 px-2.5 py-2 text-left shadow-[0_1px_2px_rgba(30,35,45,0.05),0_2px_8px_rgba(30,35,45,0.05)] backdrop-blur-[3px] transition-all hover:-translate-y-[1px] hover:bg-card"
+          >
+            {current ? <ItemMedia item={current} /> : null}
+            <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-foreground">
+              {current?.name ?? "Choose…"}
+            </span>
+            <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-muted-foreground transition-colors group-hover:text-foreground">
+              browse
+            </span>
+          </button>
+        </Popover.Trigger>
+
+        <Popover.Portal>
+          <Popover.Content
+            align="start"
+            side="bottom"
+            sideOffset={8}
+            collisionPadding={12}
+            onOpenAutoFocus={(e) => {
+              e.preventDefault(); // focus the search box, not the first row — and never scroll the page
+              inputRef.current?.focus({ preventScroll: true });
+            }}
+            className="z-50 flex max-h-[min(60vh,26rem)] w-[min(92vw,22rem)] flex-col overflow-hidden bg-card shadow-[0_18px_50px_rgba(30,35,45,0.24)]"
+          >
+            <div className="shrink-0 bg-card px-4 pb-2.5 pt-3">
+              <div className="mb-2 flex items-center justify-between">
+                <span className="stamp text-[var(--sumire)]">{label}</span>
+                <Popover.Close className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground transition-colors hover:text-foreground">
+                  done
+                </Popover.Close>
+              </div>
               <input
-                autoFocus
+                ref={inputRef}
                 value={q}
                 onChange={(e) => {
                   setQ(e.target.value);
                   setCursor(0);
                 }}
+                onKeyDown={(e) => {
+                  if (e.key === "ArrowDown") {
+                    e.preventDefault();
+                    setCursor((c) => Math.min(c + 1, visible.length - 1));
+                  } else if (e.key === "ArrowUp") {
+                    e.preventDefault();
+                    setCursor((c) => Math.max(c - 1, 0));
+                  } else if (e.key === "Enter") {
+                    const p = visible[cursor];
+                    if (p) pick(p.id);
+                  }
+                }}
                 placeholder={searchPlaceholder(facets)}
-                className={`${KX_FIELD} min-w-0 flex-1`}
+                className={`${KX_FIELD} h-10 text-[15px] sm:h-9 sm:text-[13px]`}
               />
-              <span className="font-mono text-[9px] uppercase tracking-[0.14em] text-muted-foreground/60">esc</span>
-            </div>
-            {facets.length > 0 ? (
-              <div className="px-4 pb-3">
-                <FacetChips facets={facets} active={active} onToggle={(k, v) => { toggle(setActive, k, v); setCursor(0); }} />
-              </div>
-            ) : null}
-            <div className="sticker-perforation" />
-            <div className="max-h-[52vh] overflow-y-auto py-1" role="listbox">
-              {visible.map((it, i) => (
-                <ItemRow key={it.id} item={it} active={i === cursor} onPick={() => { onSelect(it.id); close(); }} />
-              ))}
-              {filtered.length === 0 ? <EmptyResults /> : <CountHint shown={visible.length} total={filtered.length} noun={noun} />}
-            </div>
-          </div>
-        </div>
-      ) : null}
-    </>
-  );
-}
-
-// ── Variant B: in-place picker — anchored dropdown on desktop, bottom-sheet on
-// mobile. Never takes over the viewport or scrolls the page away, so the live
-// preview below stays visible while you choose. Scroll position is preserved.
-
-export function DrawerPicker({
-  label,
-  items,
-  value,
-  onSelect,
-}: {
-  label: string;
-  items: PickItem[];
-  value?: string;
-  onSelect: (id: string) => void;
-}) {
-  const [open, setOpen] = useState(false);
-  const [q, setQ] = useState("");
-  const [active, setActive] = useState<Record<string, Set<string>>>({});
-  const current = items.find((i) => i.id === value);
-  const facets = useFacets(items);
-  const filtered = useFiltered(items, q, active);
-  const visible = filtered.slice(0, RESULT_CAP);
-  const rootRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const noun = label.toLowerCase();
-
-  function close() {
-    setOpen(false);
-    setQ("");
-    setActive({});
-  }
-
-  // Esc to close + click-away (desktop). The mobile backdrop handles its own close.
-  useEffect(() => {
-    if (!open) return;
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") close();
-    }
-    function onDown(e: MouseEvent) {
-      if (rootRef.current && !rootRef.current.contains(e.target as Node)) close();
-    }
-    window.addEventListener("keydown", onKey);
-    window.addEventListener("mousedown", onDown);
-    // focus search WITHOUT scrolling the page to it (the old jump-to-top cause)
-    inputRef.current?.focus({ preventScroll: true });
-    return () => {
-      window.removeEventListener("keydown", onKey);
-      window.removeEventListener("mousedown", onDown);
-    };
-  }, [open]);
-
-  // On mobile only, lock the body while the sheet is up and restore the exact
-  // scroll position on close — so opening/closing never moves the page.
-  useEffect(() => {
-    if (!open) return;
-    if (typeof window === "undefined" || !window.matchMedia("(max-width: 639px)").matches) return;
-    const y = window.scrollY;
-    const body = document.body;
-    const prev = { position: body.style.position, top: body.style.top, width: body.style.width };
-    body.style.position = "fixed";
-    body.style.top = `-${y}px`;
-    body.style.width = "100%";
-    return () => {
-      body.style.position = prev.position;
-      body.style.top = prev.top;
-      body.style.width = prev.width;
-      window.scrollTo(0, y);
-    };
-  }, [open]);
-
-  return (
-    <div ref={rootRef} className="relative">
-      <Trigger label={label} current={current} onOpen={() => (open ? close() : setOpen(true))} />
-      {open ? (
-        <>
-          {/* light scrim on mobile only — desktop stays a non-blocking dropdown */}
-          <div className="fixed inset-0 z-40 bg-foreground/20 backdrop-blur-[1px] sm:hidden" onClick={close} />
-          <div
-            role="dialog"
-            aria-label={label}
-            className="fixed inset-x-0 bottom-0 z-50 flex max-h-[82vh] flex-col rounded-t-[16px] bg-card shadow-[0_-20px_60px_rgba(30,35,45,0.28)] sm:absolute sm:inset-x-auto sm:bottom-auto sm:left-0 sm:top-[calc(100%+8px)] sm:z-30 sm:max-h-[58vh] sm:w-[clamp(300px,90vw,380px)] sm:max-w-[90vw] sm:rounded-none sm:shadow-[0_18px_50px_rgba(30,35,45,0.22)]"
-          >
-            {/* sticky head: drag affordance (mobile) + label + close, then search */}
-            <div className="shrink-0 bg-card pt-2">
-              <span aria-hidden className="mx-auto mb-1.5 block h-1 w-9 rounded-full bg-foreground/15 sm:hidden" />
-              <header className="flex items-center justify-between px-4 pb-2">
-                <span className="stamp text-[var(--sumire)]">{label}</span>
-                <button type="button" onClick={close} className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground transition-colors hover:text-foreground">
-                  done
-                </button>
-              </header>
-              <div className="px-4 pb-2.5">
-                <input
-                  ref={inputRef}
-                  value={q}
-                  onChange={(e) => setQ(e.target.value)}
-                  placeholder={searchPlaceholder(facets)}
-                  className={`${KX_FIELD} h-10 text-[15px] sm:h-9 sm:text-[13px]`}
-                />
-              </div>
               {facets.length > 0 ? (
-                <div className="px-4 pb-2.5">
-                  <FacetChips facets={facets} active={active} onToggle={(k, v) => toggle(setActive, k, v)} />
+                <div className="mt-2.5">
+                  <FacetChips
+                    facets={facets}
+                    active={active}
+                    onToggle={(k, v) => {
+                      toggle(setActive, k, v);
+                      setCursor(0);
+                    }}
+                  />
                 </div>
               ) : null}
-              <div className="sticker-perforation mx-4" />
             </div>
+
+            <div className="sticker-perforation mx-4" />
+
             <div className="flex-1 overflow-y-auto overscroll-contain py-1" role="listbox">
-              {visible.map((it) => (
-                <ItemRow key={it.id} item={it} active={it.id === value} onPick={() => { onSelect(it.id); close(); }} />
+              {visible.map((it, i) => (
+                <ItemRow
+                  key={it.id}
+                  item={it}
+                  selected={it.id === value}
+                  highlighted={i === cursor}
+                  onPick={() => pick(it.id)}
+                />
               ))}
               {filtered.length === 0 ? <EmptyResults /> : null}
             </div>
-            <div className="shrink-0 bg-card">
+
+            <div className="shrink-0">
               <div className="sticker-perforation mx-4" />
-              <footer className="px-4 py-2.5 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground/70">
-                {filtered.length === items.length ? `${items.length} ${noun} · tap to apply` : `${filtered.length} of ${items.length} ${noun}`}
-              </footer>
+              <CountHint shown={visible.length} total={filtered.length} noun={noun} />
             </div>
-          </div>
-        </>
-      ) : null}
+          </Popover.Content>
+        </Popover.Portal>
+      </Popover.Root>
     </div>
   );
 }

--- a/ui/src/components/remix/inline-remix.tsx
+++ b/ui/src/components/remix/inline-remix.tsx
@@ -139,10 +139,12 @@ export function InlineRemix({
     () =>
       palettes.map((p) => {
         const facets: Record<string, string> = {};
-        // Bucket the compound temperature ("cool-balanced") to its axis so it's
-        // a small, usable facet (cool/warm/neutral), not a dozen one-offs.
-        if (p.temperature) facets.temperature = p.temperature.split("-")[0].trim();
-        if (p.keyHue) facets.hue = p.keyHue; // free-text; stays searchable, not a chip (dropped by the cardinality guard)
+        // temperature + keyHue are free-text ("warm with cool indigo structure",
+        // "transformative teal") — near-unique, so the cardinality guard keeps
+        // them out of the chip row. They stay in facets so the text search still
+        // covers them (via the haystack); they just aren't shown as filters.
+        if (p.temperature) facets.temperature = p.temperature;
+        if (p.keyHue) facets.hue = p.keyHue;
         return {
           id: p.id,
           name: p.name,

--- a/ui/src/components/remix/inline-remix.tsx
+++ b/ui/src/components/remix/inline-remix.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { RemixPreview } from "@/components/remix/remix-preview";
-import { CommandPicker, DrawerPicker, type PickItem } from "@/components/remix/entity-picker";
+import { EntityPicker, type PickItem } from "@/components/remix/entity-picker";
 import { WashiTape } from "@/components/scrapbook";
 import { buildRemixBrief } from "@/lib/remix-brief";
 import { COMPOSITIONS } from "@/lib/remix-compositions";
@@ -97,7 +97,6 @@ export function InlineRemix({
   palettes,
   art,
   fixed = {},
-  variant = "command",
   enableSave = false,
   initial,
 }: {
@@ -105,7 +104,6 @@ export function InlineRemix({
   palettes: PaletteOpt[];
   art: ArtOpt[];
   fixed?: { language?: string; palette?: string; art?: string };
-  variant?: "command" | "drawer";
   enableSave?: boolean;
   initial?: { langId?: string; palId?: string; artId?: string; compositionKey?: string };
 }) {
@@ -125,8 +123,6 @@ export function InlineRemix({
   const pal = palettes.find((p) => p.id === palId) ?? palettes[0];
   const sel = art.find((a) => a.id === artId) ?? art[0];
   const comp = COMPS[compIdx] ?? COMPS[0];
-
-  const Picker = variant === "drawer" ? DrawerPicker : CommandPicker;
 
   const langItems: PickItem[] = useMemo(
     () =>
@@ -232,17 +228,17 @@ export function InlineRemix({
         {fixed.language ? (
           <FixedChip label="UI language" name={lang?.name ?? "—"} media={<Thumb src={lang?.thumb} />} />
         ) : (
-          <Picker label="UI language" items={langItems} value={langId} onSelect={setLangId} />
+          <EntityPicker label="UI language" items={langItems} value={langId} onSelect={setLangId} />
         )}
         {fixed.palette ? (
           <FixedChip label="Palette" name={pal?.name ?? "—"} media={<Swatches colors={pal?.swatches ?? []} />} />
         ) : (
-          <Picker label="Palette" items={palItems} value={palId} onSelect={setPalId} />
+          <EntityPicker label="Palette" items={palItems} value={palId} onSelect={setPalId} />
         )}
         {fixed.art ? (
           <FixedChip label="Art style" name={sel?.name ?? "—"} media={<Thumb src={sel?.hero} />} />
         ) : (
-          <Picker label="Art style" items={artItems} value={artId} onSelect={setArtId} />
+          <EntityPicker label="Art style" items={artItems} value={artId} onSelect={setArtId} />
         )}
       </div>
 

--- a/ui/src/components/remix/inline-remix.tsx
+++ b/ui/src/components/remix/inline-remix.tsx
@@ -139,8 +139,10 @@ export function InlineRemix({
     () =>
       palettes.map((p) => {
         const facets: Record<string, string> = {};
-        if (p.temperature) facets.temperature = p.temperature;
-        if (p.keyHue) facets.hue = p.keyHue;
+        // Bucket the compound temperature ("cool-balanced") to its axis so it's
+        // a small, usable facet (cool/warm/neutral), not a dozen one-offs.
+        if (p.temperature) facets.temperature = p.temperature.split("-")[0].trim();
+        if (p.keyHue) facets.hue = p.keyHue; // free-text; stays searchable, not a chip (dropped by the cardinality guard)
         return {
           id: p.id,
           name: p.name,

--- a/ui/src/components/remix/studio-client.tsx
+++ b/ui/src/components/remix/studio-client.tsx
@@ -36,7 +36,6 @@ export function StudioClient({
         languages={ui}
         palettes={palettes}
         art={art}
-        variant="command"
         enableSave
         initial={initial}
       />


### PR DESCRIPTION
The lane picker (Studio remix + palette/art/language detail pages) opened a **busy, misplaced, page-hijacking pop-up**. Reported: "a huge pop-up with a lot of busy tags that don't make sense… poorly aligned on all devices… takes you away from where you were working."

## Root causes (confirmed in code)
- **Busy tags:** `useFacets` rendered *every distinct value of every facet, uncapped*. For palettes the `hue` row = free-text `key_hue`, **near-unique per palette** → a wall of one-off chips each matching ~1 item (why palettes were worst).
- **Random placement:** hand-rolled positioning, no collision detection — a fixed-width panel anchored `left-0` ran off-screen for right-column triggers, never flipped, wasn't portaled (parent blur/transforms shifted it).
- **Takes you away:** in Studio it was a full-screen modal with a page-dimming scrim that hid the live preview, stole focus, and hijacked global ↑/↓/Enter keys.

## Fix
- One **`EntityPicker` on Radix Popover** (portaled, collision-aware flip/shift, viewport-clamped) on every screen — no takeover, no global-key hijack, keyboard nav scoped to the search field. Drops the command/drawer variant split + the dead `variant` prop.
- **Facets now surface only low-cardinality keys (2..8 distinct values)** with counts, sorted by frequency — free-text keys like `hue` drop out automatically (still searchable via the text box). Generic fix, not a hue special-case.

UI-only. Build (full `npm run build` incl. contract test) / tsc / eslint ✓. Verified on preview against real data.