### PR TITLE
feat(ui): find-your-style intake — consent-bound corpus upload (ARN-138 v1)

### DIFF
--- a/ui/src/app/(site)/voice/actions.ts
+++ b/ui/src/app/(site)/voice/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { assertOwner } from "@/lib/owner";
-import { dispatchAction } from "@/lib/odata-mutations";
+import { createEntity, dispatchAction, uploadFile } from "@/lib/odata-mutations";
 
 // The curator gate's other half: the finalizer stops writing styles at
 // UnderReview with every Publish guard satisfied; the owner reads the voice
@@ -13,4 +13,98 @@ export async function publishWritingStyle(id: string): Promise<void> {
   revalidatePath("/voice");
   revalidatePath(`/voice/${id}`);
   revalidatePath("/under-review");
+}
+
+export interface VoiceIntakeResult {
+  id?: string;
+  error?: string;
+}
+
+// ARN-138 v1 — the find-your-style intake. Consent is bound at the moment the
+// corpus enters the commons: basis opt_in, author, provenance, and the
+// attestation checkbox all travel in the same dispatch as the files. The
+// entity stays Draft ("awaiting extraction"); ARN-139 extraction derives the
+// voice layer and bands from this corpus, and the curator gate still stands
+// between everything and Published.
+export async function submitVoiceIntake(
+  _prev: VoiceIntakeResult,
+  formData: FormData,
+): Promise<VoiceIntakeResult> {
+  try {
+    await assertOwner();
+    const name = String(formData.get("name") ?? "").trim();
+    const author = String(formData.get("author") ?? "").trim();
+    const provenance = String(formData.get("provenance") ?? "").trim();
+    const consented = formData.get("consent") === "on";
+    const refusals = String(formData.get("refusals") ?? "")
+      .split("\n")
+      .map((r) => r.trim())
+      .filter(Boolean);
+    const samples = formData
+      .getAll("samples")
+      .map((s) => String(s).trim())
+      .filter(Boolean);
+
+    if (!consented) return { error: "The consent attestation is required." };
+    if (!author) return { error: "Say who wrote these samples." };
+    if (!provenance) return { error: "Say where these samples come from." };
+    if (samples.length < 3) return { error: "At least 3 samples are needed for a usable fingerprint." };
+    if (samples.length > 20) return { error: "20 samples is the ceiling — pick the best ones." };
+
+    const slug = (name || author)
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/(^-|-$)/g, "")
+      .slice(0, 40) || "intake";
+
+    const fileIds: string[] = [];
+    for (let i = 0; i < samples.length; i++) {
+      fileIds.push(
+        await uploadFile(
+          `sample-${i + 1}.md`,
+          `/katagami/writing-styles/intake/${slug}/sample-${i + 1}.md`,
+          "text/markdown",
+          samples[i],
+        ),
+      );
+    }
+
+    const created = await createEntity("WritingStyles", {});
+    const id = created.entity_id;
+    await dispatchAction("WritingStyles", id, "AttachCorpus", {
+      corpus_file_ids: fileIds,
+      corpus_manifest: JSON.stringify({
+        // working_name is a hint for ARN-139 extraction (which owns naming);
+        // there is deliberately no name-setting action on a Draft intake.
+        working_name: name,
+        items: fileIds.map((fid, i) => ({
+          file_id: fid,
+          kind: "opt-in-sample",
+          words: samples[i].split(/\s+/).length,
+        })),
+      }),
+      consent: JSON.stringify({
+        basis: "opt_in",
+        author,
+        license: "personal corpus — rights reserved; licensed to katagami for style extraction",
+        samples: samples.length,
+        provenance,
+        attested_by_owner: true,
+      }),
+    });
+    if (name || refusals.length) {
+      await dispatchAction("WritingStyles", id, "SetVoiceLayer", {
+        persona: "",
+        tone_scales: "{}",
+        vocabulary: "{}",
+        moves: "[]",
+        register: "{}",
+        refusals: JSON.stringify(refusals),
+      });
+    }
+    revalidatePath("/voice");
+    return { id };
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : "intake failed" };
+  }
 }

--- a/ui/src/app/(site)/voice/intake/page.tsx
+++ b/ui/src/app/(site)/voice/intake/page.tsx
@@ -1,0 +1,37 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { isOwner } from "@/lib/owner";
+import { PageHero, Marker } from "@/components/page-hero";
+import { VoiceIntakeForm } from "@/components/voice-intake-form";
+
+export const dynamic = "force-dynamic";
+export const metadata = { title: "Find your style — Katagami" };
+
+export default async function VoiceIntakePage() {
+  if (!(await isOwner())) notFound();
+  return (
+    <div className="mx-auto w-full max-w-3xl px-4 py-6 sm:py-10">
+      <Link
+        href="/voice"
+        className="group inline-flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowLeft className="h-3 w-3 transition-transform group-hover:-translate-x-0.5" />
+        back to voices
+      </Link>
+      <PageHero
+        eyebrow="Voice intake"
+        eyebrowAccent="matcha"
+        title={
+          <>
+            Find <Marker color="matcha">your</Marker> style
+          </>
+        }
+        description="Bring 3-20 pieces of real writing. Consent is bound to the corpus the moment it enters; extraction derives the contract — tone, refusals, mechanical bands — from what you actually wrote, and nothing publishes without the curator."
+      />
+      <div className="mt-10">
+        <VoiceIntakeForm />
+      </div>
+    </div>
+  );
+}

--- a/ui/src/app/(site)/voice/page.tsx
+++ b/ui/src/app/(site)/voice/page.tsx
@@ -38,6 +38,15 @@ export default async function VoicePage() {
         description="Writing styles as checkable contracts, not soft guidance: a consented corpus, tone with numbers, refusals that carry the weight, and mechanical bands the finalizer verifies before anything publishes."
         rightSlot={<HeroStat value={total} label="voices" accent="matcha" />}
       />
+      <div className="mt-8">
+        <a
+          href="/voice/intake"
+          className="rounded-[9999px] bg-foreground px-5 py-2 font-mono text-[11px] uppercase tracking-[0.14em] text-background transition-opacity hover:opacity-85"
+        >
+          Find your style
+        </a>
+      </div>
+
       {items.length ? (
         <div className="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {items.map((item) => (

--- a/ui/src/components/voice-intake-form.tsx
+++ b/ui/src/components/voice-intake-form.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useActionState, useState } from "react";
+import { useRouter } from "next/navigation";
+import { submitVoiceIntake, type VoiceIntakeResult } from "@/app/(site)/voice/actions";
+
+const FIELD =
+  "w-full rounded-[16px] bg-[color-mix(in_srgb,var(--foreground)_4%,var(--card))] px-4 py-3 text-[17px] leading-relaxed text-foreground outline-none focus:ring-2 focus:ring-[var(--matcha)]";
+const LABEL = "mb-2 mt-6 block font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground";
+
+export function VoiceIntakeForm() {
+  const router = useRouter();
+  const [sampleCount, setSampleCount] = useState(3);
+  const [state, formAction, pending] = useActionState(
+    async (prev: VoiceIntakeResult, formData: FormData) => {
+      const result = await submitVoiceIntake(prev, formData);
+      if (result.id) router.push(`/voice/${result.id}`);
+      return result;
+    },
+    {} as VoiceIntakeResult,
+  );
+
+  return (
+    <form action={formAction} className="sticker-card p-6 sm:p-8">
+      <label className={LABEL} htmlFor="intake-name">
+        Working name — optional, extraction proposes the real one
+      </label>
+      <input id="intake-name" name="name" type="text" className={FIELD} placeholder="e.g. Rita's voice" />
+
+      <label className={LABEL} htmlFor="intake-author">
+        Who wrote these samples
+      </label>
+      <input id="intake-author" name="author" type="text" required className={FIELD} placeholder="the author of every sample below" />
+
+      <label className={LABEL} htmlFor="intake-provenance">
+        Where they come from
+      </label>
+      <input
+        id="intake-provenance"
+        name="provenance"
+        type="text"
+        required
+        className={FIELD}
+        placeholder="e.g. personal essays 2023-2026, unpublished drafts, sent emails I wrote"
+      />
+
+      <div className="mt-8">
+        <div className="flex items-baseline justify-between">
+          <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+            Samples — 3 to 20, each in the voice as it actually reads
+          </span>
+          <span className="font-mono text-[11px] tabular-nums text-muted-foreground">{sampleCount}/20</span>
+        </div>
+        {Array.from({ length: sampleCount }, (_, i) => (
+          <textarea
+            key={i}
+            name="samples"
+            rows={6}
+            className={`${FIELD} mt-3`}
+            placeholder={`sample ${i + 1} — a real piece of writing, ~150+ words gives the bands something to measure`}
+          />
+        ))}
+        <div className="mt-3 flex gap-2">
+          {sampleCount < 20 ? (
+            <button
+              type="button"
+              onClick={() => setSampleCount((n) => Math.min(20, n + 1))}
+              className="rounded-[9999px] bg-[color-mix(in_srgb,var(--foreground)_6%,transparent)] px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.14em] text-foreground"
+            >
+              Add a sample
+            </button>
+          ) : null}
+          {sampleCount > 3 ? (
+            <button
+              type="button"
+              onClick={() => setSampleCount((n) => Math.max(3, n - 1))}
+              className="rounded-[9999px] px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground"
+            >
+              Remove last
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      <label className={LABEL} htmlFor="intake-refusals">
+        What this voice never does — one per line, optional but it carries most of the taste
+      </label>
+      <textarea
+        id="intake-refusals"
+        name="refusals"
+        rows={4}
+        className={FIELD}
+        placeholder={"never opens with a rhetorical question\nnever uses exclamation marks in technical writing"}
+      />
+
+      <label className="mt-8 flex items-start gap-3 text-[15px] leading-relaxed text-foreground">
+        <input type="checkbox" name="consent" required className="mt-1 h-4 w-4 accent-[var(--matcha)]" />
+        <span>
+          I wrote these samples (or hold their rights) and consent to katagami
+          extracting a style contract from them. The corpus stays attributed to
+          the author named above; consent basis is recorded as{" "}
+          <span className="font-mono text-[13px]">opt_in</span>.
+        </span>
+      </label>
+
+      <div className="mt-8 flex flex-wrap items-center gap-3">
+        <button
+          type="submit"
+          disabled={pending}
+          className="rounded-[9999px] bg-foreground px-5 py-2 font-mono text-[11px] uppercase tracking-[0.14em] text-background transition-opacity hover:opacity-85 disabled:opacity-50"
+        >
+          {pending ? "Saving the corpus…" : "Start the extraction"}
+        </button>
+        {state.error ? (
+          <span className="text-[14px] text-foreground">{state.error}</span>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/ui/src/lib/odata-mutations.ts
+++ b/ui/src/lib/odata-mutations.ts
@@ -14,7 +14,9 @@ export async function dispatchAction(
   entitySet: string,
   id: string,
   action: string,
-  params: Record<string, string | number | boolean>,
+  // Values may be arrays/objects: list-typed spec fields (e.g. corpus_file_ids)
+  // must arrive as real JSON arrays for cross-entity guard resolution.
+  params: Record<string, unknown>,
 ): Promise<void> {
   const namespaces = ["KatagamiCommons", "Katagami.Curation", "Katagami", "Temper"];
   let lastError = "";
@@ -68,4 +70,35 @@ export async function deleteEntity(
   if (!res.ok) {
     throw new Error(`Delete failed ${res.status}: ${await res.text()}`);
   }
+}
+
+/** Create a File entity, upload its content, and wait until it is readable.
+ *  Returns the file id. Used by the voice intake to persist corpus samples. */
+export async function uploadFile(
+  name: string,
+  path: string,
+  mimeType: string,
+  content: string,
+): Promise<string> {
+  const created = await createEntity("Files", {
+    Name: name,
+    Path: path,
+    MimeType: mimeType,
+  });
+  const id = created.entity_id;
+  const put = await fetch(`${API_BASE}/tdata/Files('${id}')/$value`, {
+    method: "PUT",
+    headers: { ...headers, "Content-Type": mimeType },
+    body: content,
+  });
+  if (!put.ok) throw new Error(`File upload failed ${put.status}`);
+  for (let i = 0; i < 30; i++) {
+    const res = await fetch(`${API_BASE}/tdata/Files('${id}')`, { headers, cache: "no-store" });
+    if (res.ok) {
+      const row = (await res.json()) as { status?: string };
+      if (row.status === "Ready" || row.status === "Locked") return id;
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  throw new Error(`File ${id} never became Ready`);
 }


### PR DESCRIPTION
Owner-gated `/voice/intake`: bring 3–20 real writing samples; author, provenance, and an explicit consent attestation are **bound to the corpus in the same dispatch** that attaches it (basis `opt_in`). Refusals prompt included ('it carries most of the taste'). The entity stays **Draft awaiting extraction** (ARN-139 owns derivation + naming — the working name travels as a manifest hint, not a fake field).

| Verification (live local e2e) | Result |
|---|---|
| Public `/voice/intake` | 404 |
| Owner session (minted HS256 JWT, real browser) | form renders, 200 |
| Submit → corpus Files on temper | 3/3 `fl-` ids, Ready |
| Consent basis `opt_in` + working-name hint + refusals on the Draft | all present |
| Redirect to the new contract page | ✓ |
| tsc | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)