### PR TITLE
feat(facets): faceted gallery search via stored fields (ARN-126) [WIP]

### DIFF
--- a/katagami-commons/specs/design_language.ioa.toml
+++ b/katagami-commons/specs/design_language.ioa.toml
@@ -329,6 +329,13 @@ from = ["Draft", "UnderReview", "Published"]
 params = ["taste_vector", "taste_vector_model"]
 hint = "Attach the semantic taste embedding computed from the language's canonical taste document (name, tags, philosophy summary, typography, palette). taste_vector is a JSON float array; taste_vector_model identifies the embedding model so mixed-model vectors are never compared. Written by the curation finalizer after quality review, or by the backfill job."
 
+[[action]]
+name = "AttachComputedFacets"
+kind = "internal"
+from = ["Draft", "UnderReview", "Published"]
+params = ["search_blob", "hue_bucket", "family_id"]
+hint = "Attach precomputed gallery facets so the catalog filters + searches server-side under keyset pagination — the kernel only $filters flat stored scalars, and only case-sensitively, so these are derived once at publish and stored. search_blob = lowercase(name + tags + philosophy summary) for case-insensitive contains; hue_bucket = HSL bucket of the primary token color (one of neutral/red/orange/yellow/green/teal/blue/violet/pink); family_id = the language's root taxonomy family id. Written by the curation finalizer after quality review, or by the backfill job."
+
 # --- Actions: Classification ---
 
 [[action]]

--- a/katagami-commons/specs/model.csdl.xml
+++ b/katagami-commons/specs/model.csdl.xml
@@ -76,6 +76,14 @@
              related languages). JSON float array + the model that made it. -->
         <Property Name="TasteVector" Type="Edm.String" Nullable="false" DefaultValue="" />
         <Property Name="TasteVectorModel" Type="Edm.String" Nullable="false" DefaultValue="" />
+        <!-- Precomputed gallery facets: flat scalars for server-side filtering +
+             keyset pagination. The kernel can only $filter stored scalars (not
+             JSON-derived values, and only case-sensitively), so the categorical
+             facets are derived once at publish and stored here. Written by the
+             curation finalizer / backfill via AttachComputedFacets. -->
+        <Property Name="SearchBlob" Type="Edm.String" Nullable="false" DefaultValue="" />
+        <Property Name="HueBucket" Type="Edm.String" Nullable="false" DefaultValue="" />
+        <Property Name="FamilyId" Type="Edm.String" Nullable="false" DefaultValue="" />
         <!-- Quality signals -->
         <Property Name="QualityScore" Type="Edm.String" Nullable="false" DefaultValue="{}" />
         <Property Name="QualityReviewPassed" Type="Edm.Boolean" Nullable="false" DefaultValue="false" />

--- a/ui/scripts/backfill-facets.mjs
+++ b/ui/scripts/backfill-facets.mjs
@@ -1,0 +1,121 @@
+// Backfill precomputed gallery facets (search_blob, hue_bucket, family_id) onto
+// every Published DesignLanguage via the AttachComputedFacets action. Idempotent
+// + additive (re-runnable; nothing deleted). DRY-RUN by default; pass --apply to
+// write. Concurrency capped at 10 (batch-pipeline limit).
+//
+// Env (source .env.katagami-curator.local — points at openpaw-production):
+//   TEMPER_API_URL, TEMPER_API_KEY, TEMPER_TENANT (default "default")
+//
+// Reads the canonical (unprojected) rows so tokens + taxonomy_ids are present
+// (a $select projection drops list fields — ARN-97).
+import { hueBucket, familyId, searchBlob } from "./facets.mjs";
+
+const API = requiredEnv("TEMPER_API_URL").replace(/\/+$/, "");
+const KEY = requiredEnv("TEMPER_API_KEY");
+const TENANT = process.env.TEMPER_TENANT || "default";
+const APPLY = process.argv.includes("--apply");
+const CONCURRENCY = 10;
+// Namespace fallback, mirroring the app's dispatchAction (AttachTasteVector
+// resolves as Temper.* today; try the others if the kernel disagrees).
+const NAMESPACES = ["Temper", "KatagamiCommons", "Katagami.Curation", "Katagami"];
+const H = { "X-Tenant-Id": TENANT, Authorization: `Bearer ${KEY}` };
+
+async function collectAll(path) {
+  const out = [];
+  let url = `${API}/tdata/${path}`;
+  while (url) {
+    const res = await fetch(url, { headers: H });
+    if (!res.ok) throw new Error(`GET ${url} -> ${res.status}: ${await res.text()}`);
+    const j = await res.json();
+    out.push(...(j.value ?? []));
+    url = j["@odata.nextLink"] ?? null;
+  }
+  return out;
+}
+
+function fieldsOf(row) {
+  let f = row.fields ?? row;
+  if (f && f.fields && typeof f.fields === "object") f = f.fields;
+  return f ?? {};
+}
+
+async function attach(id, facets) {
+  let lastErr = "";
+  for (const ns of NAMESPACES) {
+    const res = await fetch(
+      `${API}/tdata/DesignLanguages('${id}')/${ns}.AttachComputedFacets`,
+      { method: "POST", headers: { ...H, "Content-Type": "application/json" }, body: JSON.stringify(facets) },
+    );
+    if (res.ok) return ns;
+    lastErr = `${ns} -> ${res.status}: ${(await res.text()).slice(0, 160)}`;
+    if (res.status !== 404) break; // 404 = wrong namespace; anything else is a real error
+  }
+  throw new Error(lastErr);
+}
+
+async function main() {
+  const taxRows = await collectAll("Taxonomies?$top=5000");
+  const taxIndex = new Map();
+  for (const r of taxRows) {
+    const id = r.entity_id ?? fieldsOf(r).Id;
+    if (!id) continue;
+    const f = fieldsOf(r);
+    taxIndex.set(id, { parentId: String(f.parent_id ?? f.ParentId ?? "").trim() });
+  }
+  console.log(`taxonomy nodes: ${taxIndex.size}`);
+
+  // $top must exceed the corpus in one page: the kernel caps a page and omits
+  // @odata.nextLink (ARN-97 class), so a small $top silently drops the tail.
+  const langs = await collectAll("DesignLanguages?$filter=Status eq 'Published'&$top=5000");
+  console.log(`published languages: ${langs.length}   mode: ${APPLY ? "APPLY" : "DRY-RUN"}`);
+
+  const items = langs.map((row) => {
+    const f = fieldsOf(row);
+    return {
+      id: row.entity_id ?? f.Id,
+      name: f.name,
+      facets: {
+        search_blob: searchBlob(f.name, f.tags, f.philosophy),
+        hue_bucket: hueBucket(f.tokens),
+        family_id: familyId(f.taxonomy_ids, taxIndex),
+      },
+    };
+  });
+
+  const hueDist = {};
+  const famCount = items.filter((i) => i.facets.family_id).length;
+  for (const it of items) hueDist[it.facets.hue_bucket] = (hueDist[it.facets.hue_bucket] || 0) + 1;
+  console.log("hue distribution:", JSON.stringify(hueDist));
+  console.log(`family_id resolved: ${famCount}/${items.length}`);
+  console.log("sample:", JSON.stringify(items.slice(0, 4).map((i) => ({ name: i.name, hue: i.facets.hue_bucket, fam: i.facets.family_id || "-", blob: i.facets.search_blob.slice(0, 36) })), null, 0));
+
+  if (!APPLY) {
+    console.log("\nDRY-RUN — no writes. Re-run with --apply to backfill.");
+    return;
+  }
+
+  let done = 0, failed = 0, nsUsed = "";
+  const queue = [...items];
+  async function worker() {
+    while (queue.length) {
+      const it = queue.shift();
+      try {
+        nsUsed = await attach(it.id, it.facets);
+        done++;
+      } catch (e) {
+        failed++;
+        console.error(`FAIL ${it.id} (${it.name}): ${String(e).slice(0, 200)}`);
+      }
+      if ((done + failed) % 25 === 0) console.log(`  ${done + failed}/${items.length}`);
+    }
+  }
+  await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+  console.log(`\ndone: ${done} written (via ${nsUsed}.AttachComputedFacets), ${failed} failed`);
+}
+
+function requiredEnv(n) {
+  const v = process.env[n];
+  if (!v) { console.error(`missing env ${n} — source .env.katagami-curator.local`); process.exit(1); }
+  return v;
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/ui/scripts/facets.mjs
+++ b/ui/scripts/facets.mjs
@@ -1,0 +1,98 @@
+// Canonical facet derivations for the design-language gallery — the SINGLE
+// source of truth, consumed by the backfill (Node) and, ported identically, by
+// the curation finalizer (Rust). Pure + deterministic so both produce the same
+// stored scalars. The kernel can only $filter flat stored scalars (and only
+// case-sensitively), so these are computed once at publish and stored on the row
+// (search_blob / hue_bucket / family_id), then filtered server-side.
+//
+// Keep this in lockstep with the Rust port — the shared test vectors in
+// facets.test.mjs are the contract both must satisfy.
+
+/**
+ * HSL hue bucket of a language's primary token color.
+ * NORMALIZED (ARN-126): only 3- or 6-digit hex are treated as real colors;
+ * anything else (malformed, alpha, missing, grayscale, low-saturation) → "neutral".
+ * This deliberately drops the pre-refactor 4/5/7/8-digit NaN→"pink" quirk —
+ * real tokens are 6-digit, so the quirk only ever mislabelled bad data.
+ * @returns one of neutral|red|orange|yellow|green|teal|blue|violet|pink
+ */
+export function hueBucket(tokens) {
+  const t = typeof tokens === "string" ? safeJson(tokens) : tokens;
+  const hex = t?.colors?.primary ?? t?.colors?.accent;
+  if (typeof hex !== "string") return "neutral";
+  const m = hex.replace(/^#/, "").toLowerCase();
+  if (!/^[0-9a-f]+$/.test(m) || (m.length !== 3 && m.length !== 6)) return "neutral";
+  const v =
+    m.length === 3
+      ? m.split("").map((c) => parseInt(c + c, 16) / 255)
+      : [0, 2, 4].map((i) => parseInt(m.slice(i, i + 2), 16) / 255);
+  const [r, g, b] = v;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  if (max === min) return "neutral";
+  const l = (max + min) / 2;
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  if (s < 0.14) return "neutral";
+  let h;
+  if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) * 60;
+  else if (max === g) h = ((b - r) / d + 2) * 60;
+  else h = ((r - g) / d + 4) * 60;
+  if (h >= 345 || h < 15) return "red";
+  if (h < 45) return "orange";
+  if (h < 75) return "yellow";
+  if (h < 160) return "green";
+  if (h < 200) return "teal";
+  if (h < 260) return "blue";
+  if (h < 300) return "violet";
+  return "pink";
+}
+
+/**
+ * Root taxonomy family id: the first of a language's taxonomy_ids that exists in
+ * the tree (its primary leaf), walked up parentId to its highest present
+ * ancestor. taxIndex: Map<id, { parentId }>. Returns "" for orphans / no taxonomy.
+ * The walk order must match the stored taxonomy_ids order (pipeline + backfill
+ * read the same canonical row), so first-known-leaf is deterministic.
+ */
+export function familyId(taxonomyIds, taxIndex) {
+  const ids = Array.isArray(taxonomyIds) ? taxonomyIds : safeJson(taxonomyIds);
+  if (!Array.isArray(ids)) return "";
+  const leaf = ids.find((id) => typeof id === "string" && taxIndex.has(id));
+  if (!leaf) return "";
+  let cur = leaf;
+  for (let guard = 0; guard < 64; guard++) {
+    const parent = taxIndex.get(cur)?.parentId;
+    if (!parent || !taxIndex.has(parent)) break;
+    cur = parent;
+  }
+  return cur;
+}
+
+/**
+ * Lowercased search text: name + tags + philosophy summary, collapsed. Powers
+ * case-insensitive contains() — the kernel has no tolower/$search/matchesPattern.
+ */
+export function searchBlob(name, tags, philosophy) {
+  const tagArr = Array.isArray(tags) ? tags : safeJson(tags);
+  const phil = typeof philosophy === "string" ? safeJson(philosophy) : philosophy;
+  const summary = phil && typeof phil === "object" ? phil.summary ?? "" : "";
+  return [
+    String(name ?? ""),
+    ...(Array.isArray(tagArr) ? tagArr.map(String) : []),
+    String(summary ?? ""),
+  ]
+    .join(" ")
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function safeJson(s) {
+  if (typeof s !== "string" || !s) return undefined;
+  try {
+    return JSON.parse(s);
+  } catch {
+    return undefined;
+  }
+}

--- a/ui/scripts/facets.test.mjs
+++ b/ui/scripts/facets.test.mjs
@@ -1,0 +1,59 @@
+// Shared contract vectors for the facet derivations. The Rust finalizer port
+// MUST satisfy the same vectors so pipeline + backfill never drift.
+// Run: node ui/scripts/facets.test.mjs
+import { hueBucket, familyId, searchBlob } from "./facets.mjs";
+
+let fails = 0;
+const eq = (got, want, msg) => {
+  const ok = JSON.stringify(got) === JSON.stringify(want);
+  if (!ok) {
+    fails++;
+    console.error(`FAIL ${msg}: got ${JSON.stringify(got)} want ${JSON.stringify(want)}`);
+  }
+};
+
+// --- hueBucket ---
+eq(hueBucket({ colors: { primary: "#ff0000" } }), "red", "pure red");
+eq(hueBucket({ colors: { primary: "#00ff00" } }), "green", "pure green");
+eq(hueBucket({ colors: { primary: "#0000ff" } }), "blue", "pure blue");
+eq(hueBucket({ colors: { primary: "#00ced1" } }), "teal", "darkturquoise→teal");
+eq(hueBucket({ colors: { primary: "#8a2be2" } }), "violet", "blueviolet→violet");
+eq(hueBucket({ colors: { primary: "#ff69b4" } }), "pink", "hotpink→pink");
+eq(hueBucket({ colors: { primary: "#888888" } }), "neutral", "grayscale→neutral");
+eq(hueBucket({ colors: { primary: "#fff" } }), "neutral", "white 3-digit→neutral");
+eq(hueBucket({ colors: { primary: "#f00" } }), "red", "3-digit red");
+eq(hueBucket({ colors: { accent: "#0000ff" } }), "blue", "falls back to accent");
+eq(hueBucket({ colors: {} }), "neutral", "no color→neutral");
+eq(hueBucket(undefined), "neutral", "no tokens→neutral");
+eq(hueBucket('{"colors":{"primary":"#ff0000"}}'), "red", "accepts JSON string");
+eq(hueBucket({ colors: { primary: "#ff000" } }), "neutral", "5-digit malformed→neutral (normalized, not pink)");
+eq(hueBucket({ colors: { primary: "#ff0000aa" } }), "neutral", "8-digit alpha→neutral (normalized)");
+eq(hueBucket({ colors: { primary: "rgb(255,0,0)" } }), "neutral", "non-hex→neutral");
+
+// --- familyId ---
+const tree = new Map([
+  ["leaf-poster", { parentId: "mid-print" }],
+  ["mid-print", { parentId: "root-graphic" }],
+  ["root-graphic", { parentId: "" }],
+  ["leaf-orphan", { parentId: "ghost-missing" }],
+]);
+eq(familyId(["leaf-poster"], tree), "root-graphic", "walks leaf→root");
+eq(familyId(["mid-print"], tree), "root-graphic", "mid→root");
+eq(familyId(["root-graphic"], tree), "root-graphic", "root→itself");
+eq(familyId(["leaf-orphan"], tree), "leaf-orphan", "missing parent stops at known node");
+eq(familyId(["unknown-x", "leaf-poster"], tree), "root-graphic", "skips unknown, uses first known leaf");
+eq(familyId([], tree), "", "no taxonomy→empty");
+eq(familyId('["leaf-poster"]', tree), "root-graphic", "accepts JSON string");
+
+// --- searchBlob ---
+eq(searchBlob("Cadence", ["Editorial", "Grid"], { summary: "A Bold System" }),
+   "cadence editorial grid a bold system", "lowercased blob");
+eq(searchBlob("Warm Editorial", '["warm"]', '{"summary":"Soft"}'),
+   "warm editorial warm soft", "accepts JSON strings");
+eq(searchBlob("X", [], null), "x", "minimal");
+
+if (fails) {
+  console.error(`\n${fails} test(s) FAILED`);
+  process.exit(1);
+}
+console.log("facets: all vectors pass");

--- a/ui/src/app/(site)/gallery-actions.ts
+++ b/ui/src/app/(site)/gallery-actions.ts
@@ -20,10 +20,14 @@ const LIMIT = 48;
 export async function loadLanguagePage(input: {
   cursor?: string | null;
   search?: string;
+  hue?: string;
+  family?: string;
 }): Promise<PageResult<DesignLanguage>> {
   return pageDesignLanguages({
     cursor: input.cursor ?? undefined,
     search: input.search,
+    hue: input.hue,
+    family: input.family,
     limit: LIMIT,
   });
 }

--- a/ui/src/components/infinite-galleries.tsx
+++ b/ui/src/components/infinite-galleries.tsx
@@ -27,6 +27,7 @@ function InfiniteShell({
   search,
   setSearch,
   placeholder,
+  toolbar,
   loading,
   exhausted,
   empty,
@@ -36,6 +37,7 @@ function InfiniteShell({
   search: string;
   setSearch: (v: string) => void;
   placeholder: string;
+  toolbar?: ReactNode;
   loading: boolean;
   exhausted: boolean;
   empty: boolean;
@@ -44,15 +46,18 @@ function InfiniteShell({
 }) {
   return (
     <div className="space-y-6">
-      <div className="relative max-w-sm">
-        <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-        <input
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder={placeholder}
-          aria-label={placeholder}
-          className={`${KX_FIELD} h-9 pl-7`}
-        />
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="relative max-w-sm flex-1">
+          <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={placeholder}
+            aria-label={placeholder}
+            className={`${KX_FIELD} h-9 pl-7`}
+          />
+        </div>
+        {toolbar}
       </div>
 
       {empty && !loading ? (
@@ -89,6 +94,65 @@ function CuratorsPicks({ children }: { children: ReactNode }) {
 
 const LANGUAGE_GRID = "grid gap-7 sm:grid-cols-2 lg:grid-cols-3";
 
+// The 9 hue_bucket facets, each with a representative ink. Toggling one filters
+// server-side (hue_bucket eq …), AND-composed with search + the keyset cursor.
+const HUE_SWATCHES: [string, string][] = [
+  ["red", "#e5484d"],
+  ["orange", "#f76b15"],
+  ["yellow", "#f5c000"],
+  ["green", "#30a46c"],
+  ["teal", "#12a594"],
+  ["blue", "#3b82f6"],
+  ["violet", "#8b5cf6"],
+  ["pink", "#e93d82"],
+  ["neutral", "#9ba1a6"],
+];
+
+function HueBar({
+  active,
+  onPick,
+}: {
+  active?: string;
+  onPick: (h?: string) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      <span className="mr-1 font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+        color
+      </span>
+      {HUE_SWATCHES.map(([bucket, color]) => (
+        <button
+          key={bucket}
+          type="button"
+          onClick={() => onPick(bucket)}
+          data-on={active === bucket}
+          aria-pressed={active === bucket}
+          title={bucket}
+          className="flex items-center gap-1 rounded-full py-0.5 pl-0.5 pr-1.5 transition-colors hover:bg-[color-mix(in_srgb,var(--foreground)_6%,transparent)] data-[on=true]:bg-foreground data-[on=true]:text-background"
+        >
+          <span
+            aria-hidden
+            className="h-3.5 w-3.5 rounded-full shadow-[inset_0_0_0_1px_rgba(0,0,0,0.14)]"
+            style={{ background: color }}
+          />
+          <span className="font-mono text-[10px] lowercase tracking-[0.02em]">
+            {bucket}
+          </span>
+        </button>
+      ))}
+      {active ? (
+        <button
+          type="button"
+          onClick={() => onPick(undefined)}
+          className="ml-1 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground transition-colors hover:text-foreground"
+        >
+          clear
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
 export function InfiniteLanguages({
   featured = [],
   initialItems,
@@ -100,9 +164,23 @@ export function InfiniteLanguages({
   initialCursor: string | null;
   canDelete?: boolean;
 }) {
-  const { items, search, setSearch, loading, cursor, sentinelRef } =
-    useInfiniteList<DesignLanguage>(initialItems, initialCursor, loadLanguagePage);
-  const browsing = search.trim() === "" && featured.length > 0;
+  const {
+    items,
+    search,
+    setSearch,
+    facets,
+    setFacet,
+    loading,
+    cursor,
+    sentinelRef,
+  } = useInfiniteList<DesignLanguage>(
+    initialItems,
+    initialCursor,
+    loadLanguagePage,
+  );
+  // Curator's picks lead only the unfiltered browse view.
+  const filtering = search.trim() !== "" || !!facets.hue || !!facets.family;
+  const browsing = !filtering && featured.length > 0;
   const pinnedIds = new Set(featured.map((f) => f.entity_id));
   const gridItems = browsing
     ? items.filter((l) => !pinnedIds.has(l.entity_id))
@@ -111,7 +189,8 @@ export function InfiniteLanguages({
     <InfiniteShell
       search={search}
       setSearch={setSearch}
-      placeholder="Search languages by name or tag…"
+      placeholder="Search languages…"
+      toolbar={<HueBar active={facets.hue} onPick={(h) => setFacet("hue", h)} />}
       loading={loading}
       exhausted={cursor === null}
       empty={(browsing ? featured.length : 0) + gridItems.length === 0}

--- a/ui/src/lib/odata.ts
+++ b/ui/src/lib/odata.ts
@@ -925,6 +925,8 @@ export interface PageOpts {
   cursor?: string | null;
   limit?: number;
   search?: string;
+  hue?: string; // hue_bucket facet (design languages)
+  family?: string; // family_id facet (design languages)
 }
 
 function odataLiteral(s: string): string {
@@ -935,14 +937,28 @@ function pageQuery(
   cursor: string | null | undefined,
   limit: number,
   search: string | undefined,
+  facets: {
+    searchField?: "search_blob" | "name_tags";
+    hue?: string;
+    family?: string;
+  } = {},
 ): string {
   const clauses = ["Status eq 'Published'"];
   if (cursor) clauses.push(`Id lt '${odataLiteral(cursor)}'`);
   const q = search?.trim();
   if (q) {
-    const lit = odataLiteral(q);
-    clauses.push(`(contains(name,'${lit}') or contains(tags,'${lit}'))`);
+    if (facets.searchField === "search_blob") {
+      // search_blob is stored lowercased → case-insensitive substring match
+      // (the kernel has no tolower/$search). Lowercase the query to match.
+      clauses.push(`contains(search_blob,'${odataLiteral(q.toLowerCase())}')`);
+    } else {
+      const lit = odataLiteral(q);
+      clauses.push(`(contains(name,'${lit}') or contains(tags,'${lit}'))`);
+    }
   }
+  if (facets.hue) clauses.push(`hue_bucket eq '${odataLiteral(facets.hue)}'`);
+  if (facets.family)
+    clauses.push(`family_id eq '${odataLiteral(facets.family)}'`);
   const params = new URLSearchParams();
   params.set("$filter", clauses.join(" and "));
   params.set("$orderby", "Id desc");
@@ -984,10 +1000,12 @@ export async function pageDesignLanguages({
   cursor,
   limit = 48,
   search,
+  hue,
+  family,
 }: PageOpts = {}): Promise<PageResult<DesignLanguage>> {
   try {
     const resp = await odata<{ value?: Record<string, unknown>[] }>(
-      `DesignLanguages?${pageQuery(cursor, limit, search)}`,
+      `DesignLanguages?${pageQuery(cursor, limit, search, { searchField: "search_blob", hue, family })}`,
     );
     const rows = (resp.value ?? [])
       .map(normalizeDesignLanguageRow)

--- a/ui/src/lib/use-infinite-list.ts
+++ b/ui/src/lib/use-infinite-list.ts
@@ -3,16 +3,21 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { PageResult } from "@/lib/odata";
 
+export type Facets = { hue?: string; family?: string };
+
 type LoadPage<T> = (input: {
   cursor?: string | null;
   search?: string;
+  hue?: string;
+  family?: string;
 }) => Promise<PageResult<T>>;
 
 /**
- * Keyset-paginated, infinite-scroll list with debounced server-side search.
- * Holds only the pages actually loaded (never the whole catalog): a sentinel
- * loads the next page as it nears the viewport, and typing resets to the query's
- * first server page.
+ * Keyset-paginated, infinite-scroll list with server-side search + facets
+ * (hue/family). Holds only the pages actually loaded (never the whole catalog):
+ * a sentinel loads the next page as it nears the viewport; typing or toggling a
+ * facet resets to the query's first server page. Every clause AND-composes with
+ * the keyset cursor server-side.
  */
 export function useInfiniteList<T>(
   initialItems: T[],
@@ -22,46 +27,63 @@ export function useInfiniteList<T>(
   const [items, setItems] = useState<T[]>(initialItems);
   const [cursor, setCursor] = useState<string | null>(initialCursor);
   const [search, setSearch] = useState("");
+  const [facets, setFacets] = useState<Facets>({});
   const [loading, setLoading] = useState(false);
-  const seq = useRef(0); // guards against out-of-order search/scroll responses
-  const skipFirstSearch = useRef(true);
+  const seq = useRef(0); // guards against out-of-order responses
+  const skipFirst = useRef(true);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
 
-  // Debounced server search → reset to the query's first page.
+  const paramsFor = useCallback(
+    () => ({
+      search: search.trim() || undefined,
+      hue: facets.hue,
+      family: facets.family,
+    }),
+    [search, facets],
+  );
+
+  // Toggle a facet (click same value again to clear it).
+  const setFacet = useCallback((key: keyof Facets, value?: string) => {
+    setFacets((prev) => {
+      const next = { ...prev };
+      if (!value || prev[key] === value) delete next[key];
+      else next[key] = value;
+      return next;
+    });
+  }, []);
+
+  // Any query change (search debounced, facets effectively immediate) → reset to
+  // the first page for the new query.
   useEffect(() => {
-    if (skipFirstSearch.current) {
-      skipFirstSearch.current = false; // the SSR first page already covers ""
+    if (skipFirst.current) {
+      skipFirst.current = false; // the SSR first page already covers the empty query
       return;
     }
-    const q = search.trim();
     const mine = ++seq.current;
     setLoading(true);
     const t = setTimeout(async () => {
-      const page = await loadPage({ search: q || undefined });
+      const page = await loadPage(paramsFor());
       if (mine !== seq.current) return;
       setItems(page.items);
       setCursor(page.nextCursor);
       setLoading(false);
     }, 300);
     return () => clearTimeout(t);
-  }, [search, loadPage]);
+  }, [search, facets, loadPage, paramsFor]);
 
   const loadMore = useCallback(async () => {
     if (loading || cursor === null) return;
     const mine = seq.current;
     setLoading(true);
     try {
-      const page = await loadPage({
-        cursor,
-        search: search.trim() || undefined,
-      });
-      if (mine !== seq.current) return; // a newer search superseded this
+      const page = await loadPage({ cursor, ...paramsFor() });
+      if (mine !== seq.current) return; // a newer query superseded this
       setItems((prev) => [...prev, ...page.items]);
       setCursor(page.nextCursor);
     } finally {
       if (mine === seq.current) setLoading(false);
     }
-  }, [loading, cursor, search, loadPage]);
+  }, [loading, cursor, loadPage, paramsFor]);
 
   // Infinite scroll: fetch the next page when the sentinel nears the viewport.
   useEffect(() => {
@@ -77,5 +99,5 @@ export function useInfiniteList<T>(
     return () => io.disconnect();
   }, [loadMore, cursor]);
 
-  return { items, search, setSearch, loading, cursor, sentinelRef };
+  return { items, search, setSearch, facets, setFacet, loading, cursor, sentinelRef };
 }


### PR DESCRIPTION
**Draft / WIP.** Restores case-insensitive search + color/family faceting on the languages gallery, server-side under keyset pagination. Plan: ARN-126.

The kernel has no case-insensitive matching and only `$filter`s flat **stored** scalars, so facets are computed once at publish + stored on each `DesignLanguage`.

### Landed so far
- **Spec (commons):** `SearchBlob` / `HueBucket` / `FamilyId` properties on the DesignLanguage entity + `AttachComputedFacets` internal action — modeled on the existing `AttachTasteVector` (a finalizer/backfill-written declared field that works in prod).
- **Compute (`ui/scripts/facets.mjs`):** canonical deterministic derivations (single source for backfill now, Rust finalizer later). `hueBucket` normalized to 3/6-digit hex (drops the old NaN→pink quirk); `familyId` taxonomy leaf→root walk; `searchBlob` lowercased name+tags+philosophy. Shared contract vectors (`facets.test.mjs`) all pass.

### Still to do
- Backfill script (~213 Published languages, idempotent, ≤10 concurrent) — needs the commons spec **deployed to the Railway Temper** first.
- UI facet bar (thread params through `pageQuery`/`gallery-actions`/`use-infinite-list`).
- (fast-follow) Rust finalizer port so new languages auto-get facets; extend search to palettes/art-styles.

### Blocked on
Deploying the commons spec to the live prod Temper needs a `GENESIS_API_KEY` (the local Temper is read-only, so the backfill + all verification run against prod).