### PR TITLE
feat(ui): the corpus is the artifact — signature quotes on cards, long-form reading on contract pages

### DIFF
--- a/katagami-curation/agents/curator/skills/synthesize-writing-style/SKILL.md
+++ b/katagami-curation/agents/curator/skills/synthesize-writing-style/SKILL.md
@@ -152,3 +152,16 @@ temper.done("synthesize_writing_style complete")
   are real lists — the cross-entity guards resolve arrays).
 - The bands checker is deterministic and unforgiving: derive, don't guess.
 - Do not fire finalizer-owned actions (see When to Use).
+
+## Exemplars — style, never subject (curator review, 2026-07-04)
+
+- Every exemplar demonstrates CONSTRUCTION — how the sentence moves — not what
+  it mentions. If the annotation describes content, pick a different passage.
+- The FIRST exemplar is the signature passage: it renders in quotes on the
+  catalog card, so the register must be assessable from it alone.
+- Public-domain registers quote the corpus VERBATIM (kind "corpus"), verified
+  against the source text; original registers quote their own corpus (kind
+  "authored"). "sent" is reserved for opt-in personal voices.
+- Annotations are one plain clause about the move, never workshop narration.
+- The corpus is displayed on the contract page ("how it reads") — it is the
+  style artifact. Excerpts must be long-form passages, not snippets.

--- a/ui/src/app/(site)/voice/[id]/page.tsx
+++ b/ui/src/app/(site)/voice/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
-import { getWritingStyle, getFileUrl, parseJson } from "@/lib/odata";
+import { getWritingStyle, getFileUrl, getFileText, parseJson } from "@/lib/odata";
 import { isOwner } from "@/lib/owner";
 import { PageHero } from "@/components/page-hero";
 import { StickyNote, SectionHeading, Stamp, Perforation } from "@/components/scrapbook";
@@ -64,6 +64,30 @@ export default async function VoiceDetailPage({
       provenance?: string;
     }>(f.consent) ?? {};
   const tags = parseJson<string[]>(f.tags) ?? [];
+  const corpusIds = parseJson<string[]>(f.corpus_file_ids) ?? [];
+  const manifest =
+    parseJson<{ items?: Array<{ file_id?: string; source?: string; kind?: string }> }>(
+      f.corpus_manifest,
+    ) ?? {};
+  const sourceByFile = new Map(
+    (manifest.items ?? []).map((it) => [it.file_id ?? "", it.source ?? it.kind ?? ""]),
+  );
+  // The corpus IS the style artifact — fetch it and show real long-form prose.
+  // Cap the render per excerpt at a paragraph boundary near 1500 chars.
+  const excerpts = (
+    await Promise.all(
+      corpusIds.slice(0, 6).map(async (fid) => {
+        const body = (await getFileText(fid)).trim();
+        if (!body) return null;
+        let cut = body;
+        if (body.length > 1600) {
+          const at = body.lastIndexOf("\n\n", 1500);
+          cut = body.slice(0, at > 400 ? at : 1500);
+        }
+        return { source: sourceByFile.get(fid) ?? "", text: cut, truncated: cut.length < body.length };
+      }),
+    )
+  ).filter((e): e is { source: string; text: string; truncated: boolean } => e !== null);
   const voiceMdUrl =
     (f.voice_md_asset_url ?? "").trim() ||
     (f.voice_md_file_id ? getFileUrl(f.voice_md_file_id) : "");
@@ -113,6 +137,20 @@ export default async function VoiceDetailPage({
             </span>
           </div>
         </StickyNote>
+      ) : null}
+
+      {exemplars[0]?.text ? (
+        <blockquote
+          className="max-w-3xl text-[24px] font-medium leading-snug text-foreground sm:text-[28px]"
+          style={{ letterSpacing: "-0.02em" }}
+        >
+          &ldquo;{exemplars[0].text}&rdquo;
+          {exemplars[0].annotation ? (
+            <footer className="mt-3 font-mono text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+              {exemplars[0].annotation}
+            </footer>
+          ) : null}
+        </blockquote>
       ) : null}
 
       {/* The refusals lead — taste is what you reject. */}
@@ -274,23 +312,48 @@ export default async function VoiceDetailPage({
         </div>
       </StickyNote>
 
-      {/* Annotated exemplars — the gap is the voice */}
-      {exemplars.length ? (
+      {excerpts.length || exemplars.length > 1 ? (
         <section>
-          <SectionHeading eyebrow="ground truth" eyebrowColor="matcha">
-            annotated examples
+          <SectionHeading eyebrow="the artifact" eyebrowColor="matcha">
+            how it reads
           </SectionHeading>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {exemplars.map((ex, i) => (
-              <StickyNote key={i} className="p-4">
-                <p className="text-[15px] leading-relaxed text-foreground">
-                  &ldquo;{ex.text}&rdquo;
-                </p>
-                {ex.annotation ? (
-                  <p className="mt-2 font-mono text-[11px] text-muted-foreground">
-                    {ex.annotation}
-                    {ex.kind ? ` · ${ex.kind}` : ""}
+          <p className="mb-5 max-w-2xl text-[14px] leading-relaxed text-muted-foreground">
+            The corpus this contract was derived from — real passages at
+            length, the same files the checker measures. Style lives in the
+            construction; read for how the sentences move, not what they
+            mention.
+          </p>
+          {exemplars.length > 1 ? (
+            <div className="mb-6 grid gap-4 sm:grid-cols-2">
+              {exemplars.slice(1).map((ex, i) => (
+                <StickyNote key={i} className="p-4">
+                  <p className="text-[16px] leading-relaxed text-foreground">
+                    &ldquo;{ex.text}&rdquo;
                   </p>
+                  {ex.annotation ? (
+                    <p className="mt-2 font-mono text-[11px] text-muted-foreground">
+                      {ex.annotation}
+                    </p>
+                  ) : null}
+                </StickyNote>
+              ))}
+            </div>
+          ) : null}
+          <div className="space-y-4">
+            {excerpts.map((ex, i) => (
+              <StickyNote key={i} className="p-5 sm:p-6">
+                <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+                  {ex.source || `corpus excerpt ${i + 1}`}
+                </div>
+                <div className="max-w-3xl space-y-4 text-[17px] leading-relaxed text-foreground">
+                  {ex.text.split(/\n\n+/).map((p, j) => (
+                    <p key={j}>{p}</p>
+                  ))}
+                </div>
+                {ex.truncated ? (
+                  <div className="mt-3 font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground/70">
+                    excerpt — the full file is in the corpus
+                  </div>
                 ) : null}
               </StickyNote>
             ))}

--- a/ui/src/components/writing-style-card.tsx
+++ b/ui/src/components/writing-style-card.tsx
@@ -9,6 +9,9 @@ export interface WritingStyleItem {
   slug: string;
   status: string;
   persona: string;
+  /** The style's signature passage — shown in quotes on the card so the
+   *  register is assessable at a glance. */
+  signature: string;
   basis: string;
   tone: string[];
   refusal: string;
@@ -43,8 +46,13 @@ export function WritingStyleCard({ item }: { item: WritingStyleItem }) {
       >
         {item.name}
       </h3>
+      {item.signature ? (
+        <blockquote className="mt-3 text-[16px] leading-relaxed text-foreground">
+          &ldquo;{item.signature}&rdquo;
+        </blockquote>
+      ) : null}
       {item.persona ? (
-        <p className="mt-2 text-[15px] leading-relaxed text-muted-foreground">
+        <p className="mt-3 text-[14px] leading-relaxed text-muted-foreground">
           {item.persona}
         </p>
       ) : null}

--- a/ui/src/lib/lane-items.ts
+++ b/ui/src/lib/lane-items.ts
@@ -64,12 +64,14 @@ export function toWritingStyleItem(r: LaneEntity): import("@/components/writing-
   const consent = parseJson<{ basis?: string }>(r.fields.consent) ?? {};
   const tone = parseJson<Record<string, unknown>>(r.fields.tone_scales) ?? {};
   const refusals = parseJson<string[]>(r.fields.refusals) ?? [];
+  const exemplars = parseJson<Array<{ text?: string }>>(r.fields.exemplars) ?? [];
   return {
     id: r.entity_id,
     name: r.fields.name ?? "",
     slug: r.fields.slug ?? "",
     status: r.status,
     persona: r.fields.persona ?? "",
+    signature: exemplars[0]?.text ?? "",
     basis: consent.basis ?? "",
     tone: Object.entries(tone)
       .filter(([, v]) => typeof v === "number" || typeof v === "string")

--- a/ui/src/lib/odata.ts
+++ b/ui/src/lib/odata.ts
@@ -938,6 +938,23 @@ export const getArtStyle = (id: string) =>
   getDemoArtStyle(id)
     ? Promise.resolve(getDemoArtStyle(id)!)
     : getLane("ArtStyles", id);
+/** Read a governed File's text content server-side (corpus excerpts on the
+ *  voice contract pages). Returns "" on any failure — a missing excerpt
+ *  degrades to nothing rather than a 500. */
+export async function getFileText(id: string): Promise<string> {
+  if (!id || !id.startsWith("fl-")) return "";
+  try {
+    const res = await fetch(`${API_BASE}/tdata/Files('${id}')/$value`, {
+      headers,
+      next: { revalidate: 300 },
+    });
+    if (!res.ok) return "";
+    return await res.text();
+  } catch {
+    return "";
+  }
+}
+
 export const listWritingStyles = (filter = "Status eq 'Published'") =>
   listLane("WritingStyles", filter);
 export const getWritingStyle = (id: string) => getLane("WritingStyles", id);


### PR DESCRIPTION
Per Rita's queue review: cards now lead with the style's **signature passage in quotes**; contract pages open on it and gain **'how it reads'** — the actual corpus excerpts rendered long-form with sources labeled (the separate 'annotated examples' section is removed). The curator skill now encodes the exemplar rules: construction over content, signature-first, verbatim-verified quotes only.

Alongside (data, already live in prod): all 13 queued voices re-picked to hand-chosen, source-verified passages and re-verified through the deployed finalizer (13/13 Completed, all still UnderReview). Standing Orders' translator credit corrected — Gutenberg 2680 is Casaubon (1634), not Long.

Verified: tsc clean; rendered live against the real prod queue with an owner session (screenshots in session); suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)