### PR TITLE
feat(auth): human user sign-in with Google — sessions, Studio gating, attribution (ARN-143)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -37,6 +37,9 @@ Set in Vercel project settings (Production + Preview):
 | `NEXT_PUBLIC_TEMPER_TENANT` | yes | Tenant identifier passed as `X-Tenant-Id` |
 | `TEMPER_API_KEY` | **server-only** | Bearer token for Railway. Read only by Server Components, Server Actions, and the file-proxy route handler. No `NEXT_PUBLIC_` prefix → never shipped to the browser bundle |
 | `KATAGAMI_OWNER_SECRET` | **server-only** | Passphrase for `/owner`. When unlocked, Vercel sets an HTTP-only owner cookie that reveals delete controls and gates destructive Server Actions |
+| `GOOGLE_CLIENT_ID` | **server-only** | OAuth 2.0 client id for human "Sign in with Google" (`/signin`). Authorized redirect URIs: `https://katagami.ai/api/auth/google/callback` and `http://localhost:3000/api/auth/google/callback` |
+| `GOOGLE_CLIENT_SECRET` | **server-only** | OAuth 2.0 client secret paired with `GOOGLE_CLIENT_ID` |
+| `KATAGAMI_AUTH_SECRET` | **server-only** | HS256 secret signing the human session cookie (`katagami_user`). Generate with `openssl rand -base64 32`. Unset ⇒ sign-in is off and `/signin` says so; there is no fallback secret |
 
 The browser never sees the Bearer token. All Temper calls go through Vercel-side code:
 - Server Components in `ui/src/app/**/page.tsx` (e.g. the gallery, language detail, taxonomy, lineage, compare).

--- a/katagami-commons/specs/remix.ioa.toml
+++ b/katagami-commons/specs/remix.ioa.toml
@@ -33,6 +33,11 @@ type = "bool"
 initial = "false"
 
 [[state]]
+name = "has_creator"
+type = "bool"
+initial = "false"
+
+[[state]]
 name = "usage_count"
 type = "counter"
 initial = 0
@@ -46,6 +51,14 @@ from = ["Draft"]
 effect = [{ type = "set_bool", var = "has_selection", value = "true" }]
 params = ["design_language_id", "palette_system_id", "art_style_id", "composition_key"]
 hint = "Set the three lane selections and the composition key for this mix."
+
+[[action]]
+name = "SetCreator"
+kind = "input"
+from = ["Draft"]
+effect = [{ type = "set_bool", var = "has_creator", value = "true" }]
+params = ["creator_sub", "creator_email", "creator_name", "creator_avatar_url"]
+hint = "Attribute this mix to the signed-in human saving it (Google identity from katagami.ai): stable subject id, email, display name, avatar URL. Set once in Draft, before Save."
 
 [[action]]
 name = "SetSlotAssignments"

--- a/katagami-curation/app.toml
+++ b/katagami-curation/app.toml
@@ -6,7 +6,7 @@ dependencies = [
   "temperpaw/paw-fs@bff862b415505f5a563998265a2f6ac29472f899",
   "temperpaw/paw-agent@81d8beb78923dc22aeda850828f510f3c6eab510",
   "temperpaw/paw-research@910d01612b2632362fb5f537c4357a5fb6c7bcdd",
-  "katagami/katagami-commons@468be7897a683e69107bb2fbe246bd84f62792b1",
+  "katagami/katagami-commons@031a100806ebb34544a07584cb506f22eff00102",
 ]
 
 # These declarations are REQUIRED — the installer only uploads WASM

--- a/katagami-curation/tests/test_remix_creator_contract.py
+++ b/katagami-curation/tests/test_remix_creator_contract.py
@@ -1,0 +1,51 @@
+import unittest
+from pathlib import Path
+import tomllib
+
+
+class RemixCreatorContractTests(unittest.TestCase):
+    """Saved Remixes are attributed to the signed-in human who made them
+    (ARN-143). The Remix entity carries a `has_creator` boolean and a
+    `SetCreator` input action that records the Google identity (subject id,
+    email, name, avatar) while the mix is still in Draft — before Save pins it.
+    Attribution is identity, not lifecycle: SetCreator must not gate Save."""
+
+    def setUp(self):
+        root = Path(__file__).resolve().parents[2]
+        self.commons_root = root / "katagami-commons"
+        self.spec = tomllib.loads(
+            (self.commons_root / "specs" / "remix.ioa.toml").read_text()
+        )
+        self.actions = {action["name"]: action for action in self.spec["action"]}
+        self.states = {state["name"]: state for state in self.spec["state"]}
+
+    def test_has_creator_is_a_bool_state_defaulting_to_false(self):
+        self.assertIn("has_creator", self.states)
+        state = self.states["has_creator"]
+        self.assertEqual(state["type"], "bool")
+        self.assertEqual(state["initial"], "false")
+
+    def test_set_creator_records_the_full_identity_in_draft(self):
+        self.assertIn("SetCreator", self.actions)
+        action = self.actions["SetCreator"]
+        self.assertEqual(action["kind"], "input")
+        self.assertEqual(action["from"], ["Draft"])
+        self.assertEqual(
+            action["params"],
+            ["creator_sub", "creator_email", "creator_name", "creator_avatar_url"],
+        )
+        self.assertIn(
+            {"type": "set_bool", "var": "has_creator", "value": "true"},
+            action["effect"],
+        )
+
+    def test_save_does_not_require_a_creator(self):
+        # Anonymous historical remixes and agent-made remixes must stay valid:
+        # Save's guard is selection-only.
+        save = self.actions["Save"]
+        for guard in save.get("guard", []):
+            self.assertNotEqual(guard.get("var"), "has_creator")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/katagami-curation/wasm/finalize_spawned_session/src/lib.rs
+++ b/katagami-curation/wasm/finalize_spawned_session/src/lib.rs
@@ -1826,6 +1826,27 @@ fn walk_lane_entity_to_published(
         publish_action,
         &json!({}),
     )?;
+    // Derive + store the lane's case-insensitive search blob (compute here, Temper
+    // governs the write). Non-fatal — never fails a publish.
+    let empty = json!({});
+    let sb = facets::lane_search_blob(set_name, entity.get("fields").unwrap_or(&empty));
+    if !sb.is_empty()
+        && dispatch_action(
+            ctx,
+            api_url,
+            headers,
+            set_name,
+            entity_id,
+            "AttachComputedFacets",
+            &json!({ "search_blob": sb }),
+        )
+        .is_err()
+    {
+        ctx.log(
+            "warn",
+            &format!("facets: AttachComputedFacets failed for {set_name}('{entity_id}') (non-fatal)"),
+        );
+    }
     Ok(())
 }
 

--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -11,6 +11,10 @@ const nextConfig: NextConfig = {
     // Cache them long so the image-heavy art-styles gallery serves /_next/image
     // HITs instead of re-optimizing hundreds of images on every cold load.
     minimumCacheTTL: 2592000, // 30 days
+    // Google account avatars (header chip, /account) — lh3/lh4/… subdomains.
+    remotePatterns: [
+      { protocol: "https", hostname: "*.googleusercontent.com" },
+    ],
   },
 };
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -35,6 +35,7 @@
         "@xenova/transformers": "^2.17.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "jose": "^6.2.3",
         "lucide-react": "^1.8.0",
         "next": "16.2.3",
         "react": "19.2.4",
@@ -8246,9 +8247,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,9 +10,10 @@
     "lint": "eslint",
     "backfill:published-assets": "node scripts/backfill-published-assets.mjs",
     "backfill:taste-vectors": "node scripts/backfill-taste-vectors.mjs",
-    "test": "npm run test:gallery && npm run test:shadcn-export",
+    "test": "npm run test:gallery && npm run test:shadcn-export && npm run test:auth",
     "test:gallery": "node scripts/check-gallery-renders-all-cards.mjs",
-    "test:shadcn-export": "node scripts/check-shadcn-preview-contract.mjs"
+    "test:shadcn-export": "node scripts/check-shadcn-preview-contract.mjs",
+    "test:auth": "node scripts/check-auth-contract.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -42,6 +42,7 @@
     "@xenova/transformers": "^2.17.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "jose": "^6.2.3",
     "lucide-react": "^1.8.0",
     "next": "16.2.3",
     "react": "19.2.4",

--- a/ui/scripts/check-auth-contract.mjs
+++ b/ui/scripts/check-auth-contract.mjs
@@ -1,0 +1,58 @@
+// Human sign-in contract (ARN-143): the Google OIDC flow stays secure and the
+// Studio stays gated. Source-greps in the style of the other check-* scripts —
+// these encode the invariants a refactor must not silently drop.
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+function read(path) {
+  return readFileSync(resolve(path), "utf8");
+}
+
+const session = read("src/lib/user-auth.ts");
+const oidc = read("src/lib/google-oidc.ts");
+const start = read("src/app/api/auth/google/start/route.ts");
+const callback = read("src/app/api/auth/google/callback/route.ts");
+const actions = read("src/app/remix-actions.ts");
+const signin = read("src/app/(site)/signin/page.tsx");
+const account = read("src/app/(site)/account/page.tsx");
+const layout = read("src/app/(site)/layout.tsx");
+const studio = read("src/app/(site)/studio/page.tsx");
+const authActions = read("src/app/auth-actions.ts");
+
+const required = [
+  // The session is off, never insecurely on: no fallback secret anywhere.
+  ["session secret has no fallback", session, /raw \? new TextEncoder/],
+  ["session cookie is httpOnly", callback, /httpOnly: true/],
+  ["callback checks the state cookie (CSRF)", callback, /state !== cookieState/],
+  ["callback follows only internal redirect targets", callback, /safeInternalPath/],
+  ["start route refuses when unconfigured", start, /isAuthConfigured\(\)/],
+  ["ID token is verified against Google JWKS", oidc, /createRemoteJWKSet/],
+  ["unverified Google emails are rejected", oidc, /email_verified === false/],
+  ["sign-out is a server action, not a GET route", authActions, /"use server"/],
+  // The Studio is a signed-in space for making, open for browsing.
+  ["saveRemix requires a signed-in human", actions, /saveRemix[\s\S]*?requireUser/],
+  ["saved mixes are attributed via SetCreator", actions, /"SetCreator"/],
+  ["rateRemix checks the mix's creator", actions, /creator_email[\s\S]*?creator can rate/],
+  ["studio scopes saved mixes to the signed-in human", studio, /creator_email/],
+  // The front of the house exists and degrades gracefully.
+  ["signin page names its error states", signin, /errorCopy/],
+  ["signin page explains the unconfigured state", signin, /KATAGAMI_AUTH_SECRET/],
+  ["account page bounces signed-out visitors to /signin", account, /redirect\("\/signin/],
+  ["header renders the user menu", layout, /<UserMenu user=/],
+];
+
+let failed = 0;
+for (const [name, source, pattern] of required) {
+  if (pattern.test(source)) {
+    console.log(`ok: ${name}`);
+  } else {
+    console.error(`MISSING: ${name}`);
+    failed += 1;
+  }
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} auth contract check(s) failed.`);
+  process.exit(1);
+}
+console.log("\nauth contract holds.");

--- a/ui/scripts/check-auth-contract.mjs
+++ b/ui/scripts/check-auth-contract.mjs
@@ -12,33 +12,47 @@ const session = read("src/lib/user-auth.ts");
 const oidc = read("src/lib/google-oidc.ts");
 const start = read("src/app/api/auth/google/start/route.ts");
 const callback = read("src/app/api/auth/google/callback/route.ts");
+const me = read("src/app/api/auth/me/route.ts");
 const actions = read("src/app/remix-actions.ts");
 const signin = read("src/app/(site)/signin/page.tsx");
 const account = read("src/app/(site)/account/page.tsx");
 const layout = read("src/app/(site)/layout.tsx");
 const studio = read("src/app/(site)/studio/page.tsx");
 const authActions = read("src/app/auth-actions.ts");
+const inlineRemix = read("src/components/remix/inline-remix.tsx");
 
 const required = [
   // The session is off, never insecurely on: no fallback secret anywhere.
   ["session secret has no fallback", session, /raw \? new TextEncoder/],
   ["session cookie is httpOnly", callback, /httpOnly: true/],
-  ["callback checks the state cookie (CSRF)", callback, /state !== cookieState/],
+  // Redirect targets are validated by resolution, not by prefix (a prefix
+  // check is bypassable with URL-parser-stripped control characters).
+  ["safe path validates by resolving against a fixed origin", session, /katagami\.invalid/],
   ["callback follows only internal redirect targets", callback, /safeInternalPath/],
+  ["callback checks the state cookie (CSRF)", callback, /state !== cookieState/],
+  ["callback requires the PKCE verifier and nonce cookies", callback, /!verifier ||\s*!nonce/],
   ["start route refuses when unconfigured", start, /isAuthConfigured\(\)/],
+  ["start route clears a stale next-target cookie", start, /cookies\.delete\(OAUTH_NEXT_COOKIE\)/],
+  ["PKCE: S256 challenge on the authorization request", oidc, /code_challenge_method: "S256"/],
   ["ID token is verified against Google JWKS", oidc, /createRemoteJWKSet/],
-  ["unverified Google emails are rejected", oidc, /email_verified === false/],
+  ["ID-token nonce must match ours (fail closed)", oidc, /payload\.nonce !== expectedNonce/],
+  ["email_verified must be present and true (fail closed)", oidc, /email_verified !== true/],
   ["sign-out is a server action, not a GET route", authActions, /"use server"/],
   // The Studio is a signed-in space for making, open for browsing.
   ["saveRemix requires a signed-in human", actions, /saveRemix[\s\S]*?requireUser/],
   ["saved mixes are attributed via SetCreator", actions, /"SetCreator"/],
-  ["rateRemix checks the mix's creator", actions, /creator_email[\s\S]*?creator can rate/],
-  ["studio scopes saved mixes to the signed-in human", studio, /creator_email/],
+  ["rateRemix keys ownership on the stable Google sub", actions, /creator_sub[\s\S]*?creator can rate/],
+  ["studio scopes saved mixes by creator_sub", studio, /creator_sub/],
+  ["save failures are caught, not thrown to the boundary", inlineRemix, /doSave[\s\S]*?catch/],
   // The front of the house exists and degrades gracefully.
   ["signin page names its error states", signin, /errorCopy/],
   ["signin page explains the unconfigured state", signin, /KATAGAMI_AUTH_SECRET/],
   ["account page bounces signed-out visitors to /signin", account, /redirect\("\/signin/],
-  ["header renders the user menu", layout, /<UserMenu user=/],
+  ["header renders the user menu", layout, /<UserMenu \/>/],
+  // The shared layout must never read cookies — it would make every route
+  // dynamic; the header chip hydrates from /api/auth/me instead.
+  ["layout stays cookie-free (full-route cache preserved)", layout, /^(?![\s\S]*getUser)[\s\S]*$/],
+  ["identity endpoint is uncacheable", me, /no-store/],
 ];
 
 let failed = 0;

--- a/ui/src/app/(site)/account/page.tsx
+++ b/ui/src/app/(site)/account/page.tsx
@@ -55,7 +55,7 @@ export default async function AccountPage() {
   ) => lane.find((e) => e.entity_id === id)?.fields.name ?? "—";
 
   const mine: MixRow[] = remixes
-    .filter((r) => (r.fields.creator_email ?? "") === user.email)
+    .filter((r) => (r.fields.creator_sub ?? "") === user.sub)
     .map((r) => ({
       id: r.entity_id,
       language: nameOf(languages, r.fields.design_language_id ?? ""),

--- a/ui/src/app/(site)/account/page.tsx
+++ b/ui/src/app/(site)/account/page.tsx
@@ -1,0 +1,185 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { ArrowLeft, LogOut, Palette } from "lucide-react";
+import { signOut } from "@/app/auth-actions";
+import { getUser } from "@/lib/user-auth";
+import {
+  listArtStyles,
+  listDesignLanguages,
+  listPaletteSystems,
+  listRemixes,
+} from "@/lib/odata";
+import { Marker, PageHero } from "@/components/page-hero";
+import { SectionHeading, StickyNote, WashiTape } from "@/components/scrapbook";
+import { UserAvatar } from "@/components/user-menu";
+import { KX_BTN_PAPER } from "@/lib/katagami-ui";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "Account — Katagami",
+  description: "Your Katagami identity and the mixes you saved.",
+};
+
+const COMP_NAME: Record<string, string> = {
+  "compositions.landing": "Landing",
+  "compositions.dashboard": "Dashboard",
+};
+
+type MixRow = {
+  id: string;
+  language: string;
+  palette: string;
+  art: string;
+  composition: string;
+  rating: number;
+};
+
+export default async function AccountPage() {
+  const user = await getUser();
+  if (!user) redirect("/signin?next=/account");
+
+  // Reads are catalog-wide and filtered here in app code on purpose: OData
+  // projected reads can silently omit entities (ARN-97), and creator fields
+  // only exist on post-attribution remixes.
+  const [remixes, languages, palettes, artStyles] = await Promise.all([
+    listRemixes("Status eq 'Saved'").catch(() => []),
+    listDesignLanguages("Status eq 'Published'").catch(() => []),
+    listPaletteSystems().catch(() => []),
+    listArtStyles().catch(() => []),
+  ]);
+
+  const nameOf = (
+    lane: { entity_id: string; fields: Record<string, string | undefined> }[],
+    id: string,
+  ) => lane.find((e) => e.entity_id === id)?.fields.name ?? "—";
+
+  const mine: MixRow[] = remixes
+    .filter((r) => (r.fields.creator_email ?? "") === user.email)
+    .map((r) => ({
+      id: r.entity_id,
+      language: nameOf(languages, r.fields.design_language_id ?? ""),
+      palette: nameOf(palettes, r.fields.palette_system_id ?? ""),
+      art: nameOf(artStyles, r.fields.art_style_id ?? ""),
+      composition:
+        COMP_NAME[r.fields.composition_key ?? ""] ??
+        (r.fields.composition_key || "—"),
+      rating: Number(r.fields.rating ?? r.fields.Rating ?? 0),
+    }));
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-8 px-4 py-6 sm:py-10">
+      <Link
+        href="/"
+        className="group inline-flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowLeft className="h-3 w-3 transition-transform group-hover:-translate-x-0.5" />
+        back to gallery
+      </Link>
+
+      <PageHero
+        eyebrow={
+          <>
+            <span>your account</span>
+            <span className="font-mono text-muted-foreground/70">·</span>
+            <span className="font-mono lowercase tracking-wide">
+              signed in with Google
+            </span>
+          </>
+        }
+        eyebrowAccent="teal"
+        title={
+          <>
+            Hello, <Marker color="teal">{firstName(user.name, user.email)}</Marker>
+          </>
+        }
+        description="This is everything Katagami knows about you: who you are, and the mixes you saved. No more, by design."
+        rightSlot={<span className="stamp text-[var(--teal)]">signed in</span>}
+      />
+
+      <section className="relative">
+        <WashiTape color="teal" rotate={-4} className="-left-3 -top-3" width={86} />
+        <StickyNote className="p-5 sm:p-6">
+          <SectionHeading eyebrow="identity" eyebrowColor="teal">
+            <Marker color="teal">Who you are here</Marker>
+          </SectionHeading>
+          <div className="mt-5 flex flex-wrap items-center gap-4">
+            <UserAvatar user={user} size={56} />
+            <div className="min-w-0 flex-1">
+              <p className="text-lg font-semibold leading-tight text-foreground">
+                {user.name || user.email}
+              </p>
+              <p className="mt-0.5 font-mono text-[12px] lowercase tracking-[0.04em] text-muted-foreground">
+                {user.email}
+              </p>
+            </div>
+            <form action={signOut}>
+              <button className={KX_BTN_PAPER}>
+                <LogOut className="h-3.5 w-3.5" aria-hidden />
+                sign out
+              </button>
+            </form>
+          </div>
+        </StickyNote>
+      </section>
+
+      <section className="relative">
+        <WashiTape color="sakura" rotate={3} className="-right-3 -top-3" width={94} />
+        <StickyNote className="p-5 sm:p-6">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <SectionHeading eyebrow="your work" eyebrowColor="sakura">
+              <Marker color="sakura">Saved mixes</Marker>
+            </SectionHeading>
+            <span className="stamp text-[var(--sakura)]">
+              {mine.length} {mine.length === 1 ? "mix" : "mixes"}
+            </span>
+          </div>
+
+          {mine.length > 0 ? (
+            <div className="mt-5 space-y-2.5">
+              {mine.map((m) => (
+                <article
+                  key={m.id}
+                  className="flex flex-col gap-1.5 bg-background/70 px-3.5 py-3 sm:flex-row sm:items-center sm:justify-between"
+                  style={{ boxShadow: "var(--shadow-card)" }}
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-[14px] font-medium text-foreground">
+                      {m.language} · {m.palette} · {m.art}
+                    </p>
+                    <p className="mt-0.5 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                      {m.composition}
+                      {m.rating > 0 ? ` · rated ${m.rating}/5` : " · unrated"}
+                    </p>
+                  </div>
+                  <Link
+                    href="/studio"
+                    className="shrink-0 font-mono text-[10px] uppercase tracking-[0.16em] text-[color-mix(in_oklch,var(--teal)_72%,var(--foreground))] transition-colors hover:text-foreground"
+                  >
+                    open in studio →
+                  </Link>
+                </article>
+              ))}
+            </div>
+          ) : (
+            <div className="mt-5 space-y-3">
+              <p className="text-sm text-muted-foreground">
+                Nothing saved yet. Mix a language, a palette, and an art style —
+                then save it here under your name.
+              </p>
+              <Link href="/studio" className={KX_BTN_PAPER}>
+                <Palette className="h-3.5 w-3.5" aria-hidden />
+                open the studio
+              </Link>
+            </div>
+          )}
+        </StickyNote>
+      </section>
+    </div>
+  );
+}
+
+function firstName(name: string, email: string): string {
+  const first = name.trim().split(/\s+/)[0];
+  return first || email.split("@")[0];
+}

--- a/ui/src/app/(site)/layout.tsx
+++ b/ui/src/app/(site)/layout.tsx
@@ -4,6 +4,8 @@ import { HeaderNav } from "@/components/header-nav";
 import { MobileNav } from "@/components/mobile-nav";
 import { MobileMenu } from "@/components/mobile-menu";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { UserMenu } from "@/components/user-menu";
+import { getUser } from "@/lib/user-auth";
 import { ScrollReveal } from "@/components/scroll-reveal";
 import {
   CommandPalette,
@@ -123,7 +125,13 @@ export default async function SiteLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const searchIndex = await buildSearchIndex();
+  const [searchIndex, user] = await Promise.all([
+    buildSearchIndex(),
+    getUser(),
+  ]);
+  const headerUser = user
+    ? { name: user.name, email: user.email, picture: user.picture }
+    : null;
 
   return (
     <div className="flex min-h-full w-full max-w-full flex-col overflow-x-hidden pb-[calc(4rem+env(safe-area-inset-bottom))] md:pb-0">
@@ -161,10 +169,12 @@ export default async function SiteLayout({
           <div className="ml-auto hidden items-center gap-2.5 lg:flex">
             <CommandPaletteTrigger />
             <ThemeToggle />
+            <UserMenu user={headerUser} />
           </div>
           <div className="ml-auto flex items-center gap-2 lg:hidden">
             <CommandPaletteTrigger />
             <ThemeToggle />
+            <UserMenu user={headerUser} />
             <MobileMenu />
           </div>
         </nav>

--- a/ui/src/app/(site)/layout.tsx
+++ b/ui/src/app/(site)/layout.tsx
@@ -5,7 +5,6 @@ import { MobileNav } from "@/components/mobile-nav";
 import { MobileMenu } from "@/components/mobile-menu";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { UserMenu } from "@/components/user-menu";
-import { getUser } from "@/lib/user-auth";
 import { ScrollReveal } from "@/components/scroll-reveal";
 import {
   CommandPalette,
@@ -125,13 +124,7 @@ export default async function SiteLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const [searchIndex, user] = await Promise.all([
-    buildSearchIndex(),
-    getUser(),
-  ]);
-  const headerUser = user
-    ? { name: user.name, email: user.email, picture: user.picture }
-    : null;
+  const searchIndex = await buildSearchIndex();
 
   return (
     <div className="flex min-h-full w-full max-w-full flex-col overflow-x-hidden pb-[calc(4rem+env(safe-area-inset-bottom))] md:pb-0">
@@ -169,12 +162,12 @@ export default async function SiteLayout({
           <div className="ml-auto hidden items-center gap-2.5 lg:flex">
             <CommandPaletteTrigger />
             <ThemeToggle />
-            <UserMenu user={headerUser} />
+            <UserMenu />
           </div>
           <div className="ml-auto flex items-center gap-2 lg:hidden">
             <CommandPaletteTrigger />
             <ThemeToggle />
-            <UserMenu user={headerUser} />
+            <UserMenu />
             <MobileMenu />
           </div>
         </nav>

--- a/ui/src/app/(site)/signin/page.tsx
+++ b/ui/src/app/(site)/signin/page.tsx
@@ -1,0 +1,195 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { ArrowLeft, Palette, Star, UserRound } from "lucide-react";
+import { getUser, isAuthConfigured, safeInternalPath } from "@/lib/user-auth";
+import { Marker, PageHero } from "@/components/page-hero";
+import { SectionHeading, StickyNote, WashiTape } from "@/components/scrapbook";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "Sign in — Katagami",
+  description:
+    "Sign in with Google to save mixes in the Remix Studio and put your name on your work.",
+};
+
+const errorCopy: Record<string, string> = {
+  state: "That sign-in attempt expired or didn't come back intact. Try again.",
+  google: "Google didn't confirm that sign-in. Try again.",
+  config:
+    "Sign-in isn't configured on this server yet — the Google client and session secret are missing.",
+};
+
+export default async function SignInPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string; next?: string }>;
+}) {
+  const sp = await searchParams;
+  const next = safeInternalPath(sp.next);
+  const user = await getUser();
+  if (user) redirect(next === "/" ? "/account" : next);
+
+  const configured = isAuthConfigured();
+  const error = sp.error
+    ? (errorCopy[sp.error] ?? errorCopy.google)
+    : undefined;
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-8 px-4 py-6 sm:py-10">
+      <Link
+        href="/"
+        className="group inline-flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowLeft className="h-3 w-3 transition-transform group-hover:-translate-x-0.5" />
+        back to gallery
+      </Link>
+
+      <PageHero
+        eyebrow={
+          <>
+            <span>for humans</span>
+            <span className="font-mono text-muted-foreground/70">·</span>
+            <span className="font-mono lowercase tracking-wide">
+              one click, no passwords
+            </span>
+          </>
+        }
+        eyebrowAccent="teal"
+        title={
+          <>
+            Bring <Marker color="teal">your taste</Marker>
+          </>
+        }
+        description={
+          <>
+            The gallery is open to everyone. Signing in gives your work a name:
+            mixes you save in the Studio are yours, and your ratings teach the
+            commons what good looks like.
+          </>
+        }
+        rightSlot={<span className="stamp text-[var(--teal)]">humans only</span>}
+      />
+
+      <section className="relative">
+        <WashiTape color="teal" rotate={-4} className="-left-3 -top-3" width={86} />
+        <StickyNote className="p-5 sm:p-6">
+          <SectionHeading eyebrow="sign in" eyebrowColor="teal">
+            <Marker color="teal">Continue with Google</Marker>
+          </SectionHeading>
+
+          <div className="mt-5 space-y-4">
+            {configured ? (
+              <a
+                href={`/api/auth/google/start?next=${encodeURIComponent(next)}`}
+                className="inline-flex h-12 items-center justify-center gap-3 bg-card px-6 font-mono text-[12px] font-bold uppercase tracking-[0.16em] text-foreground shadow-[0_2px_0_rgba(30,35,45,0.12)] transition-all duration-200 hover:-translate-y-[2px] hover:rotate-[-1deg]"
+              >
+                <GoogleG />
+                continue with Google
+              </a>
+            ) : (
+              <span className="inline-flex h-12 cursor-not-allowed items-center justify-center gap-3 bg-card px-6 font-mono text-[12px] font-bold uppercase tracking-[0.16em] text-foreground opacity-50 shadow-none">
+                <GoogleG />
+                continue with Google
+              </span>
+            )}
+
+            {error ? (
+              <p className="text-sm font-medium text-destructive">{error}</p>
+            ) : null}
+
+            {!configured ? (
+              <p className="text-sm text-muted-foreground">
+                Set <code className="font-mono text-[12px]">GOOGLE_CLIENT_ID</code>,{" "}
+                <code className="font-mono text-[12px]">GOOGLE_CLIENT_SECRET</code>, and{" "}
+                <code className="font-mono text-[12px]">KATAGAMI_AUTH_SECRET</code>{" "}
+                on the server first.
+              </p>
+            ) : null}
+
+            <p className="max-w-md text-[13px] leading-relaxed text-muted-foreground">
+              We keep your name, email, and avatar in a signed cookie in this
+              browser — nothing more, no password, no tracking. Sign out any
+              time from the header.
+            </p>
+          </div>
+        </StickyNote>
+      </section>
+
+      <section className="relative">
+        <WashiTape color="yuzu" rotate={3} className="-right-3 -top-3" width={94} />
+        <StickyNote className="p-5 sm:p-6">
+          <SectionHeading eyebrow="the account" eyebrowColor="yuzu">
+            <Marker color="yuzu">Three things, nothing else</Marker>
+          </SectionHeading>
+          <div className="mt-5 grid gap-4 sm:grid-cols-3">
+            <PerkCard
+              icon={<Palette className="h-4 w-4" aria-hidden />}
+              title="Save your mixes"
+              body="Keep the language + palette + art style combinations you make in the Remix Studio."
+            />
+            <PerkCard
+              icon={<UserRound className="h-4 w-4" aria-hidden />}
+              title="Your name on your work"
+              body="Saved mixes carry your identity — the first step toward human contributions with credit."
+            />
+            <PerkCard
+              icon={<Star className="h-4 w-4" aria-hidden />}
+              title="Teach the taste loop"
+              body="Rating your mixes feeds the taste signal that curates the whole commons."
+            />
+          </div>
+        </StickyNote>
+      </section>
+    </div>
+  );
+}
+
+function PerkCard({
+  icon,
+  title,
+  body,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  body: string;
+}) {
+  return (
+    <div
+      className="bg-background/70 p-4"
+      style={{ boxShadow: "var(--shadow-card)" }}
+    >
+      <div className="flex items-center gap-2 text-[color-mix(in_oklch,var(--teal)_72%,var(--foreground))]">
+        {icon}
+        <h3 className="text-[14px] font-semibold text-foreground">{title}</h3>
+      </div>
+      <p className="mt-2 text-[13px] leading-relaxed text-muted-foreground">
+        {body}
+      </p>
+    </div>
+  );
+}
+
+/** The four-color Google "G" — inline so the button stays self-contained. */
+function GoogleG() {
+  return (
+    <svg viewBox="0 0 48 48" aria-hidden className="h-[18px] w-[18px] shrink-0">
+      <path
+        fill="#EA4335"
+        d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+      />
+      <path
+        fill="#4285F4"
+        d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+      />
+      <path
+        fill="#34A853"
+        d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+      />
+    </svg>
+  );
+}

--- a/ui/src/app/(site)/studio/page.tsx
+++ b/ui/src/app/(site)/studio/page.tsx
@@ -33,10 +33,11 @@ export default async function StudioPage() {
   const art = toArtOpts(artStyles);
 
   // "Your mixes" means yours: creator-attributed remixes of the signed-in
-  // human. Filtered in app code — projected OData filters can silently omit
-  // entities (ARN-97), and pre-attribution saves carry no creator fields.
+  // human, matched on the stable Google subject id (emails change hands;
+  // subs don't). Filtered in app code — projected OData filters can silently
+  // omit entities (ARN-97), and pre-attribution saves carry no creator fields.
   const mine = user
-    ? savedRemixes.filter((r) => (r.fields.creator_email ?? "") === user.email)
+    ? savedRemixes.filter((r) => (r.fields.creator_sub ?? "") === user.sub)
     : [];
 
   const saved: SavedMix[] = mine.map((r) => ({

--- a/ui/src/app/(site)/studio/page.tsx
+++ b/ui/src/app/(site)/studio/page.tsx
@@ -5,6 +5,7 @@ import {
   listRemixes,
 } from "@/lib/odata";
 import { toLanguageOpts, toPaletteOpts, toArtOpts } from "@/lib/remix-options";
+import { getUser } from "@/lib/user-auth";
 import Link from "next/link";
 import { PageHero, Marker } from "@/components/page-hero";
 import { StudioClient } from "@/components/remix/studio-client";
@@ -18,18 +19,27 @@ export const metadata = {
 };
 
 export default async function StudioPage() {
-  const [languages, palettes, artStyles, savedRemixes] = await Promise.all([
-    listDesignLanguages("Status eq 'Published'").catch(() => []),
-    listPaletteSystems().catch(() => []),
-    listArtStyles().catch(() => []),
-    listRemixes("Status eq 'Saved'").catch(() => []),
-  ]);
+  const [user, languages, palettes, artStyles, savedRemixes] =
+    await Promise.all([
+      getUser(),
+      listDesignLanguages("Status eq 'Published'").catch(() => []),
+      listPaletteSystems().catch(() => []),
+      listArtStyles().catch(() => []),
+      listRemixes("Status eq 'Saved'").catch(() => []),
+    ]);
 
   const ui = toLanguageOpts(languages);
   const pal = toPaletteOpts(palettes);
   const art = toArtOpts(artStyles);
 
-  const saved: SavedMix[] = savedRemixes.map((r) => ({
+  // "Your mixes" means yours: creator-attributed remixes of the signed-in
+  // human. Filtered in app code — projected OData filters can silently omit
+  // entities (ARN-97), and pre-attribution saves carry no creator fields.
+  const mine = user
+    ? savedRemixes.filter((r) => (r.fields.creator_email ?? "") === user.email)
+    : [];
+
+  const saved: SavedMix[] = mine.map((r) => ({
     id: r.entity_id,
     ui: r.fields.design_language_id ?? "",
     palette: r.fields.palette_system_id ?? "",
@@ -57,7 +67,13 @@ export default async function StudioPage() {
         </div>
       ) : (
         <div className="mt-8">
-          <StudioClient ui={ui} palettes={pal} art={art} saved={saved} />
+          <StudioClient
+            ui={ui}
+            palettes={pal}
+            art={art}
+            saved={saved}
+            signedIn={Boolean(user)}
+          />
         </div>
       )}
     </div>

--- a/ui/src/app/api/auth/google/callback/route.ts
+++ b/ui/src/app/api/auth/google/callback/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { exchangeGoogleCode } from "@/lib/google-oidc";
+import {
+  OAUTH_NEXT_COOKIE,
+  OAUTH_STATE_COOKIE,
+  SESSION_COOKIE,
+  SESSION_MAX_AGE,
+  safeInternalPath,
+  signSession,
+} from "@/lib/user-auth";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const origin = req.nextUrl.origin;
+  const code = req.nextUrl.searchParams.get("code");
+  const state = req.nextUrl.searchParams.get("state");
+  const cookieState = req.cookies.get(OAUTH_STATE_COOKIE)?.value;
+
+  if (!code || !state || !cookieState || state !== cookieState) {
+    return NextResponse.redirect(new URL("/signin?error=state", origin));
+  }
+
+  const user = await exchangeGoogleCode(origin, code);
+  const token = user ? await signSession(user) : null;
+  if (!token) {
+    return NextResponse.redirect(new URL("/signin?error=google", origin));
+  }
+
+  const next = safeInternalPath(req.cookies.get(OAUTH_NEXT_COOKIE)?.value);
+  const res = NextResponse.redirect(new URL(next, origin));
+  res.cookies.set(SESSION_COOKIE, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: SESSION_MAX_AGE,
+  });
+  res.cookies.delete(OAUTH_STATE_COOKIE);
+  res.cookies.delete(OAUTH_NEXT_COOKIE);
+  return res;
+}

--- a/ui/src/app/api/auth/google/callback/route.ts
+++ b/ui/src/app/api/auth/google/callback/route.ts
@@ -42,7 +42,8 @@ export async function GET(req: NextRequest) {
   const res = NextResponse.redirect(new URL(next, origin));
   res.cookies.set(SESSION_COOKIE, token, {
     httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
+    // Transport-keyed like the handshake cookies in start/route.ts.
+    secure: req.nextUrl.protocol === "https:",
     sameSite: "lax",
     path: "/",
     maxAge: SESSION_MAX_AGE,

--- a/ui/src/app/api/auth/google/callback/route.ts
+++ b/ui/src/app/api/auth/google/callback/route.ts
@@ -2,7 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { exchangeGoogleCode } from "@/lib/google-oidc";
 import {
   OAUTH_NEXT_COOKIE,
+  OAUTH_NONCE_COOKIE,
   OAUTH_STATE_COOKIE,
+  OAUTH_VERIFIER_COOKIE,
   SESSION_COOKIE,
   SESSION_MAX_AGE,
   safeInternalPath,
@@ -16,12 +18,21 @@ export async function GET(req: NextRequest) {
   const code = req.nextUrl.searchParams.get("code");
   const state = req.nextUrl.searchParams.get("state");
   const cookieState = req.cookies.get(OAUTH_STATE_COOKIE)?.value;
+  const verifier = req.cookies.get(OAUTH_VERIFIER_COOKIE)?.value;
+  const nonce = req.cookies.get(OAUTH_NONCE_COOKIE)?.value;
 
-  if (!code || !state || !cookieState || state !== cookieState) {
+  if (
+    !code ||
+    !state ||
+    !cookieState ||
+    state !== cookieState ||
+    !verifier ||
+    !nonce
+  ) {
     return NextResponse.redirect(new URL("/signin?error=state", origin));
   }
 
-  const user = await exchangeGoogleCode(origin, code);
+  const user = await exchangeGoogleCode(origin, code, verifier, nonce);
   const token = user ? await signSession(user) : null;
   if (!token) {
     return NextResponse.redirect(new URL("/signin?error=google", origin));
@@ -37,6 +48,8 @@ export async function GET(req: NextRequest) {
     maxAge: SESSION_MAX_AGE,
   });
   res.cookies.delete(OAUTH_STATE_COOKIE);
+  res.cookies.delete(OAUTH_VERIFIER_COOKIE);
+  res.cookies.delete(OAUTH_NONCE_COOKIE);
   res.cookies.delete(OAUTH_NEXT_COOKIE);
   return res;
 }

--- a/ui/src/app/api/auth/google/start/route.ts
+++ b/ui/src/app/api/auth/google/start/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { googleAuthUrl } from "@/lib/google-oidc";
+import {
+  OAUTH_NEXT_COOKIE,
+  OAUTH_STATE_COOKIE,
+  isAuthConfigured,
+  safeInternalPath,
+} from "@/lib/user-auth";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const origin = req.nextUrl.origin;
+  if (!isAuthConfigured()) {
+    // Fail loudly at our door instead of bouncing off Google's error page.
+    return NextResponse.redirect(new URL("/signin?error=config", origin));
+  }
+  const state = crypto.randomUUID();
+  const next = safeInternalPath(req.nextUrl.searchParams.get("next"));
+  const res = NextResponse.redirect(googleAuthUrl(origin, state));
+  const cookie = {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 600,
+  } as const;
+  res.cookies.set(OAUTH_STATE_COOKIE, state, cookie);
+  if (next !== "/") res.cookies.set(OAUTH_NEXT_COOKIE, next, cookie);
+  return res;
+}

--- a/ui/src/app/api/auth/google/start/route.ts
+++ b/ui/src/app/api/auth/google/start/route.ts
@@ -23,7 +23,10 @@ export async function GET(req: NextRequest) {
   const res = NextResponse.redirect(handshake.url);
   const cookie = {
     httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
+    // Keyed to the actual transport, not NODE_ENV: a production build served
+    // over http://localhost must not mark cookies Secure — Safari drops them,
+    // which kills the state/verifier round-trip and fails every sign-in.
+    secure: req.nextUrl.protocol === "https:",
     sameSite: "lax",
     path: "/",
     maxAge: 600,

--- a/ui/src/app/api/auth/google/start/route.ts
+++ b/ui/src/app/api/auth/google/start/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { googleAuthUrl } from "@/lib/google-oidc";
+import { beginGoogleAuth } from "@/lib/google-oidc";
 import {
   OAUTH_NEXT_COOKIE,
+  OAUTH_NONCE_COOKIE,
   OAUTH_STATE_COOKIE,
+  OAUTH_VERIFIER_COOKIE,
   isAuthConfigured,
   safeInternalPath,
 } from "@/lib/user-auth";
@@ -17,7 +19,8 @@ export async function GET(req: NextRequest) {
   }
   const state = crypto.randomUUID();
   const next = safeInternalPath(req.nextUrl.searchParams.get("next"));
-  const res = NextResponse.redirect(googleAuthUrl(origin, state));
+  const handshake = await beginGoogleAuth(origin, state);
+  const res = NextResponse.redirect(handshake.url);
   const cookie = {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
@@ -26,6 +29,14 @@ export async function GET(req: NextRequest) {
     maxAge: 600,
   } as const;
   res.cookies.set(OAUTH_STATE_COOKIE, state, cookie);
-  if (next !== "/") res.cookies.set(OAUTH_NEXT_COOKIE, next, cookie);
+  res.cookies.set(OAUTH_VERIFIER_COOKIE, handshake.verifier, cookie);
+  res.cookies.set(OAUTH_NONCE_COOKIE, handshake.nonce, cookie);
+  if (next !== "/") {
+    res.cookies.set(OAUTH_NEXT_COOKIE, next, cookie);
+  } else {
+    // Clear any leftover target from an abandoned attempt so it can't
+    // redirect this fresh sign-in.
+    res.cookies.delete(OAUTH_NEXT_COOKIE);
+  }
   return res;
 }

--- a/ui/src/app/api/auth/me/route.ts
+++ b/ui/src/app/api/auth/me/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { getUser } from "@/lib/user-auth";
+
+// The header identity chip reads the session from here, client-side, so the
+// shared (site) layout never touches cookies() — keeping /language/[id],
+// /taxonomy, and friends in the full-route cache.
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const user = await getUser();
+  return NextResponse.json(
+    {
+      user: user
+        ? { name: user.name, email: user.email, picture: user.picture }
+        : null,
+    },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}

--- a/ui/src/app/auth-actions.ts
+++ b/ui/src/app/auth-actions.ts
@@ -1,0 +1,13 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { SESSION_COOKIE } from "@/lib/user-auth";
+
+// Sign-out is a POST (server action), never a GET route: links and
+// prefetchers must not be able to end a session.
+export async function signOut(): Promise<void> {
+  const cookieStore = await cookies();
+  cookieStore.delete(SESSION_COOKIE);
+  redirect("/");
+}

--- a/ui/src/app/remix-actions.ts
+++ b/ui/src/app/remix-actions.ts
@@ -47,7 +47,9 @@ export async function saveRemix(sel: RemixSelection): Promise<string> {
 export async function rateRemix(id: string, rating: number): Promise<void> {
   const user = await requireUser();
   const remix = await getRemix(id);
-  if ((remix.fields.creator_email ?? "") !== user.email) {
+  // Ownership is the stable Google subject id, not the email — emails change
+  // hands (and Workspace recycles them); subs don't.
+  if ((remix.fields.creator_sub ?? "") !== user.sub) {
     throw new Error("Only the mix's creator can rate it.");
   }
   const clamped = Math.max(1, Math.min(5, Math.round(rating)));

--- a/ui/src/app/remix-actions.ts
+++ b/ui/src/app/remix-actions.ts
@@ -1,7 +1,9 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { getRemix } from "@/lib/odata";
 import { createEntity, dispatchAction } from "@/lib/odata-mutations";
+import { requireUser } from "@/lib/user-auth";
 
 export interface RemixSelection {
   designLanguageId: string;
@@ -11,14 +13,24 @@ export interface RemixSelection {
   slotAssignments?: string; // JSON: slot key -> reference id/url
 }
 
-/** Persist the current mix as a Remix entity, walked to Saved. Returns its id. */
+/**
+ * Persist the current mix as a Remix entity, walked to Saved and attributed
+ * to the signed-in human. Returns its id.
+ */
 export async function saveRemix(sel: RemixSelection): Promise<string> {
+  const user = await requireUser();
   const remix = await createEntity("Remixes");
   await dispatchAction("Remixes", remix.entity_id, "SetSelection", {
     design_language_id: sel.designLanguageId,
     palette_system_id: sel.paletteSystemId,
     art_style_id: sel.artStyleId,
     composition_key: sel.compositionKey,
+  });
+  await dispatchAction("Remixes", remix.entity_id, "SetCreator", {
+    creator_sub: user.sub,
+    creator_email: user.email,
+    creator_name: user.name,
+    creator_avatar_url: user.picture,
   });
   if (sel.slotAssignments) {
     await dispatchAction("Remixes", remix.entity_id, "SetSlotAssignments", {
@@ -27,12 +39,19 @@ export async function saveRemix(sel: RemixSelection): Promise<string> {
   }
   await dispatchAction("Remixes", remix.entity_id, "Save", {});
   revalidatePath("/studio");
+  revalidatePath("/account");
   return remix.entity_id;
 }
 
-/** Rate a saved mix 1–5. Feeds the remix-compatibility taste signal. */
+/** Rate one of your own mixes 1–5. Feeds the remix-compatibility taste signal. */
 export async function rateRemix(id: string, rating: number): Promise<void> {
+  const user = await requireUser();
+  const remix = await getRemix(id);
+  if ((remix.fields.creator_email ?? "") !== user.email) {
+    throw new Error("Only the mix's creator can rate it.");
+  }
   const clamped = Math.max(1, Math.min(5, Math.round(rating)));
   await dispatchAction("Remixes", id, "Rate", { rating: clamped });
   revalidatePath("/studio");
+  revalidatePath("/account");
 }

--- a/ui/src/components/remix/inline-remix.tsx
+++ b/ui/src/components/remix/inline-remix.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState, useTransition } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { RemixPreview } from "@/components/remix/remix-preview";
 import { EntityPicker, type PickItem } from "@/components/remix/entity-picker";
@@ -98,6 +99,7 @@ export function InlineRemix({
   art,
   fixed = {},
   enableSave = false,
+  signedIn = true,
   initial,
 }: {
   languages: LanguageOpt[];
@@ -105,6 +107,8 @@ export function InlineRemix({
   art: ArtOpt[];
   fixed?: { language?: string; palette?: string; art?: string };
   enableSave?: boolean;
+  /** Saving is a signed-in act; signed out, the save button becomes the door. */
+  signedIn?: boolean;
   initial?: { langId?: string; palId?: string; artId?: string; compositionKey?: string };
 }) {
   const router = useRouter();
@@ -268,9 +272,15 @@ export function InlineRemix({
           </button>
         ) : null}
         {enableSave ? (
-          <button type="button" onClick={doSave} disabled={!haveAll || pending} className={KX_BTN_PAPER}>
-            {saved ? "Saved" : pending ? "Saving" : "Save mix"}
-          </button>
+          signedIn ? (
+            <button type="button" onClick={doSave} disabled={!haveAll || pending} className={KX_BTN_PAPER}>
+              {saved ? "Saved" : pending ? "Saving" : "Save mix"}
+            </button>
+          ) : (
+            <Link href="/signin?next=/studio" className={KX_BTN_PAPER}>
+              Sign in to save
+            </Link>
+          )
         ) : null}
         <button
           type="button"

--- a/ui/src/components/remix/inline-remix.tsx
+++ b/ui/src/components/remix/inline-remix.tsx
@@ -122,6 +122,7 @@ export function InlineRemix({
   });
   const [copied, setCopied] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [saveFailed, setSaveFailed] = useState(false);
 
   const lang = languages.find((l) => l.id === langId) ?? languages[0];
   const pal = palettes.find((p) => p.id === palId) ?? palettes[0];
@@ -216,16 +217,24 @@ export function InlineRemix({
   function doSave() {
     if (!haveAll) return;
     startTransition(async () => {
-      await saveRemix({
-        designLanguageId: lang.id,
-        paletteSystemId: pal.id,
-        artStyleId: sel.id,
-        compositionKey: comp.key,
-        slotAssignments: JSON.stringify({ hero }),
-      });
-      setSaved(true);
-      setTimeout(() => setSaved(false), 1600);
-      router.refresh();
+      try {
+        await saveRemix({
+          designLanguageId: lang.id,
+          paletteSystemId: pal.id,
+          artStyleId: sel.id,
+          compositionKey: comp.key,
+          slotAssignments: JSON.stringify({ hero }),
+        });
+        setSaveFailed(false);
+        setSaved(true);
+        setTimeout(() => setSaved(false), 1600);
+        router.refresh();
+      } catch {
+        // Most likely an expired session mid-visit (signedIn is a render-time
+        // snapshot). Keep the mix on screen and point at the door instead of
+        // crashing to the route error boundary.
+        setSaveFailed(true);
+      }
     });
   }
 
@@ -274,13 +283,21 @@ export function InlineRemix({
         {enableSave ? (
           signedIn ? (
             <button type="button" onClick={doSave} disabled={!haveAll || pending} className={KX_BTN_PAPER}>
-              {saved ? "Saved" : pending ? "Saving" : "Save mix"}
+              {saved ? "Saved" : pending ? "Saving" : saveFailed ? "Retry save" : "Save mix"}
             </button>
           ) : (
             <Link href="/signin?next=/studio" className={KX_BTN_PAPER}>
               Sign in to save
             </Link>
           )
+        ) : null}
+        {saveFailed ? (
+          <Link
+            href="/signin?next=/studio"
+            className="font-mono text-[10px] uppercase tracking-[0.14em] text-destructive underline-offset-2 hover:underline"
+          >
+            couldn&apos;t save — check you&apos;re signed in →
+          </Link>
         ) : null}
         <button
           type="button"

--- a/ui/src/components/remix/saved-mixes.tsx
+++ b/ui/src/components/remix/saved-mixes.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { RemixPreview } from "@/components/remix/remix-preview";
 import { rateRemix } from "@/app/remix-actions";
@@ -43,12 +43,20 @@ export function SavedMixes({
 }) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
+  const [rateFailed, setRateFailed] = useState(false);
   if (saved.length === 0) return null;
 
   function rate(id: string, n: number) {
     startTransition(async () => {
-      await rateRemix(id, n);
-      router.refresh();
+      try {
+        await rateRemix(id, n);
+        setRateFailed(false);
+        router.refresh();
+      } catch {
+        // Expired session or a refused rating — surface it inline instead of
+        // crashing to the route error boundary.
+        setRateFailed(true);
+      }
     });
   }
 
@@ -57,6 +65,11 @@ export function SavedMixes({
       <div className="mb-3 flex flex-wrap items-center gap-2.5">
         <span className="stamp text-[var(--yuzu)]">saved</span>
         <span className={KX_LABEL}>your mixes · click one to reopen it above · rate to teach taste</span>
+        {rateFailed ? (
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-destructive">
+            rating didn&apos;t stick — check you&apos;re still signed in
+          </span>
+        ) : null}
       </div>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {saved.map((m) => {

--- a/ui/src/components/remix/studio-client.tsx
+++ b/ui/src/components/remix/studio-client.tsx
@@ -14,11 +14,13 @@ export function StudioClient({
   palettes,
   art,
   saved,
+  signedIn,
 }: {
   ui: LanguageOpt[];
   palettes: PaletteOpt[];
   art: ArtOpt[];
   saved: SavedMix[];
+  signedIn: boolean;
 }) {
   const [initial, setInitial] = useState<LoadSelection | undefined>(undefined);
   const [nonce, setNonce] = useState(0);
@@ -37,9 +39,12 @@ export function StudioClient({
         palettes={palettes}
         art={art}
         enableSave
+        signedIn={signedIn}
         initial={initial}
       />
-      <SavedMixes saved={saved} languages={ui} palettes={palettes} art={art} onLoad={load} />
+      {signedIn ? (
+        <SavedMixes saved={saved} languages={ui} palettes={palettes} art={art} onLoad={load} />
+      ) : null}
     </div>
   );
 }

--- a/ui/src/components/user-menu.tsx
+++ b/ui/src/components/user-menu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import * as Dropdown from "@radix-ui/react-dropdown-menu";
@@ -10,14 +10,40 @@ import { signOut } from "@/app/auth-actions";
 // Header identity chip — the human counterpart of the theme stamp next to it.
 // Signed out it's a "sign in" stamp; signed in it's your avatar opening a
 // small paper menu (account, sign out). Owner mode stays separate at /owner.
+//
+// The session is fetched client-side from /api/auth/me: reading cookies()
+// in the shared (site) layout would opt every route out of the full-route
+// cache, and this chip is the only personalized element on most pages.
 
 export type HeaderUser = { name: string; email: string; picture: string };
 
 const MENU_ITEM =
   "flex w-full cursor-pointer items-center gap-2 px-2.5 py-2 font-mono text-[11px] uppercase tracking-[0.15em] text-foreground/80 outline-none transition-colors data-[highlighted]:bg-[color-mix(in_srgb,var(--foreground)_6%,transparent)] data-[highlighted]:text-foreground";
 
-export function UserMenu({ user }: { user: HeaderUser | null }) {
+export function UserMenu() {
   const [, startTransition] = useTransition();
+  // undefined = still resolving; render a same-size blank so the header
+  // doesn't jump when the answer arrives.
+  const [user, setUser] = useState<HeaderUser | null | undefined>(undefined);
+
+  useEffect(() => {
+    let alive = true;
+    fetch("/api/auth/me", { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : { user: null }))
+      .then((d: { user: HeaderUser | null }) => {
+        if (alive) setUser(d.user ?? null);
+      })
+      .catch(() => {
+        if (alive) setUser(null);
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  if (user === undefined) {
+    return <span aria-hidden className="inline-block h-7 w-7" />;
+  }
 
   if (!user) {
     return (
@@ -78,7 +104,14 @@ export function UserMenu({ user }: { user: HeaderUser | null }) {
             </Dropdown.Item>
             <Dropdown.Item
               className={MENU_ITEM}
-              onSelect={() => startTransition(() => signOut())}
+              onSelect={() =>
+                startTransition(async () => {
+                  // The layout persists through the action's client-side
+                  // redirect, so flip the chip ourselves.
+                  setUser(null);
+                  await signOut();
+                })
+              }
             >
               <LogOut className="h-3.5 w-3.5" aria-hidden />
               sign out

--- a/ui/src/components/user-menu.tsx
+++ b/ui/src/components/user-menu.tsx
@@ -42,7 +42,8 @@ export function UserMenu() {
   }, []);
 
   if (user === undefined) {
-    return <span aria-hidden className="inline-block h-7 w-7" />;
+    // Sized to the signed-in avatar button so returning users see no shift.
+    return <span aria-hidden className="inline-block h-8 w-8" />;
   }
 
   if (!user) {

--- a/ui/src/components/user-menu.tsx
+++ b/ui/src/components/user-menu.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useTransition } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import * as Dropdown from "@radix-ui/react-dropdown-menu";
+import { LogIn, LogOut, UserRound } from "lucide-react";
+import { signOut } from "@/app/auth-actions";
+
+// Header identity chip — the human counterpart of the theme stamp next to it.
+// Signed out it's a "sign in" stamp; signed in it's your avatar opening a
+// small paper menu (account, sign out). Owner mode stays separate at /owner.
+
+export type HeaderUser = { name: string; email: string; picture: string };
+
+const MENU_ITEM =
+  "flex w-full cursor-pointer items-center gap-2 px-2.5 py-2 font-mono text-[11px] uppercase tracking-[0.15em] text-foreground/80 outline-none transition-colors data-[highlighted]:bg-[color-mix(in_srgb,var(--foreground)_6%,transparent)] data-[highlighted]:text-foreground";
+
+export function UserMenu({ user }: { user: HeaderUser | null }) {
+  const [, startTransition] = useTransition();
+
+  if (!user) {
+    return (
+      <Link
+        href="/signin"
+        aria-label="sign in"
+        title="sign in"
+        className="stamp inline-flex h-7 items-center gap-1.5 whitespace-nowrap px-2.5 text-[var(--teal)] transition-transform duration-200 hover:-translate-y-[1px] hover:rotate-[-6deg]"
+      >
+        <LogIn className="h-3.5 w-3.5" aria-hidden />
+        {/* icon-only below sm — the mobile header row is already full */}
+        <span
+          className="hidden font-mono sm:inline"
+          style={{ fontSize: 11, letterSpacing: "0.08em", lineHeight: 1 }}
+        >
+          sign in
+        </span>
+      </Link>
+    );
+  }
+
+  return (
+    <Dropdown.Root>
+      <Dropdown.Trigger asChild>
+        <button
+          type="button"
+          aria-label={`Account — ${user.name || user.email}`}
+          title={user.name || user.email}
+          className="inline-flex h-8 w-8 items-center justify-center transition-transform duration-200 hover:-translate-y-[1px] data-[state=open]:-translate-y-[1px]"
+        >
+          <UserAvatar user={user} size={26} />
+        </button>
+      </Dropdown.Trigger>
+      <Dropdown.Portal>
+        <Dropdown.Content
+          align="end"
+          sideOffset={10}
+          className="z-[70] w-64 bg-card p-2 shadow-[0_2px_4px_rgba(30,35,45,0.08),0_12px_32px_rgba(30,35,45,0.16)] data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+        >
+          <div className="flex items-center gap-2.5 px-2.5 pb-2.5 pt-2">
+            <UserAvatar user={user} size={34} />
+            <div className="min-w-0">
+              <p className="truncate text-[13px] font-semibold leading-tight text-foreground">
+                {user.name || user.email}
+              </p>
+              <p className="truncate font-mono text-[10px] lowercase tracking-[0.04em] text-muted-foreground">
+                {user.email}
+              </p>
+            </div>
+          </div>
+          <div className="sticker-perforation mx-1" />
+          <div className="pt-1.5">
+            <Dropdown.Item asChild>
+              <Link href="/account" className={MENU_ITEM}>
+                <UserRound className="h-3.5 w-3.5" aria-hidden />
+                account
+              </Link>
+            </Dropdown.Item>
+            <Dropdown.Item
+              className={MENU_ITEM}
+              onSelect={() => startTransition(() => signOut())}
+            >
+              <LogOut className="h-3.5 w-3.5" aria-hidden />
+              sign out
+            </Dropdown.Item>
+          </div>
+        </Dropdown.Content>
+      </Dropdown.Portal>
+    </Dropdown.Root>
+  );
+}
+
+export function UserAvatar({
+  user,
+  size,
+}: {
+  user: Pick<HeaderUser, "name" | "email" | "picture">;
+  size: number;
+}) {
+  if (user.picture) {
+    return (
+      <Image
+        src={user.picture}
+        alt=""
+        width={size}
+        height={size}
+        referrerPolicy="no-referrer"
+        className="rounded-full shadow-[0_1px_2px_rgba(30,35,45,0.22)]"
+      />
+    );
+  }
+  return (
+    <span
+      aria-hidden
+      style={{ width: size, height: size, fontSize: Math.round(size * 0.44) }}
+      className="grid place-items-center rounded-full bg-[var(--teal)] font-mono font-bold text-background"
+    >
+      {(user.name || user.email).charAt(0).toUpperCase()}
+    </span>
+  );
+}

--- a/ui/src/lib/google-oidc.ts
+++ b/ui/src/lib/google-oidc.ts
@@ -1,8 +1,9 @@
 import "server-only";
 
 // Minimal Google OIDC (same in-house flow as the Aya UI): build the consent
-// URL, exchange the code server-side, verify the returned ID token against
-// Google's JWKS. No provider framework — this is the whole dance.
+// URL with PKCE + nonce, exchange the code server-side, verify the returned
+// ID token against Google's JWKS. No provider framework — this is the whole
+// dance.
 import { createRemoteJWKSet, jwtVerify } from "jose";
 import type { SessionUser } from "@/lib/user-auth";
 
@@ -16,21 +17,53 @@ function redirectUri(origin: string): string {
   return `${origin}/api/auth/google/callback`;
 }
 
-export function googleAuthUrl(origin: string, state: string): string {
+function randomToken(bytes: number): string {
+  const buf = new Uint8Array(bytes);
+  crypto.getRandomValues(buf);
+  return Buffer.from(buf).toString("base64url");
+}
+
+async function s256(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(input),
+  );
+  return Buffer.from(digest).toString("base64url");
+}
+
+export type GoogleHandshake = {
+  url: string;
+  /** PKCE code verifier — round-trips via an httpOnly cookie to the callback. */
+  verifier: string;
+  /** OIDC nonce — must come back inside the verified ID token. */
+  nonce: string;
+};
+
+export async function beginGoogleAuth(
+  origin: string,
+  state: string,
+): Promise<GoogleHandshake> {
+  const verifier = randomToken(32);
+  const nonce = randomToken(16);
   const p = new URLSearchParams({
     client_id: process.env.GOOGLE_CLIENT_ID ?? "",
     redirect_uri: redirectUri(origin),
     response_type: "code",
     scope: "openid email profile",
     state,
+    nonce,
+    code_challenge: await s256(verifier),
+    code_challenge_method: "S256",
     prompt: "select_account",
   });
-  return `${GOOGLE_AUTH}?${p.toString()}`;
+  return { url: `${GOOGLE_AUTH}?${p.toString()}`, verifier, nonce };
 }
 
 export async function exchangeGoogleCode(
   origin: string,
   code: string,
+  verifier: string,
+  expectedNonce: string,
 ): Promise<SessionUser | null> {
   const res = await fetch(GOOGLE_TOKEN, {
     method: "POST",
@@ -41,6 +74,7 @@ export async function exchangeGoogleCode(
       client_secret: process.env.GOOGLE_CLIENT_SECRET ?? "",
       redirect_uri: redirectUri(origin),
       grant_type: "authorization_code",
+      code_verifier: verifier,
     }),
   });
   if (!res.ok) return null;
@@ -53,7 +87,10 @@ export async function exchangeGoogleCode(
     });
     const sub = String(payload.sub ?? "");
     const email = String(payload.email ?? "");
-    if (!sub || !email || payload.email_verified === false) return null;
+    if (!sub || !email) return null;
+    // Absent claims fail closed: verified email and our nonce, or no session.
+    if (payload.email_verified !== true) return null;
+    if (payload.nonce !== expectedNonce) return null;
     return {
       sub,
       email,

--- a/ui/src/lib/google-oidc.ts
+++ b/ui/src/lib/google-oidc.ts
@@ -1,0 +1,66 @@
+import "server-only";
+
+// Minimal Google OIDC (same in-house flow as the Aya UI): build the consent
+// URL, exchange the code server-side, verify the returned ID token against
+// Google's JWKS. No provider framework — this is the whole dance.
+import { createRemoteJWKSet, jwtVerify } from "jose";
+import type { SessionUser } from "@/lib/user-auth";
+
+const GOOGLE_AUTH = "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN = "https://oauth2.googleapis.com/token";
+const JWKS = createRemoteJWKSet(
+  new URL("https://www.googleapis.com/oauth2/v3/certs"),
+);
+
+function redirectUri(origin: string): string {
+  return `${origin}/api/auth/google/callback`;
+}
+
+export function googleAuthUrl(origin: string, state: string): string {
+  const p = new URLSearchParams({
+    client_id: process.env.GOOGLE_CLIENT_ID ?? "",
+    redirect_uri: redirectUri(origin),
+    response_type: "code",
+    scope: "openid email profile",
+    state,
+    prompt: "select_account",
+  });
+  return `${GOOGLE_AUTH}?${p.toString()}`;
+}
+
+export async function exchangeGoogleCode(
+  origin: string,
+  code: string,
+): Promise<SessionUser | null> {
+  const res = await fetch(GOOGLE_TOKEN, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      code,
+      client_id: process.env.GOOGLE_CLIENT_ID ?? "",
+      client_secret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+      redirect_uri: redirectUri(origin),
+      grant_type: "authorization_code",
+    }),
+  });
+  if (!res.ok) return null;
+  const tok = (await res.json()) as { id_token?: string };
+  if (!tok.id_token) return null;
+  try {
+    const { payload } = await jwtVerify(tok.id_token, JWKS, {
+      issuer: ["https://accounts.google.com", "accounts.google.com"],
+      audience: process.env.GOOGLE_CLIENT_ID,
+    });
+    const sub = String(payload.sub ?? "");
+    const email = String(payload.email ?? "");
+    if (!sub || !email || payload.email_verified === false) return null;
+    return {
+      sub,
+      email,
+      name: String(payload.name ?? email.split("@")[0]),
+      picture: String(payload.picture ?? ""),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/ui/src/lib/user-auth.ts
+++ b/ui/src/lib/user-auth.ts
@@ -1,0 +1,92 @@
+import "server-only";
+
+import { SignJWT, jwtVerify } from "jose";
+import { cookies } from "next/headers";
+
+// Human sign-in sessions (Google identity), sibling of the curator-only owner
+// mode in owner.ts. Stateless by design: the signed cookie IS the account —
+// there is no user table. Google proves who you are once; the session carries
+// {sub, email, name, picture} until it expires.
+
+export const SESSION_COOKIE = "katagami_user";
+export const OAUTH_STATE_COOKIE = "katagami_oauth_state";
+export const OAUTH_NEXT_COOKIE = "katagami_oauth_next";
+export const SESSION_MAX_AGE = 60 * 60 * 24 * 30;
+
+export type SessionUser = {
+  /** Google's stable subject id — survives email/name changes. */
+  sub: string;
+  email: string;
+  name: string;
+  picture: string;
+};
+
+function sessionSecret(): Uint8Array | null {
+  const raw = process.env.KATAGAMI_AUTH_SECRET ?? "";
+  // No dev fallback secret: unset means sign-in is off, never insecurely on.
+  return raw ? new TextEncoder().encode(raw) : null;
+}
+
+export function isAuthConfigured(): boolean {
+  return Boolean(
+    process.env.GOOGLE_CLIENT_ID &&
+      process.env.GOOGLE_CLIENT_SECRET &&
+      process.env.KATAGAMI_AUTH_SECRET,
+  );
+}
+
+export async function signSession(user: SessionUser): Promise<string | null> {
+  const secret = sessionSecret();
+  if (!secret) return null;
+  return new SignJWT({
+    email: user.email,
+    name: user.name,
+    picture: user.picture,
+  })
+    .setProtectedHeader({ alg: "HS256" })
+    .setSubject(user.sub)
+    .setIssuedAt()
+    .setExpirationTime(`${SESSION_MAX_AGE}s`)
+    .sign(secret);
+}
+
+export async function verifySession(
+  token?: string,
+): Promise<SessionUser | null> {
+  const secret = sessionSecret();
+  if (!secret || !token) return null;
+  try {
+    const { payload } = await jwtVerify(token, secret, {
+      algorithms: ["HS256"],
+    });
+    const email = String(payload.email ?? "");
+    if (!payload.sub || !email) return null;
+    return {
+      sub: payload.sub,
+      email,
+      name: String(payload.name ?? ""),
+      picture: String(payload.picture ?? ""),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** The signed-in human, or null. */
+export async function getUser(): Promise<SessionUser | null> {
+  const cookieStore = await cookies();
+  return verifySession(cookieStore.get(SESSION_COOKIE)?.value);
+}
+
+/** Guard for server actions that create or mutate a human's own work. */
+export async function requireUser(): Promise<SessionUser> {
+  const user = await getUser();
+  if (!user) throw new Error("Sign in with Google to do this.");
+  return user;
+}
+
+// Post-sign-in redirect targets must stay on this site: a single leading
+// slash (no scheme, no //host, no /\host). Anything else falls back to "/".
+export function safeInternalPath(p?: string | null): string {
+  return p && /^\/(?![/\\])/.test(p) ? p : "/";
+}

--- a/ui/src/lib/user-auth.ts
+++ b/ui/src/lib/user-auth.ts
@@ -11,6 +11,8 @@ import { cookies } from "next/headers";
 export const SESSION_COOKIE = "katagami_user";
 export const OAUTH_STATE_COOKIE = "katagami_oauth_state";
 export const OAUTH_NEXT_COOKIE = "katagami_oauth_next";
+export const OAUTH_VERIFIER_COOKIE = "katagami_oauth_verifier";
+export const OAUTH_NONCE_COOKIE = "katagami_oauth_nonce";
 export const SESSION_MAX_AGE = 60 * 60 * 24 * 30;
 
 export type SessionUser = {
@@ -85,8 +87,17 @@ export async function requireUser(): Promise<SessionUser> {
   return user;
 }
 
-// Post-sign-in redirect targets must stay on this site: a single leading
-// slash (no scheme, no //host, no /\host). Anything else falls back to "/".
+// Post-sign-in redirect targets must stay on this site. Control characters
+// are rejected outright — the WHATWG URL parser strips tab/CR/LF, so
+// "/\t/evil.com" would sail past a prefix check and resolve off-site — and
+// the survivor is validated by actually resolving it against a fixed origin.
 export function safeInternalPath(p?: string | null): string {
-  return p && /^\/(?![/\\])/.test(p) ? p : "/";
+  if (!p || /[\u0000-\u001f\\]/.test(p) || !/^\/(?!\/)/.test(p)) return "/";
+  try {
+    const url = new URL(p, "https://katagami.invalid");
+    if (url.origin !== "https://katagami.invalid") return "/";
+    return url.pathname + url.search + url.hash;
+  } catch {
+    return "/";
+  }
 }


### PR DESCRIPTION
## What we are addressing

katagami.ai has no concept of a human user: Studio saves/ratings are anonymous and open to anyone, and the only identity on the site is the curator-only owner passphrase. Rita asked for user authorization through Gmail — for humans, properly set up, beautifully styled (Linear: ARN-143).

## Expected end state

- Humans sign in with Google on a styled /signin page; a profile menu lives in the header; /account shows who you are and the mixes you saved.
- Saving and rating in the Studio requires sign-in; saved Remixes are attributed (SetCreator: sub, email, name, avatar) and "your mixes" means yours.
- Zero new auth framework: hand-rolled Google OIDC + jose (the same in-house pattern as the Aya UI, ARN-131), mirroring the existing owner.ts HMAC-cookie idiom. Unset env ⇒ sign-in is off, gracefully, with /signin saying exactly which vars are missing.

## What's in

- **OIDC flow**: `/api/auth/google/start` (state + **PKCE S256 + nonce**, all round-tripping in httpOnly cookies; refuses unconfigured; clears stale next-targets) → Google → `/api/auth/google/callback` (state CSRF check, verifier+nonce required, server-side code exchange with `code_verifier`, JWKS-verified ID token, `email_verified !== true` and nonce-mismatch fail closed, redirect targets validated **by URL resolution**, not prefix). Sign-out is a server action, not a GET route.
- **Sessions**: stateless HS256 cookie `katagami_user` {sub, email, name, picture}, 30 days, httpOnly/SameSite=Lax; no user table; **no fallback secret** — `KATAGAMI_AUTH_SECRET` unset means off, never insecurely on.
- **UI**: /signin + /account in the scrapbook idiom; header identity chip (sign-in stamp / avatar dropdown) as a **client island hydrating from /api/auth/me**, so the shared layout stays cookie-free and /language/[id], /taxonomy, /model-bake-off/model/[slug] stay in the full-route cache.
- **Gating + attribution**: saveRemix requires sign-in and dispatches SetCreator; ownership keys on **creator_sub** (stable Google subject id — emails change hands, subs don't); Studio/account filter to the signed-in human in app code (ARN-97 makes projected OData filters unsafe). Save/rate failures surface inline nudges instead of crashing to the error boundary.
- **Spec**: additive `SetCreator` + `has_creator` on the Remix IOA (katagami-commons) with a Python contract test; Save's guard untouched so historical/agent remixes stay valid.
- **Checks**: `scripts/check-auth-contract.mjs` — 24 invariants wired into `npm test`; env vars documented in DEPLOYMENT.md.

## Review

Independent review (read-only agent): first pass **FAIL** — 1 P1 (open redirect: the URL parser strips tab/CR/LF, so `/%09/evil.com` sailed past the prefix check) + 6 P2s. All fixed in 8acf124; re-review verified each fix empirically (10-case exploit table all collapsing to `/`) and scanned the new surfaces: **PASS**.

## Verified live locally (prod build, real Railway backend)

- Unconfigured /signin (disabled button, names the missing vars) and configured /signin.
- OAuth start route: 307 to accounts.google.com with `code_challenge`+`nonce`; 4 httpOnly cookies; exploit next-param `%2F%09%2Fevil.com` falls back to `/`.
- Minted-session pass: header avatar menu, /account identity card + saved-mixes states, sign-out action (cookie cleared, chip flips), /api/auth/me in both states.
- Signed-out: Studio shows "Sign in to save" → /signin?next=/studio; /account bounces to /signin.
- Mobile 390px: one-line header (icon-only chip), pages fully responsive.

Not exercised yet: the Google hop itself (no OAuth client exists yet) and a real attributed save (SetCreator must be installed on the backend first).

## Deploy order (so nothing breaks and no capability regresses)

1. katagami-commons spec → Genesis → Railway install (SetCreator must exist before any signed-in save).
2. Google OAuth client (console) + Vercel env: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `KATAGAMI_AUTH_SECRET`. Redirect URIs: `https://katagami.ai/api/auth/google/callback`, `http://localhost:3000/api/auth/google/callback`.
3. Merge this PR → Vercel → live e2e (real Google sign-in, attributed save, rating).

## Decisions for Rita (flagged, not silently decided)

- **Pre-attribution saved mixes** no longer render in anyone's "your mixes" and are permanently unratable (no creator fields). Deliberate — attribution needs identity — but it changes shipped behavior; needs your sign-off.
- First-class User/Member entity in Temper (durable accounts, roles, cross-device) vs. session-only — session-only shipped for v1.
- Whether Google sign-in should eventually replace the /owner passphrase via an allowlist — untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)