### PR TITLE
chore(curation): pin katagami-commons@2e415be3 (WritingStyle release)

### DIFF
--- a/katagami-curation/app.toml
+++ b/katagami-curation/app.toml
@@ -6,7 +6,7 @@ dependencies = [
   "temperpaw/paw-fs@bff862b415505f5a563998265a2f6ac29472f899",
   "temperpaw/paw-agent@81d8beb78923dc22aeda850828f510f3c6eab510",
   "temperpaw/paw-research@910d01612b2632362fb5f537c4357a5fb6c7bcdd",
-  "katagami/katagami-commons@81865eb4f22fcc18cea3751e9628eff1af9b8a4a",
+  "katagami/katagami-commons@2e415be3178c5180f7ba05842177f273ee0c6eb4",
 ]
 
 # These declarations are REQUIRED — the installer only uploads WASM

--- a/katagami-curation/tests/test_genesis_source_contract.py
+++ b/katagami-curation/tests/test_genesis_source_contract.py
@@ -9,7 +9,7 @@ CURRENT_GENESIS_DEPS = {
     "temperpaw/paw-fs": "bff862b415505f5a563998265a2f6ac29472f899",
     "temperpaw/paw-agent": "81d8beb78923dc22aeda850828f510f3c6eab510",
     "temperpaw/paw-research": "910d01612b2632362fb5f537c4357a5fb6c7bcdd",
-    "katagami/katagami-commons": "81865eb4f22fcc18cea3751e9628eff1af9b8a4a",
+    "katagami/katagami-commons": "2e415be3178c5180f7ba05842177f273ee0c6eb4",
 }
 
 


### PR DESCRIPTION
Pin dance for the #133 deploy: commons published to Genesis at `2e415be3`; app.toml + the source-contract constant follow the installed version. Suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)