### PR TITLE
feat(auth): owner-by-identity + spec-enforced no-anonymous-remixes (ARN-144)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -36,7 +36,7 @@ Set in Vercel project settings (Production + Preview):
 | `NEXT_PUBLIC_TEMPER_API_URL` | yes | Public Railway URL of the temperpaw backend |
 | `NEXT_PUBLIC_TEMPER_TENANT` | yes | Tenant identifier passed as `X-Tenant-Id` |
 | `TEMPER_API_KEY` | **server-only** | Bearer token for Railway. Read only by Server Components, Server Actions, and the file-proxy route handler. No `NEXT_PUBLIC_` prefix → never shipped to the browser bundle |
-| `KATAGAMI_OWNER_SECRET` | **server-only** | Passphrase for `/owner`. When unlocked, Vercel sets an HTTP-only owner cookie that reveals delete controls and gates destructive Server Actions |
+| `KATAGAMI_OWNER_SUBS` | **server-only** | Comma-separated allowlist of Google subject ids whose signed-in accounts get owner access (`/owner`, delete controls, destructive Server Actions). Replaced the `KATAGAMI_OWNER_SECRET` passphrase — owner mode now follows identity. Find a sub on any attributed Remix (`creator_sub`) |
 | `GOOGLE_CLIENT_ID` | **server-only** | OAuth 2.0 client id for human "Sign in with Google" (`/signin`). Authorized redirect URIs: `https://katagami.ai/api/auth/google/callback` and `http://localhost:3000/api/auth/google/callback` |
 | `GOOGLE_CLIENT_SECRET` | **server-only** | OAuth 2.0 client secret paired with `GOOGLE_CLIENT_ID` |
 | `KATAGAMI_AUTH_SECRET` | **server-only** | HS256 secret signing the human session cookie (`katagami_user`). Generate with `openssl rand -base64 32`. Unset ⇒ sign-in is off and `/signin` says so; there is no fallback secret |

--- a/katagami-commons/specs/remix.ioa.toml
+++ b/katagami-commons/specs/remix.ioa.toml
@@ -79,8 +79,11 @@ name = "Save"
 kind = "internal"
 from = ["Draft"]
 to = "Saved"
-guard = [{ type = "is_true", var = "has_selection" }]
-hint = "Persist the mix once a selection exists. Pins it for sharing and rating."
+guard = [
+  { type = "is_true", var = "has_selection" },
+  { type = "is_true", var = "has_creator" },
+]
+hint = "Persist the mix once a selection AND a creator exist. Anonymous remixes are impossible by construction: every Saved mix belongs to a signed-in human (SetCreator runs before Save)."
 
 [[action]]
 name = "Rate"
@@ -110,7 +113,8 @@ name = "Restore"
 kind = "input"
 from = ["Archived"]
 to = "Saved"
-hint = "Restore an archived mix."
+guard = [{ type = "is_true", var = "has_creator" }]
+hint = "Restore an archived mix. Guarded on has_creator so legacy anonymous mixes archived before attribution existed cannot re-enter Saved."
 
 # --- Output Actions ---
 
@@ -130,3 +134,8 @@ hint = "Emitted when a mix is rated. Consumed by curation taste-distillation to 
 name = "SavedRequiresSelection"
 when = ["Saved"]
 assert = "has_selection"
+
+[[invariant]]
+name = "SavedRequiresCreator"
+when = ["Saved"]
+assert = "has_creator"

--- a/katagami-curation/app.toml
+++ b/katagami-curation/app.toml
@@ -6,7 +6,7 @@ dependencies = [
   "temperpaw/paw-fs@bff862b415505f5a563998265a2f6ac29472f899",
   "temperpaw/paw-agent@81d8beb78923dc22aeda850828f510f3c6eab510",
   "temperpaw/paw-research@910d01612b2632362fb5f537c4357a5fb6c7bcdd",
-  "katagami/katagami-commons@031a100806ebb34544a07584cb506f22eff00102",
+  "katagami/katagami-commons@f766a9b66570685e2f61b3bd1108c1c5b293fa14",
 ]
 
 # These declarations are REQUIRED — the installer only uploads WASM

--- a/katagami-curation/tests/test_remix_creator_contract.py
+++ b/katagami-curation/tests/test_remix_creator_contract.py
@@ -5,10 +5,11 @@ import tomllib
 
 class RemixCreatorContractTests(unittest.TestCase):
     """Saved Remixes are attributed to the signed-in human who made them
-    (ARN-143). The Remix entity carries a `has_creator` boolean and a
-    `SetCreator` input action that records the Google identity (subject id,
-    email, name, avatar) while the mix is still in Draft — before Save pins it.
-    Attribution is identity, not lifecycle: SetCreator must not gate Save."""
+    (ARN-143), and anonymous remixes are impossible by construction (ARN-144).
+    The Remix entity carries a `has_creator` boolean and a `SetCreator` input
+    action that records the Google identity (subject id, email, name, avatar)
+    while the mix is still in Draft; Save and Restore are guarded on it and
+    the SavedRequiresCreator invariant holds it for the whole Saved state."""
 
     def setUp(self):
         root = Path(__file__).resolve().parents[2]
@@ -18,6 +19,16 @@ class RemixCreatorContractTests(unittest.TestCase):
         )
         self.actions = {action["name"]: action for action in self.spec["action"]}
         self.states = {state["name"]: state for state in self.spec["state"]}
+        self.invariants = {
+            invariant["name"]: invariant for invariant in self.spec["invariant"]
+        }
+
+    def _guard_vars(self, action_name):
+        return {
+            guard.get("var")
+            for guard in self.actions[action_name].get("guard", [])
+            if isinstance(guard, dict)
+        }
 
     def test_has_creator_is_a_bool_state_defaulting_to_false(self):
         self.assertIn("has_creator", self.states)
@@ -39,12 +50,22 @@ class RemixCreatorContractTests(unittest.TestCase):
             action["effect"],
         )
 
-    def test_save_does_not_require_a_creator(self):
-        # Anonymous historical remixes and agent-made remixes must stay valid:
-        # Save's guard is selection-only.
-        save = self.actions["Save"]
-        for guard in save.get("guard", []):
-            self.assertNotEqual(guard.get("var"), "has_creator")
+    def test_save_requires_a_creator(self):
+        # Anonymous remixes are impossible: the state machine refuses Save
+        # without attribution, regardless of what any frontend does.
+        self.assertIn("has_creator", self._guard_vars("Save"))
+        self.assertIn("has_selection", self._guard_vars("Save"))
+
+    def test_restore_requires_a_creator(self):
+        # Legacy anonymous mixes archived before attribution existed must not
+        # be able to re-enter Saved through the restore path.
+        self.assertIn("has_creator", self._guard_vars("Restore"))
+
+    def test_saved_state_holds_the_creator_invariant(self):
+        self.assertIn("SavedRequiresCreator", self.invariants)
+        invariant = self.invariants["SavedRequiresCreator"]
+        self.assertEqual(invariant["when"], ["Saved"])
+        self.assertEqual(invariant["assert"], "has_creator")
 
 
 if __name__ == "__main__":

--- a/ui/scripts/check-auth-contract.mjs
+++ b/ui/scripts/check-auth-contract.mjs
@@ -20,6 +20,7 @@ const layout = read("src/app/(site)/layout.tsx");
 const studio = read("src/app/(site)/studio/page.tsx");
 const authActions = read("src/app/auth-actions.ts");
 const inlineRemix = read("src/components/remix/inline-remix.tsx");
+const owner = read("src/lib/owner.ts");
 
 const required = [
   // The session is off, never insecurely on: no fallback secret anywhere.
@@ -53,6 +54,11 @@ const required = [
   // dynamic; the header chip hydrates from /api/auth/me instead.
   ["layout stays cookie-free (full-route cache preserved)", layout, /^(?![\s\S]*getUser)[\s\S]*$/],
   ["identity endpoint is uncacheable", me, /no-store/],
+  // Owner mode is identity (ARN-144): a signed-in sub on the allowlist —
+  // no passphrase, no per-browser unlock cookie, no HMAC grant path.
+  ["owner mode keys on the sub allowlist", owner, /KATAGAMI_OWNER_SUBS/],
+  ["owner check reads the signed-in session", owner, /getUser/],
+  ["no passphrase grant path remains", owner, /^(?![\s\S]*(grantOwnerSession|createHmac|timingSafeEqual|process\.env\.KATAGAMI_OWNER_SECRET))[\s\S]*$/],
 ];
 
 let failed = 0;

--- a/ui/src/app/(site)/owner/page.tsx
+++ b/ui/src/app/(site)/owner/page.tsx
@@ -6,18 +6,14 @@ import {
   Check,
   FileText,
   GitMerge,
-  KeyRound,
-  Lock,
+  LogIn,
   Sparkles,
-  Unlock,
   X,
 } from "lucide-react";
 import {
   acceptTasteRule,
-  lockOwnerMode,
   queueTasteDistillation,
   rejectTasteRule,
-  unlockOwnerMode,
 } from "@/app/actions";
 import {
   getFileUrl,
@@ -27,6 +23,9 @@ import {
 } from "@/lib/odata";
 import type { CurationJob, TasteRule } from "@/lib/odata";
 import { isOwner, isOwnerModeConfigured } from "@/lib/owner";
+import { getUser } from "@/lib/user-auth";
+import { UserAvatar } from "@/components/user-menu";
+import { KX_BTN_PAPER } from "@/lib/katagami-ui";
 import {
   Marker,
   PageHero,
@@ -36,11 +35,6 @@ import {
   StickyNote,
   WashiTape,
 } from "@/components/scrapbook";
-
-const errorCopy: Record<string, string> = {
-  "bad-passphrase": "That passphrase did not unlock owner mode.",
-  "not-configured": "Set KATAGAMI_OWNER_SECRET on the server first.",
-};
 
 type TasteRuleDashboard = {
   proposed: TasteRule[];
@@ -287,21 +281,12 @@ function tasteRuleIds(rule: TasteRule, ...keys: string[]): string[] {
   return [];
 }
 
-export default async function OwnerPage({
-  searchParams,
-}: {
-  searchParams: Promise<{
-    error?: string;
-    locked?: string;
-    unlocked?: string;
-  }>;
-}) {
-  const [sp, owner, configured] = await Promise.all([
-    searchParams,
+export default async function OwnerPage() {
+  const [user, owner, configured] = await Promise.all([
+    getUser(),
     isOwner(),
     Promise.resolve(isOwnerModeConfigured()),
   ]);
-  const error = sp.error ? errorCopy[sp.error] : undefined;
   const tasteRules = await loadTasteRuleDashboard(owner);
 
   return (
@@ -328,9 +313,10 @@ export default async function OwnerPage({
         title={<Marker color={owner ? "sakura" : "sumire"}>Owner mode</Marker>}
         description={
           <>
-            Unlock this browser to reveal curator controls in the gallery and
-            language detail pages. The server still checks owner mode before it
-            archives anything.
+            Owner access follows your Google account: sign in with an
+            allowlisted account and the curator controls appear in the gallery
+            and language detail pages, on any device. The server still checks
+            the allowlist before it archives anything.
           </>
         }
         rightSlot={
@@ -339,7 +325,7 @@ export default async function OwnerPage({
               owner ? "text-[var(--sakura)]" : "text-[var(--sumire)]"
             }`}
           >
-            {owner ? "unlocked" : "locked"}
+            {owner ? "owner" : "locked"}
           </span>
         }
       />
@@ -353,72 +339,50 @@ export default async function OwnerPage({
         />
         <StickyNote className="p-5 sm:p-6">
           <SectionHeading
-            eyebrow={owner ? "session active" : "unlock"}
+            eyebrow={owner ? "access active" : "access"}
             eyebrowColor={owner ? "sakura" : "sumire"}
           >
             <Marker color={owner ? "sakura" : "sumire"}>
-              {owner ? "archive controls are visible" : "enter passphrase"}
+              {owner ? "Curator controls are live" : "Owner access"}
             </Marker>
           </SectionHeading>
 
-          {owner ? (
-            <div className="space-y-5">
-              {sp.unlocked ? (
-                <p className="text-sm text-muted-foreground">
-                  Owner mode is active in this browser.
+          {!configured ? (
+            <p className="text-sm text-muted-foreground">
+              Set{" "}
+              <code className="font-mono text-[12px]">KATAGAMI_OWNER_SUBS</code>{" "}
+              on the server first — a comma-separated allowlist of Google
+              subject ids. Find yours on any mix you saved (
+              <code className="font-mono text-[12px]">creator_sub</code>).
+            </p>
+          ) : user ? (
+            <div className="flex flex-wrap items-center gap-4">
+              <UserAvatar user={user} size={40} />
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium leading-tight text-foreground">
+                  {user.name || user.email}
                 </p>
-              ) : null}
-              <form action={lockOwnerMode}>
-                <button className="inline-flex h-9 items-center gap-1.5 bg-[color-mix(in_srgb,var(--sumire)_14%,var(--paper-stamp-mix))] px-3 font-mono text-[11px] uppercase tracking-[0.15em] text-[color-mix(in_oklch,var(--sumire)_72%,var(--foreground))] shadow-[0_1px_2px_rgba(30,35,45,0.05)] transition-all hover:-translate-y-[2px] hover:text-foreground">
-                  <Lock className="h-3.5 w-3.5" />
-                  lock owner mode
-                </button>
-              </form>
+                <p className="mt-0.5 font-mono text-[11px] lowercase tracking-[0.04em] text-muted-foreground">
+                  {user.email}
+                </p>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                {owner
+                  ? "This account is on the owner list."
+                  : "This account is not on the owner list."}
+              </p>
             </div>
           ) : (
-            <form action={unlockOwnerMode} className="space-y-4">
-              <div className="space-y-2">
-                <label
-                  htmlFor="owner-passphrase"
-                  className="block font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground"
-                >
-                  owner passphrase
-                </label>
-                <div className="flex flex-col gap-2 sm:flex-row">
-                  <span className="relative flex-1">
-                    <KeyRound className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                    <input
-                      id="owner-passphrase"
-                      name="passphrase"
-                      type="password"
-                      autoComplete="current-password"
-                      disabled={!configured}
-                      className="h-10 w-full min-w-0 border-0 border-b-2 border-foreground/15 bg-background/70 pl-9 pr-3 text-sm outline-none transition-colors placeholder:text-muted-foreground focus:border-[var(--sumire)] disabled:cursor-not-allowed disabled:opacity-60"
-                      placeholder={
-                        configured
-                          ? "Only the owner knows this"
-                          : "Set KATAGAMI_OWNER_SECRET first"
-                      }
-                    />
-                  </span>
-                  <button
-                    disabled={!configured}
-                    className="inline-flex h-10 items-center justify-center gap-1.5 bg-[color-mix(in_srgb,var(--sumire)_14%,var(--paper-stamp-mix))] px-3 font-mono text-[11px] uppercase tracking-[0.15em] text-[color-mix(in_oklch,var(--sumire)_72%,var(--foreground))] shadow-[0_1px_2px_rgba(30,35,45,0.05)] transition-all hover:-translate-y-[2px] hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
-                  >
-                    <Unlock className="h-3.5 w-3.5" />
-                    unlock
-                  </button>
-                </div>
-              </div>
-              {error ? (
-                <p className="text-sm font-medium text-destructive">{error}</p>
-              ) : null}
-              {sp.locked ? (
-                <p className="text-sm text-muted-foreground">
-                  Owner mode is locked for this browser.
-                </p>
-              ) : null}
-            </form>
+            <div className="space-y-4">
+              <p className="max-w-md text-sm text-muted-foreground">
+                No passphrase, no per-browser unlock — sign in with the
+                owner&apos;s Google account and everything lights up.
+              </p>
+              <Link href="/signin?next=/owner" className={KX_BTN_PAPER}>
+                <LogIn className="h-3.5 w-3.5" aria-hidden />
+                sign in
+              </Link>
+            </div>
           )}
         </StickyNote>
       </section>

--- a/ui/src/app/actions.ts
+++ b/ui/src/app/actions.ts
@@ -83,6 +83,7 @@ export async function addCuratorNotes(
   id: string,
   notes: string,
 ): Promise<void> {
+  await assertOwner();
   await dispatchAction("DesignLanguages", id, "AddCuratorNotes", {
     curator_notes: notes,
   });

--- a/ui/src/app/actions.ts
+++ b/ui/src/app/actions.ts
@@ -1,15 +1,9 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { redirect } from "next/navigation";
 import { getDesignLanguage } from "@/lib/odata";
 import { createEntity, deleteEntity, dispatchAction } from "@/lib/odata-mutations";
-import {
-  assertOwner,
-  grantOwnerSession,
-  isOwnerModeConfigured,
-  revokeOwnerSession,
-} from "@/lib/owner";
+import { assertOwner } from "@/lib/owner";
 
 const OWNER_ARCHIVE_NOTE = "Archived from the owner gallery controls.";
 const OWNER_REVIEW_NOTE = "Sent back to review from owner controls.";
@@ -127,24 +121,4 @@ export async function rejectTasteRule(id: string): Promise<void> {
     curator_notes: OWNER_TASTE_REJECT_NOTE,
   });
   revalidatePath("/owner");
-}
-
-export async function unlockOwnerMode(formData: FormData): Promise<void> {
-  if (!isOwnerModeConfigured()) {
-    redirect("/owner?error=not-configured");
-  }
-
-  const passphrase = String(formData.get("passphrase") ?? "");
-  if (!(await grantOwnerSession(passphrase))) {
-    redirect("/owner?error=bad-passphrase");
-  }
-
-  revalidatePath("/", "layout");
-  redirect("/owner?unlocked=1");
-}
-
-export async function lockOwnerMode(): Promise<void> {
-  await revokeOwnerSession();
-  revalidatePath("/", "layout");
-  redirect("/owner?locked=1");
 }

--- a/ui/src/lib/owner.ts
+++ b/ui/src/lib/owner.ts
@@ -20,6 +20,10 @@ export function isOwnerModeConfigured(): boolean {
 }
 
 export async function isOwner(): Promise<boolean> {
+  // Short-circuit before touching cookies: an unconfigured deploy stays
+  // fully static on the pages that ask (the old passphrase code behaved
+  // the same way).
+  if (!isOwnerModeConfigured()) return false;
   const user = await getUser();
   return Boolean(user && ownerSubs().includes(user.sub));
 }

--- a/ui/src/lib/owner.ts
+++ b/ui/src/lib/owner.ts
@@ -1,78 +1,31 @@
 import "server-only";
 
-import { timingSafeEqual, createHmac } from "crypto";
-import { cookies } from "next/headers";
+import { getUser } from "@/lib/user-auth";
 
-const OWNER_COOKIE = "katagami_owner";
-const OWNER_COOKIE_SCOPE = "katagami-owner-v1";
-const OWNER_SESSION_MAX_AGE = 60 * 60 * 24 * 30;
+// Owner mode is identity, not a passphrase: the signed-in Google account's
+// stable subject id must be in the KATAGAMI_OWNER_SUBS allowlist
+// (comma-separated). This replaced the KATAGAMI_OWNER_SECRET HMAC unlock —
+// one door, backed by the owner's Google account and its 2FA, working on any
+// device they sign in on. Find a sub via an attributed Remix (creator_sub).
 
-function ownerSecret(): string {
-  return process.env.KATAGAMI_OWNER_SECRET ?? "";
-}
-
-function ownerSignature(expiresAt: number, secret = ownerSecret()): string {
-  return createHmac("sha256", secret)
-    .update(`${OWNER_COOKIE_SCOPE}:${expiresAt}`)
-    .digest("hex");
-}
-
-function createOwnerToken(secret: string): string {
-  const expiresAt = Date.now() + OWNER_SESSION_MAX_AGE * 1000;
-  return `${expiresAt}.${ownerSignature(expiresAt, secret)}`;
-}
-
-function isValidOwnerToken(token: string, secret: string): boolean {
-  const [expiresAtRaw, signature] = token.split(".");
-  const expiresAt = Number(expiresAtRaw);
-  if (!signature || !Number.isFinite(expiresAt) || expiresAt <= Date.now()) {
-    return false;
-  }
-  return safeEqual(signature, ownerSignature(expiresAt, secret));
-}
-
-function safeEqual(a: string, b: string): boolean {
-  const left = Buffer.from(a);
-  const right = Buffer.from(b);
-  if (left.length !== right.length) return false;
-  return timingSafeEqual(left, right);
+function ownerSubs(): string[] {
+  return (process.env.KATAGAMI_OWNER_SUBS ?? "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
 }
 
 export function isOwnerModeConfigured(): boolean {
-  return ownerSecret().length > 0;
+  return ownerSubs().length > 0;
 }
 
 export async function isOwner(): Promise<boolean> {
-  const secret = ownerSecret();
-  if (!secret) return false;
-
-  const cookieStore = await cookies();
-  const token = cookieStore.get(OWNER_COOKIE)?.value;
-  return Boolean(token && isValidOwnerToken(token, secret));
-}
-
-export async function grantOwnerSession(passphrase: string): Promise<boolean> {
-  const secret = ownerSecret();
-  if (!secret || !safeEqual(passphrase, secret)) return false;
-
-  const cookieStore = await cookies();
-  cookieStore.set(OWNER_COOKIE, createOwnerToken(secret), {
-    httpOnly: true,
-    maxAge: OWNER_SESSION_MAX_AGE,
-    path: "/",
-    sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
-  });
-  return true;
-}
-
-export async function revokeOwnerSession(): Promise<void> {
-  const cookieStore = await cookies();
-  cookieStore.delete(OWNER_COOKIE);
+  const user = await getUser();
+  return Boolean(user && ownerSubs().includes(user.sub));
 }
 
 export async function assertOwner(): Promise<void> {
   if (!(await isOwner())) {
-    throw new Error("Owner mode is required for this action.");
+    throw new Error("Owner access requires an allowlisted signed-in account.");
   }
 }


### PR DESCRIPTION
## What we are addressing

Two follow-ups Rita requested on top of Google sign-in (#129 / ARN-143): the owner passphrase should be replaced by her signed-in identity, and anonymous remixes should be impossible — at the engine level, not just in the UI.

## What's in

- **Owner-by-identity**: `isOwner()` = signed-in Google `sub` ∈ `KATAGAMI_OWNER_SUBS` (comma-separated env allowlist). `KATAGAMI_OWNER_SECRET`, the HMAC unlock cookie, `unlockOwnerMode`/`lockOwnerMode`, and the passphrase form are gone. `/owner` is now an identity card: signed out → sign-in door; signed in but not listed → says so; owner → curator panels. `assertOwner()`/`isOwner()` API unchanged, so every existing gated action and owner control works as before.
- **No anonymous remixes, by construction**: Remix spec guards `Save` on `has_creator` (+ `has_selection`), guards `Restore` the same way (legacy anonymous archived mixes can't re-enter Saved), and adds a `SavedRequiresCreator` invariant. Python contract tests assert all three.
- Contract check grows to 27 invariants (owner keys on sub allowlist, reads the session, no passphrase grant path remains).

## Verified live locally (prod build)

All three /owner states server-rendered and screenshotted with minted sessions: signed-out sign-in door, non-owner "not on the owner list" (no panels), owner card + taste-rules panel.

Pre-existing, unrelated: `test:shadcn-export` fails identically on clean master (page reads stored shadcn files / preview shots / DESIGN.md) — surfaced separately, not touched here.

## Deploy order

1. Commons spec → Genesis; bump curation's app.toml commons dep; both bootstrap pins; one openpaw-production restart (the ARN-143 recipe).
2. Archive the one legacy anonymous remix (en-019ec279, unrated test save).
3. `KATAGAMI_OWNER_SUBS` in Vercel with Rita's sub (harvested from her first attributed save), remove `KATAGAMI_OWNER_SECRET`.
4. Merge → verify /owner live with Rita signed in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)