### PR TITLE
feat(commons): Published art styles must carry credits + model provenance (ARN-148 completion)

### DIFF
--- a/katagami-commons/specs/art_style.ioa.toml
+++ b/katagami-commons/specs/art_style.ioa.toml
@@ -416,3 +416,13 @@ assert = "has_published_assets"
 name = "PublishedRequiresQualityReview"
 when = ["Published"]
 assert = "quality_review_passed"
+
+[[invariant]]
+name = "PublishedRequiresCredits"
+when = ["Published"]
+assert = "has_credits"
+
+[[invariant]]
+name = "PublishedRequiresModelProvenance"
+when = ["Published"]
+assert = "has_model_provenance"

--- a/katagami-curation/app.toml
+++ b/katagami-curation/app.toml
@@ -6,7 +6,7 @@ dependencies = [
   "temperpaw/paw-fs@bff862b415505f5a563998265a2f6ac29472f899",
   "temperpaw/paw-agent@81d8beb78923dc22aeda850828f510f3c6eab510",
   "temperpaw/paw-research@910d01612b2632362fb5f537c4357a5fb6c7bcdd",
-  "katagami/katagami-commons@f766a9b66570685e2f61b3bd1108c1c5b293fa14",
+  "katagami/katagami-commons@81865eb4f22fcc18cea3751e9628eff1af9b8a4a",
 ]
 
 # These declarations are REQUIRED — the installer only uploads WASM

--- a/katagami-curation/tests/test_genesis_source_contract.py
+++ b/katagami-curation/tests/test_genesis_source_contract.py
@@ -9,7 +9,7 @@ CURRENT_GENESIS_DEPS = {
     "temperpaw/paw-fs": "bff862b415505f5a563998265a2f6ac29472f899",
     "temperpaw/paw-agent": "81d8beb78923dc22aeda850828f510f3c6eab510",
     "temperpaw/paw-research": "910d01612b2632362fb5f537c4357a5fb6c7bcdd",
-    "katagami/katagami-commons": "031a100806ebb34544a07584cb506f22eff00102",
+    "katagami/katagami-commons": "81865eb4f22fcc18cea3751e9628eff1af9b8a4a",
 }
 
 

--- a/katagami-curation/tests/test_lane_deep_verification_contract.py
+++ b/katagami-curation/tests/test_lane_deep_verification_contract.py
@@ -44,14 +44,18 @@ class LaneDeepVerificationContractTests(unittest.TestCase):
             effects,
         )
 
-    def test_no_published_requires_credits_invariant_yet(self):
-        # Existing published styles predate the requirement; a reactive
-        # invariant would flag them all at once. The guard blocks new
-        # publishes; the invariant lands only after the backfill
-        # (ARN-148 scope item 2).
+    def test_published_requires_credits_invariants(self):
+        # Landed after the 2026-07-04 backfill: all 155 published styles
+        # carry credits + model provenance, so the reactive invariants are
+        # safe (ARN-148 scope item 2 complete).
         invariants = self._by_name(self.art, "invariant")
-        self.assertNotIn("PublishedRequiresCredits", invariants)
-        self.assertNotIn("PublishedRequiresModelProvenance", invariants)
+        for name, var in [
+            ("PublishedRequiresCredits", "has_credits"),
+            ("PublishedRequiresModelProvenance", "has_model_provenance"),
+        ]:
+            self.assertIn(name, invariants)
+            self.assertEqual(invariants[name]["when"], ["Published"])
+            self.assertEqual(invariants[name]["assert"], var)
 
     # --- finalizer: deep evidence checks precede the stamp ---
 


### PR DESCRIPTION
## What

Completes ARN-148 scope item 2. The 2026-07-04 production backfill set tradition credits (115 styles) and model provenance (118 styles) — **155/155 published art styles now carry both** — so the reactive `PublishedRequiresCredits` / `PublishedRequiresModelProvenance` invariants deferred in #132 are safe and now land.

Also reconciles the commons pin: #130 bumped `app.toml` to `f766a9b6` while #132 was in flight (test constant collision); both were behind the actually-installed version. Pin + test constant now point at `81865eb4` — the version **live in production**.

## Verification

- Kernel cascade over commons specs with the new invariants: ArtStyle ALL PASSED (invariants inductive — the Publish guard already requires both vars).
- `make test-integration`: 114/114 (pin contract green against the deployed hash).
- Production backfill verified: 0 published styles missing credits or provenance.
- **Already deployed**: Genesis `commons@81865eb4` + `curation@aadf6cf2`, hot-installed into openpaw-production (`updated: ['ArtStyle']`).

Related: ARN-148, RFC-0002 §7

🤖 Generated with [Claude Code](https://claude.com/claude-code)