### PR TITLE
feat(commons): first-class provenance tier for design languages (ADR-0016)

### DIFF
--- a/docs/adrs/0016-language-provenance-tiers.md
+++ b/docs/adrs/0016-language-provenance-tiers.md
@@ -1,0 +1,106 @@
+# ADR-0016: First-class provenance tier for design languages
+
+## Status
+
+Accepted
+
+## Context
+
+The commons holds two kinds of design language and cannot tell them apart. Most
+are **agent-generated** — synthesized end to end by the curation pipeline or a
+bake-off run. A growing few are **human-driven**: a person steers an existing
+(usually agent-generated) language through iterative, taste-led refinement into a
+new descendant. The first such language, **Chiclet**, is ready to submit — a human
+directed 13 rounds of refinement on **Pushpin** (an agent-generated corkboard
+language) via the iteration loop (ARN-124), and the steered rounds are captured as
+a trajectory.
+
+Nothing in the schema records **who did the creative work.** Lineage already exists
+(`parent_ids`, `lineage_type`, `generation_number` as params on `SetLineage`) but
+answers a different question — **what** a language descends from, not **who** made
+it. A human who elevates an agent language into something they own is invisible
+today.
+
+This matters beyond bookkeeping. The Design × AI Atlas research converged on
+exactly this need: ship a **machine-readable lineage card per language** (C2PA /
+Content Credentials style), scale credit to **provenance in honest tiers, never
+blurred**, and always say **"human-curated, AI-synthesized," never bare
+"AI-generated."** The taste-training pipeline also wants to filter gold data by who
+authored a language. A first-class provenance distinction is the prerequisite for
+all three.
+
+## Decision
+
+Add provenance as a first-class fact on `DesignLanguage`, orthogonal to lineage.
+
+- **`provenance_tier`** — a `[[state]]` of `type = "string"`, `initial =
+  "agent_generated"`, value set **`agent_generated` | `human_curated` |
+  `human_authored`**. It is modeled as a documented string (not an enum) because
+  the IOA specs have no `enum` type; this follows the existing `review_status` /
+  `embodiment_format` pattern.
+- **`has_provenance`** — a presence `bool` for the lineage card, mirroring
+  `has_model_provenance` / `has_credits`.
+- **`SetProvenanceTier`** — an `input` action from `Draft` / `UnderReview` /
+  `Published`, params `["provenance_tier", "provenance"]`, effect `set_bool
+  has_provenance = true`. `provenance` is the machine-readable lineage card:
+  `{tier, parent_ids, models[], human_curator, process (iteration-loop session +
+  steered rounds), created_at}`. Editable post-publish, like `SetModelProvenance` /
+  `SetCredits` — provenance is attribution metadata, not a governed source artifact.
+
+**Orthogonal to lineage.** `parent_ids` say what a language descends from;
+`provenance_tier` says who made it. A `human_curated` language normally has an
+`agent_generated` parent — that is the whole point.
+
+**Default `agent_generated`.** The curation pipeline's own output *is*
+agent-generated, so every existing language defaults to the correct tier with no
+migration and no change to the synthesize/submit flow. Human work is tagged
+explicitly via `SetProvenanceTier`.
+
+**Curator-verified through the existing review gate.** Submissions land
+`UnderReview` and are never self-published; the curator confirms the tier before
+`Publish`. An under-review tier is a *claim*; publishing blesses it. A
+`human_curated` claim is backed by the captured iteration-loop trajectory (the
+steered rounds are the evidence). No new hard gate is introduced.
+
+**Surfaced as a badge.** An on-brand chip on the gallery card and the language
+detail page (beside `Credits` / `ModelProvenance`) shows "Human-curated" /
+"Human-authored"; agent-generated is the unmarked default.
+
+## Consequences
+
+- The commons can now distinguish human-curated from agent-generated languages
+  first-class — a queryable field plus a visible badge. This is the foundation for
+  the honest-provenance / anti-slop position and for filtering taste-training data
+  by authorship.
+- **Chiclet** submits as `provenance_tier = human_curated` (parent Pushpin, curator
+  the human contributor, process the `iter-pushpin-1` session, 13 steered rounds).
+- `provenance_tier` is **not** a `SubmitForReview` / `Publish` guard and is **not**
+  added to the finalizer's `verify_review_ready_state` lists, so existing agent
+  submissions are unaffected and the change is non-breaking. It is a plain string
+  state, so L1 verification is unchanged; the *correctness* of the value is a
+  curation-review property, not a model-checked invariant.
+- The `provenance` lineage card is the seed of the C2PA-style machine-readable
+  record the Atlas research called for; a later step can export it as a
+  `LINEAGE.md` artifact beside `DESIGN.md`.
+
+## Rejected alternatives
+
+Reuse `model_provenance`. Rejected: it records *which AI models* produced a
+language, not whether a *human* drove the creative work — a `human_curated`
+language still used models. Different axis; conflating them loses the distinction
+we need.
+
+The Atlas draft enum `cataloged-tradition / agent-synthesized /
+contributor-deposited`. Rejected: it mixes source/lineage with authorship. An
+authorship tier (`agent_generated` / `human_curated` / `human_authored`) kept
+separate from lineage is cleaner and composes with the existing `SetLineage`.
+
+A separate `Provenance` / `LineageCard` entity. Rejected as premature: a field plus
+a JSON card on the language (as with `credits` / `model_provenance`) is enough for
+v1. Promote to an entity only if provenance needs its own lifecycle.
+
+A hard curator-verified gate before `Publish` now. Deferred: publishing already
+implies curator blessing. If self-claiming becomes a problem, add a
+`provenance_verified` bool flipped by `MarkQualityPassed` and a `Publish` guard —
+recorded as deferred, following the ADR-0015 pattern of enforcing invariants in the
+spec rather than in glue.

--- a/katagami-commons/specs/design_language.ioa.toml
+++ b/katagami-commons/specs/design_language.ioa.toml
@@ -162,6 +162,23 @@ name = "has_default_art_style"
 type = "bool"
 initial = "false"
 
+# Provenance — WHO did the creative work (ADR-0016). Distinct from lineage
+# (parent_ids / lineage_type = WHAT it descends from). Modeled as a string with a
+# closed value set (the IOA specs have no enum type; cf. review_status,
+# embodiment_format): "agent_generated" | "human_curated" | "human_authored".
+# Defaults to agent_generated — the curation pipeline's own output; human work is
+# tagged explicitly via SetProvenanceTier and confirmed by the curator at review.
+[[state]]
+name = "provenance_tier"
+type = "string"
+initial = "agent_generated"
+
+# Presence of the machine-readable provenance lineage card (the receipts).
+[[state]]
+name = "has_provenance"
+type = "bool"
+initial = "false"
+
 # --- Actions: Spec Authoring (Draft & UnderReview) ---
 
 [[action]]
@@ -368,6 +385,14 @@ from = ["Draft", "UnderReview", "Published"]
 effect = [{ type = "set_bool", var = "has_default_art_style", value = "true" }]
 params = ["default_art_style_id"]
 hint = "Link the default ArtStyle entity (its id) this language is built with — the first-class entity-level pairing, distinct from the imagery_direction.pairs_with slug. Editable on Published without re-publishing."
+
+[[action]]
+name = "SetProvenanceTier"
+kind = "input"
+from = ["Draft", "UnderReview", "Published"]
+effect = [{ type = "set_bool", var = "has_provenance", value = "true" }]
+params = ["provenance_tier", "provenance"]
+hint = "Record WHO did the creative work (ADR-0016). provenance_tier is one of agent_generated | human_curated | human_authored. provenance is a JSON lineage card: {tier, parent_ids, models[], human_curator, process (iteration-loop session id + steered rounds), created_at}. This is distinct from lineage (SetLineage = what it descends from): a human_curated language normally has an agent_generated parent. Set by the submitter; the claim is confirmed by the curator during review (an under-review claim is only a claim; publishing blesses it — a human_curated claim is backed by the captured iteration-loop trajectory). Editable on Published without re-publishing, like SetModelProvenance / SetCredits."
 
 [[action]]
 name = "SetFeatured"

--- a/katagami-curation/tests/test_provenance_contract.py
+++ b/katagami-curation/tests/test_provenance_contract.py
@@ -1,0 +1,64 @@
+import unittest
+from pathlib import Path
+import tomllib
+
+
+class ProvenanceContractTests(unittest.TestCase):
+    """Provenance records WHO did the creative work (ADR-0016), distinct from
+    lineage (WHAT a language descends from). The DesignLanguage entity carries a
+    `provenance_tier` string with a closed value set, a `has_provenance` receipts
+    boolean, and a `SetProvenanceTier` action to record both."""
+
+    def setUp(self):
+        root = Path(__file__).resolve().parents[2]
+        self.commons_root = root / "katagami-commons"
+        self.spec = tomllib.loads(
+            (self.commons_root / "specs" / "design_language.ioa.toml").read_text()
+        )
+        self.actions = {action["name"]: action for action in self.spec["action"]}
+        self.states = {state["name"]: state for state in self.spec["state"]}
+
+    def _effect_entries(self, action_name):
+        effect = self.actions[action_name].get("effect", [])
+        if isinstance(effect, str):
+            return [effect]
+        return effect
+
+    def _sets_bool(self, action_name, var, value):
+        for effect in self._effect_entries(action_name):
+            if isinstance(effect, dict):
+                if (
+                    effect.get("type") == "set_bool"
+                    and effect.get("var") == var
+                    and effect.get("value") == value
+                ):
+                    return True
+            elif effect == f"set {var} {value}":
+                return True
+        return False
+
+    def test_provenance_tier_is_a_string_state_defaulting_to_agent_generated(self):
+        self.assertIn("provenance_tier", self.states)
+        tier = self.states["provenance_tier"]
+        self.assertEqual(tier["type"], "string")
+        # Defaults to the pipeline's own output; human work is tagged explicitly.
+        self.assertEqual(tier["initial"], "agent_generated")
+
+    def test_has_provenance_is_a_bool_state(self):
+        self.assertIn("has_provenance", self.states)
+        self.assertEqual(self.states["has_provenance"]["type"], "bool")
+
+    def test_set_provenance_tier_records_tier_and_lineage_card(self):
+        self.assertIn("SetProvenanceTier", self.actions)
+        action = self.actions["SetProvenanceTier"]
+        # The submitter records the tier plus a JSON lineage card (the receipts).
+        self.assertIn("provenance_tier", action["params"])
+        self.assertIn("provenance", action["params"])
+        # Recording provenance flips the has_provenance receipts flag.
+        self.assertTrue(
+            self._sets_bool("SetProvenanceTier", "has_provenance", "true")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/src/app/(site)/language/[id]/page.tsx
+++ b/ui/src/app/(site)/language/[id]/page.tsx
@@ -27,6 +27,7 @@ import { DesignShowcase } from "@/components/design-showcase";
 import { ShadcnPreview } from "@/components/shadcn-preview";
 import { Credits } from "@/components/credits";
 import { ModelProvenance } from "@/components/model-provenance";
+import { ProvenanceBadge } from "@/components/provenance-badge";
 import { PageHero } from "@/components/page-hero";
 import { shadcnDesignMdMarkdown } from "@/lib/shadcn-export";
 import {
@@ -385,6 +386,8 @@ export default async function LanguageDetailPage({
       </div>
 
       <Credits raw={f.credits} />
+
+      <ProvenanceBadge tier={f.provenance_tier} variant="detail" />
 
       <ModelProvenance raw={f.model_provenance} />
 

--- a/ui/src/components/language-card.tsx
+++ b/ui/src/components/language-card.tsx
@@ -4,6 +4,7 @@ import { TrackedLink } from "@/components/tracked-link";
 import { parseJson } from "@/lib/odata";
 import { LanguageCardOwnerControls } from "@/components/language-card-owner-controls";
 import { ThumbnailPreview } from "@/components/thumbnail-preview";
+import { ProvenanceBadge } from "@/components/provenance-badge";
 
 const statusFallbackTone: Record<string, string> = {
   Draft: "var(--muted-foreground)",
@@ -156,6 +157,8 @@ function FullCard({
   const id = lang.entity_id;
 
   const tags = parseJson<string[]>(f.tags) ?? [];
+  const isHumanProvenance =
+    f.provenance_tier === "human_curated" || f.provenance_tier === "human_authored";
   const tokens = parseJson<Tokens>(f.tokens);
 
   const colors = tokens?.colors ?? {};
@@ -241,8 +244,9 @@ function FullCard({
           ) : null}
         </div>
 
-        {tags.length > 0 && (
+        {(tags.length > 0 || isHumanProvenance) && (
           <div className="mt-auto flex flex-wrap items-center gap-x-2 gap-y-1 pt-1">
+            <ProvenanceBadge tier={f.provenance_tier} variant="card" />
             {tags.slice(0, 3).map((t, i) => (
               <span
                 key={t}

--- a/ui/src/components/provenance-badge.tsx
+++ b/ui/src/components/provenance-badge.tsx
@@ -1,0 +1,56 @@
+const TIER_LABEL: Record<string, string> = {
+  human_curated: "Human-curated",
+  human_authored: "Human-authored",
+  agent_generated: "Agent-generated",
+};
+
+/**
+ * Provenance badge — WHO did the creative work (ADR-0016), distinct from lineage
+ * (what a language descends from). Only the human tiers are worth surfacing: they
+ * mark a language a person curated or authored, apart from pure pipeline output.
+ *
+ * On a gallery card the agent-generated / empty case renders nothing, so the wall
+ * isn't cluttered with a badge every card would carry. On a detail page a muted
+ * "Agent-generated" line is fine for context. Mirrors the Credits / ModelProvenance
+ * chip conventions: same tokens, and `return null` when there is nothing to show.
+ */
+export function ProvenanceBadge({
+  tier,
+  variant = "card",
+}: {
+  tier?: string;
+  variant?: "card" | "detail";
+}) {
+  const t = (tier ?? "").trim();
+  const isHuman = t === "human_curated" || t === "human_authored";
+
+  if (isHuman) {
+    return (
+      <span
+        className="inline-flex min-w-0 items-center gap-1.5 rounded-[2px] px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.14em]"
+        style={{
+          background: "color-mix(in srgb, var(--matcha) 16%, transparent)",
+          color: "color-mix(in srgb, var(--matcha) 70%, var(--foreground))",
+        }}
+      >
+        <span
+          aria-hidden
+          className="h-1.5 w-1.5 shrink-0 rounded-full"
+          style={{ background: "var(--matcha)" }}
+        />
+        <span className="truncate">{TIER_LABEL[t]}</span>
+      </span>
+    );
+  }
+
+  // Agent-generated (or unset, which defaults to agent_generated): silent on the
+  // card, a quiet contextual line on the detail page.
+  if (variant === "detail") {
+    return (
+      <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground/70">
+        {TIER_LABEL.agent_generated}
+      </p>
+    );
+  }
+  return null;
+}

--- a/ui/src/lib/odata.ts
+++ b/ui/src/lib/odata.ts
@@ -129,6 +129,8 @@ export interface DesignLanguage {
     parent_ids?: string;
     lineage_type?: string;
     generation_number?: string;
+    provenance_tier?: string;
+    provenance?: string;
     taxonomy_ids?: string;
     tags?: string;
     taste_vector?: string;
@@ -190,6 +192,7 @@ export const DESIGN_LANGUAGE_GALLERY_FIELDS = [
   "version",
   "quality_review_passed",
   "review_status",
+  "provenance_tier",
   "has_design_md",
   "has_valid_design_md",
   "design_md_verified",


### PR DESCRIPTION
## What
First-class provenance on design languages: a `provenance_tier`
(`agent_generated | human_curated | human_authored`) + a machine-readable
`provenance` lineage card + a `SetProvenanceTier` action, **orthogonal to lineage**,
so the commons can tell human-curated languages apart from pure-agent output.

## Why
The commons mixes agent-generated languages (bake-off, pipeline) with human-driven
ones. The first human-curated descendant — **Chiclet** (a human steered 13 rounds of
refinement on Pushpin via the iteration loop, ARN-124) — is ready to submit, and
there's no first-class way to mark it. Grounded in the Design × AI Atlas provenance
research (machine-readable lineage card, honest provenance tiers, "human-curated,
AI-synthesized"). Full rationale in **ADR-0016**.

## Changes
- `katagami-commons/specs/design_language.ioa.toml` — `provenance_tier` string state
  (default `agent_generated`), `has_provenance` bool, `SetProvenanceTier` action
  (modeled on `SetModelProvenance`; no enum type in the IOA specs).
- `docs/adrs/0016-language-provenance-tiers.md` — the decision record.
- UI — a `ProvenanceBadge` (on-brand matcha chip, no hex, no border) on the gallery
  card + language detail; `provenance_tier` added to the OData type + gallery `$select`.
- `katagami-curation/tests/test_provenance_contract.py` — contract test.

## Verification
- Contract test → **PASS (3/3)**; `tsc --noEmit` → **clean**.
- **Non-breaking**: not a submit/publish guard, not in the finalizer's required-field
  lists; existing agent languages default to `agent_generated`. Plain string state →
  L1 verification unchanged.
- Pre-existing unrelated suite failure (`test_wasm_source_parity`, WASM staleness) is
  untouched by this change.

## Follow-ups
- Live badge verification happens when Chiclet submits as `human_curated`.
- Deferred (in ADR-0016): a `provenance_verified` bool + `Publish` guard if
  self-claiming ever needs hard enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xmdzh3mzpgrYcdPPyndjWp
