### PR TITLE
feat(rum): high-volume 'take-it clicks' tile per language

### DIFF
--- a/infra/datadog/README.md
+++ b/infra/datadog/README.md
@@ -61,12 +61,14 @@ No PII: `defaultPrivacyLevel: mask-user-input`, no session replay.
    to `env:production` (literal) so `env:local-verify` test events are excluded.
    The top row leads with a **Unique visitors** tile
    (`CARDINALITY(@usr.anonymous_id)`); the "Languages & engagement" group ranks
-   languages by **unique visitors** for page views / copies / downloads, lists
-   the buttons clicked on language pages, and each language row links through to
-   katagami.ai. The page-views / copies / downloads rollups group by readable
-   `@context.language_name` (from the `language_view` / `copy` / `download`
-   events); they only count traffic since the instrumented UI deployed (no
-   backfill), so they fill in over time.
+   languages by **unique visitors** — page views and most-clicked group by
+   readable `@context.language_name` (from the `language_view` / `language_click`
+   events, post-deploy only, no backfill). A **take-it clicks** tile ranks
+   languages by the take-it actions on their page (copy / download / link /
+   tokens / DESIGN.md / with shadcn); those are auto-captured button clicks that
+   carry the page URL but not the name, so it keys on `@view.url_path` (id) to
+   capture the full volume — historical included. Each language row links through
+   to katagami.ai, and the group also lists the buttons clicked on language pages.
 
 ## Facets (confirmed against live data)
 

--- a/infra/datadog/katagami-rum-dashboard.json
+++ b/infra/datadog/katagami-rum-dashboard.json
@@ -343,7 +343,7 @@
           },
           {
             "definition": {
-              "title": "Top languages — copies (unique visitors)",
+              "title": "Top languages — take-it clicks (unique visitors)",
               "type": "toplist",
               "requests": [
                 {
@@ -351,59 +351,27 @@
                   "queries": [
                     {
                       "data_source": "rum",
-                      "name": "copyUV",
+                      "name": "takeUV",
                       "indexes": ["*"],
-                      "search": { "query": "env:production @type:action @action.target.name:copy @context.language_name:*" },
+                      "search": { "query": "env:production @type:action @view.url_path:/language/* @action.target.name:(copy OR download OR link OR tokens OR \"DESIGN.md\" OR \"with shadcn\" OR \"Download DESIGN.md\")" },
                       "compute": { "aggregation": "cardinality", "metric": "@usr.anonymous_id" },
                       "group_by": [
                         {
-                          "facet": "@context.language_name",
-                          "limit": 20,
+                          "facet": "@view.url_path",
+                          "limit": 25,
                           "sort": { "aggregation": "cardinality", "metric": "@usr.anonymous_id", "order": "desc" }
                         }
                       ]
                     }
                   ],
-                  "formulas": [{ "formula": "copyUV" }]
+                  "formulas": [{ "formula": "takeUV" }]
                 }
               ],
               "custom_links": [
-                { "label": "Open language on katagami.ai", "link": "https://katagami.ai/language/{{@context.language_id}}" }
+                { "label": "Open language on katagami.ai", "link": "https://katagami.ai{{@view.url_path}}" }
               ]
             },
-            "layout": { "x": 0, "y": 4, "width": 4, "height": 4 }
-          },
-          {
-            "definition": {
-              "title": "Top languages — downloads (unique visitors)",
-              "type": "toplist",
-              "requests": [
-                {
-                  "response_format": "scalar",
-                  "queries": [
-                    {
-                      "data_source": "rum",
-                      "name": "dlUV",
-                      "indexes": ["*"],
-                      "search": { "query": "env:production @type:action @action.target.name:download @context.language_name:*" },
-                      "compute": { "aggregation": "cardinality", "metric": "@usr.anonymous_id" },
-                      "group_by": [
-                        {
-                          "facet": "@context.language_name",
-                          "limit": 20,
-                          "sort": { "aggregation": "cardinality", "metric": "@usr.anonymous_id", "order": "desc" }
-                        }
-                      ]
-                    }
-                  ],
-                  "formulas": [{ "formula": "dlUV" }]
-                }
-              ],
-              "custom_links": [
-                { "label": "Open language on katagami.ai", "link": "https://katagami.ai/language/{{@context.language_id}}" }
-              ]
-            },
-            "layout": { "x": 4, "y": 4, "width": 4, "height": 4 }
+            "layout": { "x": 0, "y": 4, "width": 6, "height": 4 }
           },
           {
             "definition": {
@@ -432,7 +400,7 @@
                 }
               ]
             },
-            "layout": { "x": 8, "y": 4, "width": 4, "height": 4 }
+            "layout": { "x": 6, "y": 4, "width": 6, "height": 4 }
           },
           {
             "definition": {


### PR DESCRIPTION
The per-language **copies** and **downloads** tiles were near-empty — language-page copy/download is genuinely rare (0 in the last 2 days), and only those two custom events carry the language name, so name-grouping had nothing to show.

Replaces them with one **"Top languages — take-it clicks (unique visitors)"** tile counting all take-it actions on a language page (copy / download / link / tokens / DESIGN.md / with shadcn). Those are mostly auto-captured button clicks that carry `@view.url_path` but not the name, so it keys on the id/url_path — which captures the real volume (one language shows **25** take-it clicks vs 1 for copies) and each row links through to the page. The name-based **most-clicked languages** tile widens beside it. Artifact/file-level copy & download breakdowns remain in the "Copies, downloads & search" group.

Verified the query returns real per-language volume. Live dashboard already updated via API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)