### PR TITLE
fix(infra): assets worker — allow art-style and palette prefixes

### DIFF
--- a/infra/cloudflare/katagami-assets-worker/src/index.js
+++ b/infra/cloudflare/katagami-assets-worker/src/index.js
@@ -1,5 +1,7 @@
 const ALLOWED_PREFIXES = [
   "katagami/design-languages/",
+  "katagami/art-styles/",
+  "katagami/palettes/",
   "published-assets/",
 ];
 


### PR DESCRIPTION
The `assets.katagami.ai` Cloudflare Worker allowlist only includes `katagami/design-languages/`, so lane assets published under `katagami/art-styles/` and `katagami/palettes/` 404 on the canonical domain even though the blobs are in the R2 bucket (they serve via `temperpaw-assets.katagami.ai`). Two-line additive allowlist fix; cannot affect design-language serving.

Found during the ARN-148 deployed-finalizer verification (Rölakan Weave publish — the entity's asset URLs are canonical and start serving the moment this deploys).

**Deploy needed after merge** (auto-mode blocked it for me):
```
cd infra/cloudflare/katagami-assets-worker && npx wrangler deploy
```

Verify: GET `https://assets.katagami.ai/katagami/art-styles/ArtStyle/en-019f2e11-dcef-7101-a2f9-a18532b6a163/thumbnail-9fc25fb58b81a06f56a536e7bbab693cc76027677185518aaa930a33d8aa48d6.jpg` → 200 `image/jpeg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)