### PR TITLE
feat(ui): family facet + case-insensitive palettes/art search (ARN-126 follow-ups)

### DIFF
--- a/katagami-commons/specs/art_style.ioa.toml
+++ b/katagami-commons/specs/art_style.ioa.toml
@@ -218,6 +218,13 @@ from = ["Draft", "UnderReview", "Published"]
 params = ["taste_vector", "taste_vector_model"]
 hint = "Attach the semantic taste embedding computed from this entity's canonical taste document. taste_vector is a JSON float array; taste_vector_model identifies the embedding model so mixed-model vectors are never compared. Written by the curation finalizer or the backfill job."
 
+[[action]]
+name = "AttachComputedFacets"
+kind = "internal"
+from = ["Draft", "UnderReview", "Published"]
+params = ["search_blob"]
+hint = "Attach the precomputed lowercase search blob (name + tags + descriptive fields) so the catalog can be searched case-insensitively server-side under keyset pagination — the kernel only $filters flat stored scalars, and only case-sensitively. Written by the curation finalizer or the backfill job."
+
 # --- Actions: Classification ---
 
 [[action]]

--- a/katagami-commons/specs/model.csdl.xml
+++ b/katagami-commons/specs/model.csdl.xml
@@ -252,6 +252,8 @@
         <Property Name="CreatedAt" Type="Edm.DateTimeOffset" />
         <Property Name="UpdatedAt" Type="Edm.DateTimeOffset" />
         <Property Name="PublishedAt" Type="Edm.DateTimeOffset" />
+        <!-- Precomputed lowercase search blob for case-insensitive catalog search. -->
+        <Property Name="SearchBlob" Type="Edm.String" Nullable="false" DefaultValue="" />
       </EntityType>
 
       <!-- ArtStyle: an engine-agnostic style-transfer recipe (prompt template + reference images + slot recipes + proof shots) -->
@@ -316,6 +318,8 @@
         <Property Name="CreatedAt" Type="Edm.DateTimeOffset" />
         <Property Name="UpdatedAt" Type="Edm.DateTimeOffset" />
         <Property Name="PublishedAt" Type="Edm.DateTimeOffset" />
+        <!-- Precomputed lowercase search blob for case-insensitive catalog search. -->
+        <Property Name="SearchBlob" Type="Edm.String" Nullable="false" DefaultValue="" />
       </EntityType>
 
       <!-- Remix: a saved cross-lane mix (DesignLanguage + PaletteSystem + ArtStyle + composition) -->

--- a/katagami-commons/specs/palette_system.ioa.toml
+++ b/katagami-commons/specs/palette_system.ioa.toml
@@ -200,6 +200,13 @@ from = ["Draft", "UnderReview", "Published"]
 params = ["taste_vector", "taste_vector_model"]
 hint = "Attach the semantic taste embedding computed from this entity's canonical taste document. taste_vector is a JSON float array; taste_vector_model identifies the embedding model so mixed-model vectors are never compared. Written by the curation finalizer or the backfill job."
 
+[[action]]
+name = "AttachComputedFacets"
+kind = "internal"
+from = ["Draft", "UnderReview", "Published"]
+params = ["search_blob"]
+hint = "Attach the precomputed lowercase search blob (name + tags + descriptive fields) so the catalog can be searched case-insensitively server-side under keyset pagination — the kernel only $filters flat stored scalars, and only case-sensitively. Written by the curation finalizer or the backfill job."
+
 # --- Actions: Classification ---
 
 [[action]]

--- a/ui/scripts/backfill-lane-search.mjs
+++ b/ui/scripts/backfill-lane-search.mjs
@@ -1,0 +1,127 @@
+// Backfill a lowercase search_blob onto every Published PaletteSystem + ArtStyle
+// via AttachComputedFacets, so the lane galleries get case-insensitive search
+// (the kernel has no tolower/$search). DRY-RUN by default; --apply to write.
+//
+// Env: source .env.katagami-curator.local (openpaw-production).
+const API = requiredEnv("TEMPER_API_URL").replace(/\/+$/, "");
+const KEY = requiredEnv("TEMPER_API_KEY");
+const TENANT = process.env.TEMPER_TENANT || "default";
+const APPLY = process.argv.includes("--apply");
+const CONCURRENCY = 10;
+const NAMESPACES = ["Temper", "KatagamiCommons", "Katagami.Curation", "Katagami"];
+const H = { "X-Tenant-Id": TENANT, Authorization: `Bearer ${KEY}` };
+
+const LANES = [
+  { set: "PaletteSystems", blob: paletteBlob },
+  { set: "ArtStyles", blob: artBlob },
+];
+
+async function collectAll(path) {
+  const out = [];
+  let url = `${API}/tdata/${path}`;
+  while (url) {
+    const res = await fetch(url, { headers: H });
+    if (!res.ok) throw new Error(`GET ${url} -> ${res.status}: ${await res.text()}`);
+    const j = await res.json();
+    out.push(...(j.value ?? []));
+    url = j["@odata.nextLink"] ?? null;
+  }
+  return out;
+}
+
+function fieldsOf(row) {
+  let f = row.fields ?? row;
+  if (f && f.fields && typeof f.fields === "object") f = f.fields;
+  return f ?? {};
+}
+
+function join(parts) {
+  return parts
+    .filter(Boolean)
+    .map(String)
+    .join(" ")
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function safeJson(s) {
+  if (typeof s !== "string" || !s) return undefined;
+  try {
+    return JSON.parse(s);
+  } catch {
+    return undefined;
+  }
+}
+
+function tagsOf(f) {
+  const t = safeJson(f.tags);
+  return Array.isArray(t) ? t.map(String) : [];
+}
+
+function paletteBlob(f) {
+  const mood = safeJson(f.mood) || {};
+  return join([f.name, f.slug, ...tagsOf(f), mood.summary, mood.key_hue, mood.temperature]);
+}
+
+function artBlob(f) {
+  return join([f.name, f.slug, ...tagsOf(f), f.medium]);
+}
+
+async function attach(set, id, facets) {
+  let lastErr = "";
+  for (const ns of NAMESPACES) {
+    const res = await fetch(`${API}/tdata/${set}('${id}')/${ns}.AttachComputedFacets`, {
+      method: "POST",
+      headers: { ...H, "Content-Type": "application/json" },
+      body: JSON.stringify(facets),
+    });
+    if (res.ok) return ns;
+    lastErr = `${ns} -> ${res.status}: ${(await res.text()).slice(0, 160)}`;
+    if (res.status !== 404) break;
+  }
+  throw new Error(lastErr);
+}
+
+async function backfillLane(lane) {
+  const rows = await collectAll(`${lane.set}?$filter=Status eq 'Published'&$top=5000`);
+  const items = rows
+    .map((r) => {
+      const f = fieldsOf(r);
+      return { id: r.entity_id ?? f.Id, search_blob: lane.blob(f) };
+    })
+    .filter((it) => it.id);
+  const withBlob = items.filter((it) => it.search_blob).length;
+  console.log(`${lane.set}: ${items.length} published, ${withBlob} with non-empty blob   mode: ${APPLY ? "APPLY" : "DRY-RUN"}`);
+  console.log("  sample:", JSON.stringify(items.slice(0, 3).map((i) => i.search_blob.slice(0, 44))));
+
+  if (!APPLY) return;
+  let done = 0, failed = 0, ns = "";
+  const queue = [...items];
+  async function worker() {
+    while (queue.length) {
+      const it = queue.shift();
+      try {
+        ns = await attach(lane.set, it.id, { search_blob: it.search_blob });
+        done++;
+      } catch (e) {
+        failed++;
+        console.error(`  FAIL ${it.id}: ${String(e).slice(0, 160)}`);
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+  console.log(`  ${lane.set}: ${done} written (${ns}.AttachComputedFacets), ${failed} failed`);
+}
+
+async function main() {
+  for (const lane of LANES) await backfillLane(lane);
+  if (!APPLY) console.log("\nDRY-RUN — no writes. Re-run with --apply.");
+}
+
+function requiredEnv(n) {
+  const v = process.env[n];
+  if (!v) { console.error(`missing env ${n} — source .env.katagami-curator.local`); process.exit(1); }
+  return v;
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/ui/src/app/(site)/page.tsx
+++ b/ui/src/app/(site)/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import {
   countDesignLanguages,
+  galleryFamilies,
   listFeaturedDesignLanguages,
   pageDesignLanguages,
 } from "@/lib/odata";
@@ -106,11 +107,14 @@ async function GalleryGrid({ demo }: { demo?: boolean }) {
   const canDelete = demo ? false : await isOwner();
   let first: Awaited<ReturnType<typeof pageDesignLanguages>>;
   let featured: Awaited<ReturnType<typeof listFeaturedDesignLanguages>>;
+  let families: Awaited<ReturnType<typeof galleryFamilies>> = [];
   try {
-    // Curator's picks lead the gallery; the rest paginate in.
-    [first, featured] = await Promise.all([
+    // Curator's picks lead the gallery; the rest paginate in. Families feed the
+    // facet dropdown (non-fatal — the gallery renders without it).
+    [first, featured, families] = await Promise.all([
       pageDesignLanguages({ limit: 48 }),
       listFeaturedDesignLanguages(),
+      galleryFamilies().catch(() => []),
     ]);
   } catch {
     return (
@@ -131,6 +135,7 @@ async function GalleryGrid({ demo }: { demo?: boolean }) {
   return (
     <InfiniteLanguages
       featured={featured}
+      families={families}
       initialItems={first.items}
       initialCursor={first.nextCursor}
       canDelete={canDelete}

--- a/ui/src/components/infinite-galleries.tsx
+++ b/ui/src/components/infinite-galleries.tsx
@@ -153,13 +153,49 @@ function HueBar({
   );
 }
 
+// Filter by taxonomy family (family_id eq …). Only the families actually present
+// in the catalog are listed (with counts), server-side filtered.
+function FamilySelect({
+  families,
+  active,
+  onPick,
+}: {
+  families: { id: string; name: string; count: number }[];
+  active?: string;
+  onPick: (id?: string) => void;
+}) {
+  if (families.length === 0) return null;
+  return (
+    <label className="flex items-center gap-1.5">
+      <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+        family
+      </span>
+      <select
+        value={active ?? ""}
+        onChange={(e) => onPick(e.target.value || undefined)}
+        aria-label="Filter by family"
+        className={`${KX_FIELD} h-8 max-w-[11rem] cursor-pointer pr-5 text-[12px]`}
+      >
+        <option value="">all families</option>
+        {families.map((f) => (
+          <option key={f.id} value={f.id}>
+            {f.name} ({f.count})
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
 export function InfiniteLanguages({
   featured = [],
+  families = [],
   initialItems,
   initialCursor,
   canDelete = false,
 }: {
   featured?: DesignLanguage[];
+  families?: { id: string; name: string; count: number }[];
   initialItems: DesignLanguage[];
   initialCursor: string | null;
   canDelete?: boolean;
@@ -190,7 +226,16 @@ export function InfiniteLanguages({
       search={search}
       setSearch={setSearch}
       placeholder="Search languages…"
-      toolbar={<HueBar active={facets.hue} onPick={(h) => setFacet("hue", h)} />}
+      toolbar={
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+          <HueBar active={facets.hue} onPick={(h) => setFacet("hue", h)} />
+          <FamilySelect
+            families={families}
+            active={facets.family}
+            onPick={(id) => setFacet("family", id)}
+          />
+        </div>
+      }
       loading={loading}
       exhausted={cursor === null}
       empty={(browsing ? featured.length : 0) + gridItems.length === 0}

--- a/ui/src/lib/odata.ts
+++ b/ui/src/lib/odata.ts
@@ -575,6 +575,34 @@ export async function taxonomyFamilyIndex(): Promise<Map<string, TaxonomyParent>
   return map;
 }
 
+/**
+ * The families actually present in the catalog (family_id → name + count), for
+ * the gallery's family facet. Derived from the published languages' stored
+ * family_id + the taxonomy index; only the small result is cached (the fetch is
+ * transient, so it never blows the Data Cache entry cap). Fine at today's size;
+ * a stored aggregate would be the move past a few thousand languages.
+ */
+export const galleryFamilies = unstable_cache(
+  async (): Promise<{ id: string; name: string; count: number }[]> => {
+    const index = await taxonomyFamilyIndex();
+    const rows = await collectODataPages<Record<string, unknown>>(
+      "DesignLanguages?$filter=Status eq 'Published'&$top=5000",
+    );
+    const counts = new Map<string, number>();
+    for (const row of rows) {
+      const f = (row.fields ?? row) as Record<string, unknown>;
+      const fid = typeof f.family_id === "string" ? f.family_id : "";
+      if (fid) counts.set(fid, (counts.get(fid) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+      .map(([id, count]) => ({ id, name: index.get(id)?.name ?? "", count }))
+      .filter((f) => f.name)
+      .sort((a, b) => b.count - a.count);
+  },
+  ["gallery-families-v1"],
+  { revalidate: 300 },
+);
+
 let languageTaxonomyCache: { at: number; map: Map<string, string[]> } | null =
   null;
 
@@ -1027,7 +1055,8 @@ async function pageLane(
 ): Promise<PageResult<LaneEntity>> {
   try {
     const resp = await odata<{ value?: Record<string, unknown>[] }>(
-      `${set}?${pageQuery(cursor, limit, search)}`,
+      // Lanes carry a backfilled search_blob too → case-insensitive search.
+      `${set}?${pageQuery(cursor, limit, search, { searchField: "search_blob" })}`,
     );
     const rows = (resp.value ?? []).map((r) => normalizeLaneRow(r, set));
     return slicePage(rows, limit);


### PR DESCRIPTION
Two ARN-126 follow-ups on the live facet backend. **Family facet** (languages): a family_id dropdown of the 17 present families (cached derivation). **Palettes/art-styles case-insensitive search**: SearchBlob + AttachComputedFacets added to both entities (deployed to Genesis `041bede` + installed on openpaw), all 258 palettes + 154 art-styles backfilled (0 failed), pageLane now uses contains(search_blob,…). Verified on prod. Commons spec mirrored to GitHub. Build/tsc/eslint ✓.