### PR TITLE
feat(rum): rank languages by readable name in the RUM dashboard

### DIFF
--- a/infra/datadog/README.md
+++ b/infra/datadog/README.md
@@ -63,9 +63,10 @@ No PII: `defaultPrivacyLevel: mask-user-input`, no session replay.
    (`CARDINALITY(@usr.anonymous_id)`); the "Languages & engagement" group ranks
    languages by **unique visitors** for page views / copies / downloads, lists
    the buttons clicked on language pages, and each language row links through to
-   katagami.ai. Until the instrumented UI is deployed those rollups key on
-   `@view.url_path` / `@context.language_id` (id); once `language_name` flows
-   they can switch to readable names (no backfill of pre-deploy data).
+   katagami.ai. The page-views / copies / downloads rollups group by readable
+   `@context.language_name` (from the `language_view` / `copy` / `download`
+   events); they only count traffic since the instrumented UI deployed (no
+   backfill), so they fill in over time.
 
 ## Facets (confirmed against live data)
 

--- a/infra/datadog/katagami-rum-dashboard.json
+++ b/infra/datadog/katagami-rum-dashboard.json
@@ -292,11 +292,11 @@
                       "data_source": "rum",
                       "name": "langUV",
                       "indexes": ["*"],
-                      "search": { "query": "env:production @type:view @view.url_path:/language/*" },
+                      "search": { "query": "env:production @type:action @action.target.name:language_view" },
                       "compute": { "aggregation": "cardinality", "metric": "@usr.anonymous_id" },
                       "group_by": [
                         {
-                          "facet": "@view.url_path",
+                          "facet": "@context.language_name",
                           "limit": 25,
                           "sort": { "aggregation": "cardinality", "metric": "@usr.anonymous_id", "order": "desc" }
                         }
@@ -307,7 +307,7 @@
                 }
               ],
               "custom_links": [
-                { "label": "Open language on katagami.ai", "link": "https://katagami.ai{{@view.url_path}}" }
+                { "label": "Open language on katagami.ai", "link": "https://katagami.ai/language/{{@context.language_id}}" }
               ]
             },
             "layout": { "x": 0, "y": 0, "width": 6, "height": 4 }
@@ -353,11 +353,11 @@
                       "data_source": "rum",
                       "name": "copyUV",
                       "indexes": ["*"],
-                      "search": { "query": "env:production @type:action @action.target.name:copy @context.language_id:*" },
+                      "search": { "query": "env:production @type:action @action.target.name:copy @context.language_name:*" },
                       "compute": { "aggregation": "cardinality", "metric": "@usr.anonymous_id" },
                       "group_by": [
                         {
-                          "facet": "@context.language_id",
+                          "facet": "@context.language_name",
                           "limit": 20,
                           "sort": { "aggregation": "cardinality", "metric": "@usr.anonymous_id", "order": "desc" }
                         }
@@ -385,11 +385,11 @@
                       "data_source": "rum",
                       "name": "dlUV",
                       "indexes": ["*"],
-                      "search": { "query": "env:production @type:action @action.target.name:download @context.language_id:*" },
+                      "search": { "query": "env:production @type:action @action.target.name:download @context.language_name:*" },
                       "compute": { "aggregation": "cardinality", "metric": "@usr.anonymous_id" },
                       "group_by": [
                         {
-                          "facet": "@context.language_id",
+                          "facet": "@context.language_name",
                           "limit": 20,
                           "sort": { "aggregation": "cardinality", "metric": "@usr.anonymous_id", "order": "desc" }
                         }


### PR DESCRIPTION
Switches the three language rollups (page views / copies / downloads) to group by `@context.language_name` now that the `language_view`/`copy`/`download` events ship the name (deployed and verified live — events landing as e.g. *Sumiha*, *Civic Press*). Unique-visitor counts; each row links through to the language page via `@context.language_id`. Post-deploy traffic only (RUM has no backfill), so the lists fill in over time. Live dashboard already updated via API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)