### PR TITLE
chore(commons): reconcile GitHub master with Genesis source-of-truth (+ preserve ARN-126 facets)

### DIFF
--- a/katagami-commons/policies/direction.cedar
+++ b/katagami-commons/policies/direction.cedar
@@ -1,0 +1,2 @@
+// Direction — open access for local development
+permit(principal, action, resource is Direction);

--- a/katagami-commons/specs/art_style.ioa.toml
+++ b/katagami-commons/specs/art_style.ioa.toml
@@ -97,6 +97,16 @@ name = "usage_count"
 type = "counter"
 initial = 0
 
+[[state]]
+name = "has_credits"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "has_model_provenance"
+type = "bool"
+initial = "false"
+
 # --- Actions: Recipe Authoring (Draft & UnderReview) ---
 
 [[action]]
@@ -106,6 +116,22 @@ from = ["Draft", "UnderReview"]
 effect = [{ type = "set_bool", var = "has_published_assets", value = "false" }, { type = "set_bool", var = "quality_review_passed", value = "false" }]
 params = ["name", "slug"]
 hint = "Set the art style name and URL-safe slug."
+
+[[action]]
+name = "SubmitArtStyle"
+kind = "input"
+from = ["Draft"]
+effect = [
+  { type = "set_bool", var = "has_medium", value = "true" },
+  { type = "set_bool", var = "has_prompt_template", value = "true" },
+  { type = "set_bool", var = "has_slot_recipes", value = "true" },
+  { type = "set_bool", var = "has_reference_images", value = "true" },
+  { type = "set_bool", var = "has_proof_shots", value = "true" },
+  { type = "set_bool", var = "has_thumbnail", value = "true" }
+]
+params = ["name", "slug", "medium", "prompt_template", "negative_prompt", "engine_hints", "slot_recipes", "guidance", "reference_image_file_ids", "reference_manifest", "proof_shots_file_ids", "proof_shots_manifest", "thumbnail_file_id", "parent_ids", "lineage_type", "generation_number", "model_provenance", "credits", "tags", "direction_id", "curator_notes"]
+hint = "Contributor hot-path: author a COMPLETE art style in ONE call — name/medium/prompt_template (with {subject}+{palette})/slot_recipes/guidance + all image file ids (reference images + manifest, proof shots + manifest, thumbnail) + lineage + model_provenance + credits + direction_id (the bake-off round this belongs to). Sets every SubmitForReview guard var so the next call is SubmitForReview. Leaves the entity in Draft — contributors never self-publish; a curator reviews then Publishes. Files must already be uploaded and Ready (the SubmitForReview cross-entity guards still verify them). Mirrors SetSpec/SubmitDesignLanguage; collapses the author ladder into one."
+
 
 [[action]]
 name = "SetMedium"

--- a/katagami-commons/specs/design_language.ioa.toml
+++ b/katagami-commons/specs/design_language.ioa.toml
@@ -211,6 +211,30 @@ params = ["name", "slug", "philosophy", "tokens", "rules", "layout_principles", 
 hint = "Set the complete core spec for a newly synthesized or substantially revised language in one coherent hot-path transition."
 
 [[action]]
+name = "SubmitDesignLanguage"
+kind = "input"
+from = ["Draft"]
+effect = [
+  { type = "set_bool", var = "has_philosophy", value = "true" },
+  { type = "set_bool", var = "has_tokens", value = "true" },
+  { type = "set_bool", var = "has_rules", value = "true" },
+  { type = "set_bool", var = "has_layout", value = "true" },
+  { type = "set_bool", var = "has_guidance", value = "true" },
+  { type = "set_bool", var = "has_embodiment", value = "true" },
+  { type = "set_bool", var = "has_compositions", value = "true" },
+  { type = "set_bool", var = "has_design_md", value = "true" },
+  { type = "set_bool", var = "has_valid_design_md", value = "true" },
+  { type = "set_bool", var = "has_shadcn_export", value = "true" },
+  { type = "set_bool", var = "has_shadcn_component_spec", value = "true" },
+  { type = "set_bool", var = "has_shadcn_preview_shots", value = "true" },
+  { type = "set_bool", var = "has_thumbnail", value = "true" },
+  { type = "set_bool", var = "has_model_provenance", value = "true" },
+  { type = "set_bool", var = "has_provenance", value = "true" }
+]
+params = ["name", "slug", "philosophy", "tokens", "rules", "layout_principles", "guidance", "tags", "imagery_direction", "embodiment_file_id", "element_count", "composition_count", "embodiment_format", "landing_file_id", "dashboard_file_id", "design_md_file_id", "design_md_lint_result", "design_md_format_version", "shadcn_export_file_id", "shadcn_export_format_version", "shadcn_export_manifest", "shadcn_component_spec_file_id", "shadcn_component_spec_format_version", "shadcn_component_spec_manifest", "shadcn_preview_shots_file_id", "shadcn_preview_shots_format_version", "shadcn_preview_shots_manifest", "thumbnail_file_id", "parent_ids", "lineage_type", "generation_number", "model_provenance", "provenance_tier", "provenance", "direction_id", "curator_notes"]
+hint = "Contributor hot-path: author a COMPLETE design language in ONE call — full spec + imagery_direction + every artifact file id (embodiment, landing + dashboard compositions, DESIGN.md + clean lint result, shadcn export/component-spec/preview-shots, thumbnail) + lineage (parent_ids/lineage_type/generation_number) + model_provenance + curator_notes (record the reimagine direction here for provenance). Sets every SubmitForReview guard var, so the very next call is SubmitForReview. It does NOT transition state — the entity stays in Draft and a curator reviews then Publishes; contributors never self-publish. Files must already be uploaded and Ready (the SubmitForReview cross-entity guards still verify them, and the finalizer still rejects a non-clean DESIGN.md lint). Mirrors SetSpec's one-coherent-transition pattern; collapses the ~12-call author ladder into one."
+
+[[action]]
 name = "WritePhilosophy"
 kind = "input"
 from = ["Draft", "UnderReview"]

--- a/katagami-commons/specs/direction.ioa.toml
+++ b/katagami-commons/specs/direction.ioa.toml
@@ -1,0 +1,35 @@
+# Direction — a reimagine brief / bake-off round.
+#
+# N models reimagine ONE Direction; each model's submissions (its ArtStyle + PaletteSystem +
+# DesignLanguage) link back via their `direction_id` param. The round = every entity whose
+# `direction_id` equals this Direction's id (a real link, not a tag). Lives in commons so a
+# Direction is queryable alongside the entities it groups, for the bake-off display.
+#
+# Lifecycle: Open -> Closed (Reopen to revisit).
+
+[automaton]
+name = "Direction"
+states = ["Open", "Closed"]
+initial = "Open"
+allow_indefinite_states = ["Open", "Closed"]
+
+[[action]]
+name = "SetDirection"
+kind = "input"
+from = ["Open"]
+params = ["title", "brief", "source_language_id", "art_style_slug", "is_bakeoff", "round_label", "model_pool", "tags"]
+hint = "Author the direction in one call: title, the reimagine brief (the concept/angle to reimagine toward + constraints — what 'good' looks like for this round), source_language_id (the language being reimagined), an optional shared art_style_slug, is_bakeoff + round_label (the bake-off round identifier), an optional model_pool (the models invited), and tags. Contributor submissions reference this Direction's id via their direction_id; the round is all entities with that direction_id."
+
+[[action]]
+name = "Close"
+kind = "input"
+from = ["Open"]
+to = "Closed"
+hint = "Close the round — no further submissions expected."
+
+[[action]]
+name = "Reopen"
+kind = "input"
+from = ["Closed"]
+to = "Open"
+hint = "Reopen a closed round to accept more submissions."

--- a/katagami-commons/specs/model.csdl.xml
+++ b/katagami-commons/specs/model.csdl.xml
@@ -72,6 +72,10 @@
         <Property Name="HasCredits" Type="Edm.Boolean" Nullable="false" DefaultValue="false" />
         <Property Name="ModelProvenance" Type="Edm.String" Nullable="false" DefaultValue="{}" />
         <Property Name="HasModelProvenance" Type="Edm.Boolean" Nullable="false" DefaultValue="false" />
+        <!-- Provenance tier (ADR-0016): WHO did the creative work — agent_generated | human_curated | human_authored -->
+        <Property Name="ProvenanceTier" Type="Edm.String" Nullable="false" DefaultValue="agent_generated" />
+        <Property Name="Provenance" Type="Edm.String" Nullable="false" DefaultValue="{}" />
+        <Property Name="HasProvenance" Type="Edm.Boolean" Nullable="false" DefaultValue="false" />
         <!-- Taste embedding: semantic vector for discovery (taste deck,
              related languages). JSON float array + the model that made it. -->
         <Property Name="TasteVector" Type="Edm.String" Nullable="false" DefaultValue="" />
@@ -165,6 +169,25 @@
         <Property Name="HistoricalContext" Type="Edm.String" Nullable="false" DefaultValue="" />
         <Property Name="RelatedTaxonomyIds" Type="Edm.String" Nullable="false" DefaultValue="[]" />
         <Property Name="LanguageCount" Type="Edm.Int32" Nullable="false" DefaultValue="0" />
+        <Property Name="CreatedAt" Type="Edm.DateTimeOffset" />
+        <Property Name="UpdatedAt" Type="Edm.DateTimeOffset" />
+      </EntityType>
+
+      <!-- Direction: a reimagine brief / bake-off round; submissions link via DirectionId -->
+      <EntityType Name="Direction">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false" />
+        <Property Name="State" Type="Edm.String" Nullable="false" DefaultValue="Open" />
+        <Property Name="Title" Type="Edm.String" Nullable="false" DefaultValue="" />
+        <Property Name="Brief" Type="Edm.String" Nullable="false" DefaultValue="" />
+        <Property Name="SourceLanguageId" Type="Edm.String" Nullable="false" DefaultValue="" />
+        <Property Name="ArtStyleSlug" Type="Edm.String" Nullable="false" DefaultValue="" />
+        <Property Name="IsBakeoff" Type="Edm.Boolean" Nullable="false" DefaultValue="false" />
+        <Property Name="RoundLabel" Type="Edm.String" Nullable="false" DefaultValue="" />
+        <Property Name="ModelPool" Type="Edm.String" Nullable="false" DefaultValue="[]" />
+        <Property Name="Tags" Type="Edm.String" Nullable="false" DefaultValue="[]" />
         <Property Name="CreatedAt" Type="Edm.DateTimeOffset" />
         <Property Name="UpdatedAt" Type="Edm.DateTimeOffset" />
       </EntityType>
@@ -326,6 +349,7 @@
         <EntitySet Name="PaletteSystems" EntityType="Katagami.PaletteSystem" />
         <EntitySet Name="ArtStyles" EntityType="Katagami.ArtStyle" />
         <EntitySet Name="Remixes" EntityType="Katagami.Remix" />
+        <EntitySet Name="Directions" EntityType="Katagami.Direction" />
       </EntityContainer>
 
     </Schema>

--- a/katagami-commons/specs/palette_system.ioa.toml
+++ b/katagami-commons/specs/palette_system.ioa.toml
@@ -90,6 +90,16 @@ name = "usage_count"
 type = "counter"
 initial = 0
 
+[[state]]
+name = "has_credits"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "has_model_provenance"
+type = "bool"
+initial = "false"
+
 # --- Actions: Spec Authoring (Draft & UnderReview) ---
 
 [[action]]
@@ -99,6 +109,21 @@ from = ["Draft", "UnderReview"]
 effect = [{ type = "set_bool", var = "has_tokens_export", value = "false" }, { type = "set_bool", var = "has_published_assets", value = "false" }, { type = "set_bool", var = "quality_review_passed", value = "false" }]
 params = ["name", "slug"]
 hint = "Set the palette system name and URL-safe slug."
+
+[[action]]
+name = "SubmitPaletteSystem"
+kind = "input"
+from = ["Draft"]
+effect = [
+  { type = "set_bool", var = "has_core", value = "true" },
+  { type = "set_bool", var = "has_ramps", value = "true" },
+  { type = "set_bool", var = "has_proof_scenes", value = "true" },
+  { type = "set_bool", var = "has_tokens_export", value = "true" },
+  { type = "set_bool", var = "has_thumbnail", value = "true" }
+]
+params = ["name", "slug", "signature", "neutrals", "semantic", "mood", "ramps", "proof_scenes", "usage_guidance", "tokens_export_file_id", "tokens_export_format_version", "tokens_export_manifest", "thumbnail_file_id", "parent_ids", "lineage_type", "generation_number", "model_provenance", "credits", "tags", "direction_id", "curator_notes"]
+hint = "Contributor hot-path: author a COMPLETE palette system in ONE call — core (signature/neutrals/semantic/mood) + ramps + proof_scenes + usage_guidance + tokens_export file + thumbnail + lineage + model_provenance + credits + direction_id (the bake-off round). Sets every SubmitForReview guard var so the next call is SubmitForReview. Leaves the entity in Draft — contributors never self-publish; a curator reviews then Publishes. Files must already be uploaded and Ready (the guards still verify them). Mirrors SubmitDesignLanguage; collapses the author ladder into one."
+
 
 [[action]]
 name = "SetCore"

--- a/katagami-curation/app.toml
+++ b/katagami-curation/app.toml
@@ -6,7 +6,7 @@ dependencies = [
   "temperpaw/paw-fs@bff862b415505f5a563998265a2f6ac29472f899",
   "temperpaw/paw-agent@81d8beb78923dc22aeda850828f510f3c6eab510",
   "temperpaw/paw-research@910d01612b2632362fb5f537c4357a5fb6c7bcdd",
-  "katagami/katagami-commons@d0c5b9064b893afff84e66339fd3684557992388",
+  "katagami/katagami-commons@468be7897a683e69107bb2fbe246bd84f62792b1",
 ]
 
 # These declarations are REQUIRED — the installer only uploads WASM

--- a/katagami-curation/knowledge/rules/design-language.md
+++ b/katagami-curation/knowledge/rules/design-language.md
@@ -1,81 +1,74 @@
 # Design language rules
 
 > The rules every Katagami design language — with its paired palette and art style — must
-> uphold. The curation pipeline (and any agent that builds a language) applies them when
-> synthesizing and reviewing. One line each; newest direction wins; when in doubt, follow the rule.
-> Sibling rulebooks for other entities (e.g. `art-style.md`) may live alongside this file in
+> uphold. The curation pipeline applies them when synthesizing and reviewing a language.
+> One line each; newest direction wins; when in doubt, follow the rule.
+> Sibling rulebooks for other entities (e.g. `art-style.md`) live alongside this file in
 > `knowledge/rules/`. Rules folded in from the TR review (2026-06-23) are tagged `·TRnnn`.
-
-## How these rules work (read first)
-> Each rule states a **taste goal** or a **procedure**, and leaves the *how* to the language.
-> An anti-pattern names the **slop** to avoid — never a whole vocabulary to remove (don't ban
-> colours, modes, borders, gradients, or layouts wholesale). Don't prescribe a specific colour,
-> composition, value, or reference language. **If a rule would make every language converge on
-> the same look, it is too prescriptive — broaden it.** Variety between languages is the point.
-> Frame each rule so an agent follows it *as written* — a clean directive or a positive taste
-> goal. Never "avoid X unless Y": an agent obeys the "avoid" and never weighs the exception, so
-> the escape clause is dead. Say what to do, not what to do *unless*.
 
 ## Concept
 1. Give each language one ownable idea, expressed as a signature mechanic.
 2. Never ship a generic language ("warm Swiss", "clean minimal").
 3. Ship the language with its paired palette and art style as one coherent set.
-4. Write copy in a real, concrete scene for whatever the language is for — concrete verbs, specific real-world nouns, invented names that fit the subject; never AI clichés, lorem, or placeholder names. `·TR008`
+4. Write copy in a real product scene — concrete verbs, product-specific nouns, invented brand/product names; never AI clichés, lorem, or placeholder names. `·TR008`
 
 ## Naming
-> The name is a **masthead, not an identifier** — slug, tags, embeddings, and the lineage tree
-> carry identity and findability. Prefer one distinctive word; a two-word maker's-mark only when
-> one word can't carry it. Two words, occasionally one; never three; never an adjective.
+> The name is a **masthead, not an identifier** — slug, tags, embeddings, and the
+> lineage tree carry identity, uniqueness, and findability at any scale. So the
+> name only has to be non-tacky and evocative, never globally unique. Prefer one
+> distinctive word; use a two-word maker's-mark only when one word can't carry it.
+> Two words, occasionally one; never three; never an adjective. Exemplars:
+> **Halation**, **Civic Press**.
 
-5. Prefer one distinctive evocative noun (real, cultural, place, or material). Match the name's language/culture to the concept's own theme — don't default to one language (Japanese especially) unless the theme genuinely is that; vary the source widely across the library: Halation, Quarry, Plakat, Marquee, Bungu. Render the name in plain-ASCII Title Case — never ALL-CAPS, never diacritics/macrons/accents (carry the cultural flavour in the spelling, e.g. Yunagi not Yūnagi, Rosee not Rosée) so names stay typable and searchable.
-6. Use `[concrete subject noun] + [grounding maker noun]` (Press, Ledger, Works, Bureau, Atelier, Bindery, Foundry) only when one word can't carry the idea.
-7. Draw the subject noun from the language's single strongest motif — a material, object, place, or cultural image — never a mood word; rotate subjects AND cultures widely (don't let one language dominate).
-8. Cap every grounding noun — only a handful of "____ Press" / "____ Works" across the whole library.
-9. Never lead with an adjective, stack genres/eras, coin portmanteaus, or append IDs/dates. Banned tokens: System, Interface, Editorial, Noir, Lab, UI, Minimalism, Cyberpunk, Terminal, Collage, Brutalist, Deco, Manga, Style, Design, Revival, Lounge, Society, Cool, Clear, Compact, Critical, Atmospheric, Austere, Cinematic, Avant.
+5. Prefer one distinctive evocative noun (real, cultural, place, or material — often non-English): Halation, Seiran, Quarry, Bungu, Plakat. This namespace is unbounded and scales to thousands while staying memorable.
+6. Use `[concrete subject noun] + [grounding maker noun]` (Press, Ledger, Desk, Works, Bureau, Atelier, Bindery, Almanac, Review, Foundry) only when one word can't carry the idea.
+7. Draw the subject noun from the language's single strongest motif — a material, object, place, or cultural image — never a mood word; rotate subjects widely (materials, places, flora, fauna, tools, civic objects).
+8. Cap every grounding noun — only a handful of "____ Press" / "____ Works" across the whole library; let slug/tags/embeddings/lineage handle uniqueness and search.
+9. Never lead with an adjective, stack genres/eras, coin portmanteaus (Tapehiss, Civica), or append IDs/dates. Banned tokens: System, Interface, Editorial, Noir, Lab, UI, Minimalism, Cyberpunk, Terminal, Collage, Brutalist, Deco, Manga, Style, Design, Revival, Lounge, Society, Cool, Clear, Compact, Critical, Atmospheric, Austere, Cinematic, Avant.
 
 ## Look
-10. Never give a card a single accent/highlight edge — not top, not a side, not bottom.
-11. Use at most 3 accent colours; their hue and intensity are the language's own choice — vivid or muted, dark or pale — never defaulted to bright.
-12. Tune neutrals to the palette's temperature. `·TR006`
-13. Clean, never muddy.
-14. One coherent geometry; no arbitrary in-between radii.
-15. Body text 17px+; high contrast.
-16. Make one button clearly primary; keep the rest quieter. A button set shares one shape and height, label centred — creative is fine, sloppy never. `·TR011`
-17. Everything fits its container — nothing overflows, clips, or crowds. Size controls and labels to their content, text optically centred and evenly padded. Loose fit reads as unfinished.
-18. Ornament should mean something and belong to one considered system — coherent with the whole and suited to the content's tone. Tacky isn't "too much"; it's decoration without an idea: unrelated flourishes piled together, or one shape stamped on everything until it's wallpaper.
-19. Don't over-box the chrome: never nest cards, and never trap navigation in a floating rounded card or pill bar — a boxed-in nav reads as a widget. Let navigation breathe as part of the page; build hierarchy with space, type, and surface. `·TR012`
-20. Explicitly style every form control — no visible browser defaults. `·TR013`
-21. Give generous spacing; always pad above titles.
-22. Light, dark, or colour — the concept chooses the mode and the ground; don't default either way.
-23. No emoji on buttons, and no symbol glyphs (▲ ▼, etc.) in copy, markup, or alt — use SVG primitives or deliberate icons. `·TR009`
+10. Use no borders, and never one special edge in their place — no coloured highlight line across a card's top, no single accent rule, least of all on rounded cards. Separate with tinted surfaces and space.
+11. Use at most 3 accent colours, like highlighters.
+12. Keep one neutral temperature — derive mid-greys from the primary's hue (cool navy ink → cool-slate muted, e.g. `#5B6479`); never set a true grey beside a warm or cool primary. `·TR006`
+13. Stay bright and clean. No gradients — use solid colour blobs; keep neutrals pure (#FFF / #000); never default to warm cream/beige page surfaces. `·TR027`
+14. Use radius 0, 16, 24, or 9999 only — one geometry, no arbitrary in-between sizes.
+15. Set body text 17px+; display tight (-0.02em); keep high contrast.
+16. Make one button clearly primary; keep secondary and destructive actions quieter. Buttons in a set share one shape and height, label centred with even padding — creative is fine, sloppy never is. `·TR011`
+17. Never nest cards; express hierarchy with spacing, type, and tinted surfaces. `·TR012`
+18. Explicitly style every form control — no visible browser defaults. `·TR013`
+19. Give generous spacing; always pad above titles.
+20. Default to light mode. No emoji on buttons, and no symbol glyphs (▲ ▼, etc.) in copy, markup, or alt — use SVG primitives or deliberate icons. `·TR009`
 
 ## Responsive (the focus)
-24. Make every artifact render well from ~390px mobile to 2560px+ ultra-wide.
-25. On mobile, stack to a single column; hide non-essential nav links and table columns; never overflow horizontally. Oversized display/hero headlines MUST shrink responsively (clamp()/viewport units) and wrap — they may never clip or run off the 390px edge; an `overflow:hidden` that merely hides the overrun is NOT a fix (it leaves words chopped). The nav must wrap or collapse, never spill off-screen. Verify by READING a 390px screenshot for clipped text, not just by `scrollWidth == clientWidth`.
-26. On ultra-wide, cap and centre the contained content; let only the full-bleed hero span 100vw.
-27. Grids never blow out their container — children shrink instead of overflowing (e.g. `minmax(0,1fr)` + `min-width:0`).
+21. Make every artifact render well from ~390px mobile to 2560px+ ultra-wide.
+22. On mobile, stack to a single column; hide non-essential nav links and table columns; never overflow horizontally.
+23. On ultra-wide, cap and centre the contained content; let only the full-bleed hero span 100vw.
+24. Use `minmax(0,1fr)` columns and `min-width:0` on grid/flex children so grids never blow out their container.
 
 ## Landing
-28. The landing opens on a full-viewport hero (100vw × 100svh, edge to edge); its composition is the language's choice — don't prescribe one layout. But it is NEVER the generic SaaS-hero template: NOT a tracked eyebrow-tag above the title, NOT a primary+secondary button pair, NOT a three-number stat row as default furniture. Derive the hero from THIS language's signature mechanic and vary it per language — "free composition" must not collapse onto the startup cliché. (One CTA is plenty; if a stat or tag genuinely belongs, it must be the language's own device, not the default trio.)
-29. The hero always uses a swappable image — `background-image: var(--hero-image)`, never an `<img>` — so the studio can swap it.
-30. Keep the hero overlay legible over the image; no lazy gradient scrim.
-31. No scroll cues, "scroll down" prompts, or down-arrow indicators.
-32. Below the hero, return to rich, full sections.
-33. Make the hero headline unmistakably this language's, not the generic AI-startup default — not the oversized italic serif, and NOT the regular-serif/italic-serif swap (some words upright, some italic in the same serif face): that flip is the tell. Highlighter marks or a colour pop on a word are good; the serif↔italic swap is not. `·TR025`
+25. Make the hero a true full-bleed image: 100vw × 100svh, edge to edge, no padding, no radius. (Video is allowed.)
+26. Default the hero to a clean, immersive image with no baked-in text, from the paired art style.
+27. Use `background-image: var(--hero-image)` for the hero — never an `<img>` — so the studio can swap it.
+28. Overlay the nav and title on the image; put the title in a solid ink "press block".
+29. Never use a gradient scrim; make overlays legible with solid blocks/chips.
+30. Never add scroll cues, "scroll down" prompts, or down-arrow indicators.
+31. Below the hero, return to a contained grid with rich, full sections.
+32. Never stack a tiny uppercase letter-spaced eyebrow directly above an oversized hero headline — fold it into the headline, run it as a breadcrumb / role tag, or set it as a caption below. `·TR026`
+33. Never use an oversized italic serif as the primary hero headline (the universal AI-startup default); editorial contexts may justify it, default is reject. `·TR025`
 
 ## Motion
-34. Animate the landing with intent, like a real, shipped page; motion carries meaning, never decoration.
-35. The fully-rendered, settled state is the default — visible with no JavaScript. Motion is added on top: an inline script gates the hidden start-state (behind a class it sets on `<html>`) and drives the reveal, so a no-JS render and the ScaledFrame gallery/studio preview show the finished page, never a blank one. Respect `prefers-reduced-motion`. `·TR-pe`
+34. Animate the landing like a shipped product page: staggered scroll-reveals per section (IntersectionObserver), count-up stats, hero parallax + ken-burns, demand bars that grow to their level, and hover micro-interactions (cards lift, image zoom, row/nav states). Motion carries meaning; never decorate.
+35. Progressive-enhance: a small inline script adds a `.anim` class and drives the scroll motion, so the settled state is the default and the page is never stuck hidden. Respect `prefers-reduced-motion` (bail entirely). The gallery + studio previews are sandboxed (no JS) and freeze CSS via ScaledFrame, so they correctly show the static state — design for both.
 
 ## Compositions (landing + dashboard)
 36. Take all colour from the role vars `injectTheme` overrides: `--bg --surface --text --muted --border --accent --on-accent --success --warning --error --info`. Set defaults in `:root`.
-37. Drive any swappable image with `background-image: var(--hero-image)`.
+37. Make the swappable image `background-image: var(--hero-image)`.
 38. Map signature mechanics onto semantic roles so they recolour on palette swap.
 
 ## Embodiment
 39. Use the language's own colours; it is the identity showcase and the thumbnail source.
 40. Make it substantial — many real component sections, not a thin gallery.
-41. Every named signature pattern and visual-character trait must visibly appear in the embodiment — not merely be cited. `·TR016`
+41. Every named signature pattern and visual_character trait must visibly appear in the embodiment — not merely be cited (a "construction grid" needs a quiet visible motif; grain belongs to the art-style/imagery layer). `·TR016`
 
 ## Thumbnail
 42. Screenshot the embodiment at a true 1440×960 viewport (fonts loaded), scale to 600×400 JPEG, no crop.
@@ -83,14 +76,14 @@
 
 ## shadcn
 44. Ship full components: an agent-authored `components.md` (`component-recipes-v1`, `Author: katagami-agent`) and a renderable `preview-shots.json` (`renderable-v1`, ≥3 product scenes, all 16 primitives). The registry theme is finalizer-owned.
-45. The shadcn preview and registry theme must look like the language itself — honour its borders, radius, and material; never stamp a generic house "chassis". The renderer follows the `visualProfile`.
+45. The shadcn preview and registry theme must look like the language itself — honor its borders (a no-border language gets a transparent `--border`, never black outlines), its radius (controls use the card radius, never forced square at `sm:0`), and its material. Never stamp a generic "chassis" (paper borders, grain, offset shadows, tape) on a language that isn't that style — the renderer follows the `visualProfile`, never a house default.
 
 ## Art style
-46. A style is the **transferable technique**, independent of subject — it should dress a face, a city, or a teapot equally. If the subject domain (botanical, soda) has crept into the style's name, medium, or prompt, it's wrong. A style treats a subject; it is never the subject, nor the apparatus/medium itself.
-47. Reference images are full-frame, style-representative exemplars — not landing comps with empty space. A style may also carry the agent's own landing image, composed however that landing needs it.
-48. Credit the source. When a style is recognizably attributable to named artists / movements / studios / traditions, name them in a first-class `credits` list (each with `name`, `kind`, and a short note) — a style is an aggregate of influences; never pass a recognizable style off as original. (Applies to languages and palettes too.) `·TR-credits`
+46. An art style is a *treatment*, not a subject. Its prompt template reads `{subject}, in the style of …, {palette}, …` and applies the look (grain, scanlines, ink, brushwork) to whatever subject the slot supplies. "A photo of a CRT screen / a printed page / a polaroid" as the object is wrong; "in the style of a CRT screen" is right — the style must never become the object.
+47. Reference and proof images show the style ON real subjects (a face, an object, a scene), full-frame — never a render of the device or medium itself. Record the generating image model on the art style as provenance.
+48. Credit the source. When an art style is recognizably attributable to a named artist, movement, studio, or tradition, name them — in a first-class `credits` property on the entity, never buried in prose. Credit *all* of them: a style an LLM produces is an aggregate of many influences, so `credits` is a list (Gekiga → Yoshihiro Tatsumi + Jirō Taniguchi + the gekiga movement; Benday Press → Roy Lichtenstein + Benjamin Day + golden-age comics). Each credit carries a `name`, a `kind` (artist / movement / studio / tradition), and a short note on how it informed the style. Never pass a recognizable style off as original — attribution is both courtesy and a correctness check. (Applies equally to design languages and palettes when they trace to a named hand.)
 
 ---
 ## Held — adopt after rewording (from the TR review)
-- **TR-028** (accent used consistently across all sections) — adopt, but exempt documented semantic / heat-scale roles, so it doesn't fight an intentional scale.
-- **TR-029** (layout-family diversity) — adopt the spirit (4+ distinct families across 8 sections), but soften the absolute "each family at most once"; N/A for dashboards / single-card artifacts.
+- **TR-028** (accent used consistently across all sections) — adopt, but reword to **exempt documented semantic / heat-scale roles**, so it doesn't fight an intentional scale like Civic Press's ink→amber→ember.
+- **TR-029** (layout-family diversity) — adopt the spirit (**4+ distinct families across 8 sections**), but **soften the absolute "each family at most once"** (three identical grids is the real smell, not a second principled reuse); N/A for dashboards / single-card artifacts.

--- a/katagami-curation/specs/curation_job.ioa.toml
+++ b/katagami-curation/specs/curation_job.ioa.toml
@@ -389,28 +389,6 @@ type = "field"
 field = "query_id"
 
 [[action]]
-name = "SessionCompletedWithoutJobCompletion"
-kind = "input"
-from = ["Running"]
-to = "Failed"
-params = ["output", "child_session_id", "child_status"]
-hint = "Child Session completed without dispatching the typed CurationJob completion action. Fail explicitly instead of leaving the job Running."
-
-[[action.triggers]]
-name = "session_completed_without_job_completion_fails_query"
-kind = "entity"
-principal = "curation-service"
-target_entity = "CurationQuery"
-target_action = "Fail"
-
-[action.triggers.params]
-error_message = "CurationJob child Session completed without dispatching its typed completion action."
-
-[action.triggers.resolve_target]
-type = "field"
-field = "query_id"
-
-[[action]]
 name = "CompleteSynthesis"
 kind = "input"
 from = ["Running"]

--- a/katagami-curation/tests/test_reaction_resolver_types.py
+++ b/katagami-curation/tests/test_reaction_resolver_types.py
@@ -94,7 +94,6 @@ class ReactionResolverTypeTests(unittest.TestCase):
             "legacy_research_completion_advances_query": "ResearchComplete",
             "legacy_organization_completion_finishes_query": "OrganizationComplete",
             "job_failure_fails_query": "Fail",
-            "session_completed_without_job_completion_fails_query": "Fail",
         }.items():
             self.assertIn(name, triggers)
             self.assertEqual(triggers[name]["target_entity"], "CurationQuery")
@@ -256,10 +255,6 @@ class ReactionResolverTypeTests(unittest.TestCase):
         ]:
             self.assertIn(name, actions)
             self.assertEqual(actions[name]["to"], "Finalizing")
-
-        self.assertIn("SessionCompletedWithoutJobCompletion", actions)
-        self.assertEqual(actions["SessionCompletedWithoutJobCompletion"]["from"], ["Running"])
-        self.assertEqual(actions["SessionCompletedWithoutJobCompletion"]["to"], "Failed")
 
     def test_job_templates_cover_all_job_types(self):
         root = Path(__file__).resolve().parents[1]

--- a/katagami-curation/wasm/build_session_message/src/lib.rs
+++ b/katagami-curation/wasm/build_session_message/src/lib.rs
@@ -447,7 +447,7 @@ fn create_session_link(
         "ParentEntityId": parent_job_id,
         "ParentActionNamespace": "Katagami.Curation",
         "ChildSessionId": child_session_id,
-        "OnCompletedAction": "SessionCompletedWithoutJobCompletion",
+        "OnCompletedAction": "",
         "OnFailureAction": "Fail",
         "MaxChecks": "80",
     });


### PR DESCRIPTION
Genesis had diverged from GitHub master (+187/−100 on commons/curation specs GitHub lacked). Brings Genesis's current main (`1cbffcc`) into GitHub. A concurrent agent's `1cbffcc` push had clobbered the ARN-126 facet fields on Genesis, so this **unions them back** (SearchBlob/HueBucket/FamilyId + AttachComputedFacets) — GitHub keeps both the Genesis-side changes and the deployed facets. Genesis main itself still needs a re-push to restore the facets (coordination — a concurrent agent is active). UI untouched.